### PR TITLE
Fix typo in chemical entity CURIE

### DIFF
--- a/models/ACETATEUTIL2-PWY-ACETATEUTIL2-PWY.ttl
+++ b/models/ACETATEUTIL2-PWY-ACETATEUTIL2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetate utilization - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ACETATEUTIL2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ACETATEUTIL2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/AERO-GLYCEROL-CAT-PWY-AERO-GLYCEROL-CAT-PWY.ttl
+++ b/models/AERO-GLYCEROL-CAT-PWY-AERO-GLYCEROL-CAT-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:AERO-GLYCEROL-CAT-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ALANINE-DEG3-PWY-ALANINE-DEG3-PWY.ttl
+++ b/models/ALANINE-DEG3-PWY-ALANINE-DEG3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-DEG3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-DEG3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ALANINE-SYN2-PWY-ALANINE-SYN2-PWY.ttl
+++ b/models/ALANINE-SYN2-PWY-ALANINE-SYN2-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-alanine biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALANINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALANINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ALL-CHORISMATE-PWY-1-ALL-CHORISMATE-PWY-1.ttl
+++ b/models/ALL-CHORISMATE-PWY-1-ALL-CHORISMATE-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,12 +191,23 @@
           <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_b391fde8-64d5-4ee9-ae2c-3a49c427795b_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -323,9 +334,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/b391fde8-64d5-4ee9-ae2c-3a49c427795b_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/748f0eeb-c690-41df-93d8-eff292c4f052_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -333,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -449,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -494,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -538,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -549,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -825,7 +836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -884,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,13 +913,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53094> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-4157> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
+] .
 
 <http://model.geneontology.org/CHEBI_29985_ANTHRANSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -919,30 +947,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53012> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002234_CHEBI_36242_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-4157> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36242_RXN3O-4157>
-] .
 
 <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -961,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -982,6 +993,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_73083>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/d47d5781-2f2e-438a-9efc-433ae7f3f8c1_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_246422>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -994,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1035,7 +1063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1055,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1069,7 +1097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,7 +1145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,7 +1288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1278,7 +1306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1295,7 +1323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1326,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,6 +1365,17 @@
           <http://model.geneontology.org/CHEBI_59776_TRYPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1346,24 +1385,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52675> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1373,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1385,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1419,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1467,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,23 +1506,6 @@
           <http://model.geneontology.org/reaction_PRTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57451_DIHYDROFOLATESYNTH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57451> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1504,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1539,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,12 +1561,23 @@
           <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ee7f8855-fdb6-4062-ac73-e6f0c2d7e7ce_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1567,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,9 +1609,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/5ba6f979-cf6d-4b05-bbba-c1b994b9882c_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/ee7f8855-fdb6-4062-ac73-e6f0c2d7e7ce_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1597,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1613,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,28 +1651,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1660,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,12 +1676,46 @@
           <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
+] .
+
+<http://model.geneontology.org/4ee5c976-c002-4be8-a0f1-5427ff517eff_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1685,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1697,7 +1736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,7 +1752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1721,11 +1760,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_9807ce05-858e-4b1a-8ffe-e9e3f336c8ac_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,7 +1772,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/9807ce05-858e-4b1a-8ffe-e9e3f336c8ac_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-31_ANTHRANSYN-RXN_controller>
@@ -1745,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,24 +1827,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53107> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15361_ADCLY-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -1816,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1830,7 +1858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1846,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1874,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1889,7 +1917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1913,11 +1941,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_3a068d14-0d2c-40c1-90ae-18ff20f8a2a5_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1925,7 +1953,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN>
+          <http://model.geneontology.org/3a068d14-0d2c-40c1-90ae-18ff20f8a2a5_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/RXN3O-4157>
@@ -1947,7 +1975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1995,7 +2023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2015,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2028,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2054,7 +2082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2070,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2081,7 +2109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2095,7 +2123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2143,7 +2171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2160,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2173,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2187,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2202,7 +2230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2219,7 +2247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2262,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2273,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2304,7 +2332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2321,7 +2349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2338,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2357,7 +2385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2385,7 +2413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2396,24 +2424,13 @@
           <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2430,7 +2447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,6 +2458,23 @@
           <http://model.geneontology.org/CHEBI_58349_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
+<http://model.geneontology.org/59c86a29-57ed-42bf-8e65-e6bbb70ef95b_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2450,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2467,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,18 +2514,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
-        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2504,13 +2529,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52829> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000003170_CPLX-9432_component>
+        a       <http://identifiers.org/sgd/S000003170> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003934>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2524,9 +2558,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/4ee5c976-c002-4be8-a0f1-5427ff517eff_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/3c53517c-dbe3-46f2-a39b-60f0de8bbb43_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2534,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2550,18 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2572,7 +2595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2583,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2595,7 +2618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2611,46 +2634,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2662,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,12 +2668,23 @@
           <http://model.geneontology.org/CPLX-9432_TYROSINE-AMINOTRANSFERASE-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2689,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2701,7 +2707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2717,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2735,7 +2741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2754,7 +2760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,7 +2780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2794,7 +2800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2810,7 +2816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2830,7 +2836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2847,7 +2853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2863,7 +2869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2874,7 +2880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2886,7 +2892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2902,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2916,7 +2922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2932,7 +2938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2943,7 +2949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2954,7 +2960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2967,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2984,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2998,7 +3004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3011,28 +3017,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.6.1.58-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CHORISMATE-SYNTHASE-RXN_RO_0002234_CHEBI_29748_CHORISMATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3052,9 +3041,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/12f723c1-c584-4779-bbb5-62680724db88_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/431c64a3-4190-4b9a-82b2-994734f63a0a_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3062,7 +3051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3070,12 +3059,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.6.1.58-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57972_2.6.1.58-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3086,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3101,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3117,7 +3123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3133,7 +3139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3144,7 +3150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3156,7 +3162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3172,7 +3178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3186,7 +3192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3198,7 +3204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3218,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3229,33 +3235,27 @@
 <http://identifiers.org/sgd/S000005316>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_748f0eeb-c690-41df-93d8-eff292c4f052_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0046820> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3276,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3291,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3304,7 +3304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3316,7 +3316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3332,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3344,7 +3344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3360,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3371,11 +3371,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_4ee5c976-c002-4be8-a0f1-5427ff517eff_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3383,7 +3383,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/4ee5c976-c002-4be8-a0f1-5427ff517eff_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004834>
@@ -3396,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3413,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3426,29 +3426,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/748f0eeb-c690-41df-93d8-eff292c4f052_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_BFO_0000066_reaction_TRYPSYN-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3463,7 +3469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3471,12 +3477,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3488,7 +3505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3508,7 +3525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3527,7 +3544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3538,7 +3555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3546,11 +3563,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_ea783c68-0278-484c-a724-8930a89fdf8a_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3558,7 +3575,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN>
+          <http://model.geneontology.org/ea783c68-0278-484c-a724-8930a89fdf8a_GCVMULTI-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58017>
@@ -3569,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3586,7 +3603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3608,7 +3625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3628,7 +3645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3661,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3675,7 +3692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3695,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3708,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3720,7 +3737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3740,7 +3757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3757,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3765,41 +3782,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3810,14 +3799,70 @@
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_RO_0002411_RXN3O-4157_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_TYROSINE-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/12f723c1-c584-4779-bbb5-62680724db88_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3826,18 +3871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3852,7 +3886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3865,7 +3899,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_ea783c68-0278-484c-a724-8930a89fdf8a_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3877,7 +3922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3897,7 +3942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3908,13 +3953,30 @@
           <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
 ] .
 
+<http://model.geneontology.org/9189d030-91e0-443b-9bf4-2cf1519c9ef5_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TYROSINE-AMINOTRANSFERASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3934,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3949,7 +4011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3969,7 +4031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3992,7 +4054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4005,7 +4067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4017,7 +4079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4034,7 +4096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4054,7 +4116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4069,7 +4131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4083,7 +4145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4103,7 +4165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4116,7 +4178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4141,7 +4203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4155,7 +4217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4172,7 +4234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4188,7 +4250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4200,7 +4262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4219,7 +4281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4236,7 +4298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4252,7 +4314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4260,11 +4322,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_d47d5781-2f2e-438a-9efc-433ae7f3f8c1_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4272,7 +4334,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/d47d5781-2f2e-438a-9efc-433ae7f3f8c1_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002233_CHEBI_58359_ANTHRANSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -4280,7 +4342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4295,7 +4357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4309,7 +4371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4325,7 +4387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4336,7 +4398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4351,7 +4413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4364,7 +4426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4375,7 +4437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4386,7 +4448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4398,7 +4460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4416,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4430,7 +4492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4447,7 +4509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4466,7 +4528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4481,7 +4543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4498,11 +4560,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53232> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/3c53517c-dbe3-46f2-a39b-60f0de8bbb43_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4513,7 +4592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4530,7 +4609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4546,7 +4625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4557,7 +4636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4575,7 +4654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4588,7 +4667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4606,7 +4685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4619,7 +4698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4631,7 +4710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4647,7 +4726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4659,7 +4738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4670,12 +4749,23 @@
           <http://model.geneontology.org/CHEBI_58866_TRYPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_be8bd22e-6eaf-4178-9bd2-ee42382fc7c5_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_58762_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4686,7 +4776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4697,11 +4787,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_be8bd22e-6eaf-4178-9bd2-ee42382fc7c5_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9789> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/be8bd22e-6eaf-4178-9bd2-ee42382fc7c5_RXN3O-9789>
+] .
 
 <http://model.geneontology.org/YBR249C-MONOMER_DAHPSYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000453> ;
@@ -4710,7 +4817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4718,46 +4825,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789>
-] .
-
-<http://model.geneontology.org/0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002413_3-DEHYDROQUINATE-DEHYDRATASE-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4768,7 +4841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4793,7 +4866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4806,7 +4879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4819,7 +4892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4839,7 +4912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4856,7 +4929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4875,7 +4948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4895,7 +4968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4911,7 +4984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4931,7 +5004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4948,7 +5021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4964,7 +5037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4979,7 +5052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4993,7 +5066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5013,7 +5086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5029,7 +5102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5045,7 +5118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5056,7 +5129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5070,7 +5143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5082,7 +5155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5099,7 +5172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5119,7 +5192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5135,7 +5208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5150,7 +5223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5170,7 +5243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5186,7 +5259,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_59c86a29-57ed-42bf-8e65-e6bbb70ef95b_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5197,7 +5281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5206,7 +5290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5223,7 +5307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5241,28 +5325,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52843> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/bc5862ad-86dd-4165-b14b-ec849b2bebea_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -5274,7 +5341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5294,7 +5361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5307,7 +5374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5318,7 +5385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5333,7 +5400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5358,7 +5425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5372,7 +5439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5392,7 +5459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5406,7 +5473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5420,12 +5487,23 @@
 <http://identifiers.org/sgd/S000003116>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_3a068d14-0d2c-40c1-90ae-18ff20f8a2a5_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5439,7 +5517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5465,7 +5543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5482,7 +5560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5501,7 +5579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5512,7 +5590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5525,7 +5603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5539,7 +5617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5555,7 +5633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5570,7 +5648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5589,7 +5667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5600,7 +5678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5611,7 +5689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5624,7 +5702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5637,7 +5715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5645,11 +5723,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_b391fde8-64d5-4ee9-ae2c-3a49c427795b_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5657,7 +5735,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/b391fde8-64d5-4ee9-ae2c-3a49c427795b_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -5665,7 +5743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5679,7 +5757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5704,7 +5782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5720,7 +5798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5735,7 +5813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5752,7 +5830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5765,7 +5843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5780,7 +5858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5797,7 +5875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5827,7 +5905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5841,7 +5919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5857,7 +5935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5882,7 +5960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5896,7 +5974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5913,7 +5991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5933,7 +6011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5947,7 +6025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5970,7 +6048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5984,7 +6062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6000,7 +6078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6013,7 +6091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6030,7 +6108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6043,7 +6121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6054,7 +6132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6079,7 +6157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6093,7 +6171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6113,7 +6191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6140,7 +6218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6150,11 +6228,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_3c53517c-dbe3-46f2-a39b-60f0de8bbb43_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6162,52 +6240,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/3c53517c-dbe3-46f2-a39b-60f0de8bbb43_THYMIDYLATESYN-RXN>
 ] .
-
-<http://model.geneontology.org/e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000288>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_15377_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6219,7 +6263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6230,12 +6274,34 @@
           <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_1c21a21b-727f-4aee-b21a-272074bff233_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_3c53517c-dbe3-46f2-a39b-60f0de8bbb43_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6247,7 +6313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6263,7 +6329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6278,7 +6344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6294,7 +6360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6306,7 +6372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6322,7 +6388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6333,7 +6399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6347,7 +6413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6362,7 +6428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6375,7 +6441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6386,7 +6452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6394,11 +6460,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_12f723c1-c584-4779-bbb5-62680724db88_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6406,7 +6472,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/12f723c1-c584-4779-bbb5-62680724db88_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6415,7 +6481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6431,7 +6497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6459,7 +6525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6473,7 +6539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6484,24 +6550,13 @@
           <http://model.geneontology.org/YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6521,7 +6576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6548,7 +6603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6562,7 +6617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6581,7 +6636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6600,7 +6655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6616,7 +6671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6627,18 +6682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_3e143759-ebca-46a4-b1b2-424846641195_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6650,7 +6694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6667,7 +6711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6681,22 +6725,16 @@
 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADCLY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57912_TRYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57912> ;
@@ -6707,7 +6745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6715,23 +6753,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_CHEBI_15740_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6742,7 +6780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6754,7 +6792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6774,7 +6812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6782,23 +6820,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADCLY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6811,7 +6855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6828,7 +6872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6836,23 +6880,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_null_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_null_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -6867,7 +6911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6882,7 +6926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6898,7 +6942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6915,7 +6959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6927,7 +6971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6946,7 +6990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6957,7 +7001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6970,7 +7014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6984,7 +7028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7000,7 +7044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7015,7 +7059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7029,7 +7073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7059,7 +7103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7076,7 +7120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7096,7 +7140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7110,23 +7154,12 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7143,7 +7176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7154,7 +7187,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_d47d5781-2f2e-438a-9efc-433ae7f3f8c1_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7165,7 +7209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7176,7 +7220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7188,7 +7232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7207,7 +7251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7226,7 +7270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7237,7 +7281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7254,7 +7298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7271,7 +7315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7288,7 +7332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7304,7 +7348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7316,7 +7360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7336,7 +7380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7352,7 +7396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7369,7 +7413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7380,28 +7424,6 @@
           <http://model.geneontology.org/YPR060C-MONOMER_CHORISMATEMUT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7411,7 +7433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of chorismate metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -7419,13 +7441,35 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002234_CHEBI_59776_TRYPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7445,7 +7489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7458,7 +7502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7476,7 +7520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7490,7 +7534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7510,7 +7554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7523,7 +7567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7541,9 +7585,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/9807ce05-858e-4b1a-8ffe-e9e3f336c8ac_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/d47d5781-2f2e-438a-9efc-433ae7f3f8c1_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -7551,7 +7595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7572,7 +7616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7588,7 +7632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7600,7 +7644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7616,7 +7660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7628,7 +7672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7644,7 +7688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7655,7 +7699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7667,7 +7711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7687,7 +7731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7695,24 +7739,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7732,7 +7765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7748,7 +7781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7763,7 +7796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7776,11 +7809,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_50878544-b430-4ede-9d7c-4ba4adeb6e02_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7788,7 +7821,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/50878544-b430-4ede-9d7c-4ba4adeb6e02_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/SGD_S000001694_CPLX3O-31_component>
@@ -7796,7 +7829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -7805,7 +7838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7816,7 +7849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7831,7 +7864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7847,7 +7880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7858,7 +7891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7870,7 +7903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7883,11 +7916,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_748f0eeb-c690-41df-93d8-eff292c4f052_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7895,7 +7928,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/748f0eeb-c690-41df-93d8-eff292c4f052_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
@@ -7903,7 +7936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7915,7 +7948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7935,7 +7968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7960,7 +7993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7974,7 +8007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7994,7 +8027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8007,7 +8040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8018,7 +8051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8029,7 +8062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8044,7 +8077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8057,7 +8090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8072,7 +8105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8086,7 +8119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8102,7 +8135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8113,11 +8146,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15740> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8128,7 +8164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8136,35 +8172,18 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8187,7 +8206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8195,8 +8214,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/5ba6f979-cf6d-4b05-bbba-c1b994b9882c_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -8204,7 +8237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8224,7 +8257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8243,7 +8276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8258,7 +8291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8269,13 +8302,24 @@
 <http://purl.obolibrary.org/obo/GO_0004106>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-KINASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8291,18 +8335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_29985_DIHYDROFOLATESYNTH-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8313,7 +8346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8328,7 +8361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8341,7 +8374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8366,7 +8399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8380,7 +8413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8396,7 +8429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8407,7 +8440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8422,7 +8455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8436,7 +8469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8452,7 +8485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8465,7 +8498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8484,7 +8517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8498,7 +8531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8511,11 +8544,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_5ba6f979-cf6d-4b05-bbba-c1b994b9882c_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8523,7 +8556,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/5ba6f979-cf6d-4b05-bbba-c1b994b9882c_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/TRYPSYN-RXN>
@@ -8543,7 +8576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8556,7 +8589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8568,7 +8601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8588,7 +8621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8604,7 +8637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8615,23 +8648,6 @@
           <http://model.geneontology.org/CHORISMATEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000005762> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -8639,7 +8655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8653,7 +8669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8670,7 +8686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8687,7 +8703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8703,28 +8719,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8734,7 +8733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8745,23 +8744,29 @@
           <http://model.geneontology.org/reaction_H2PTEROATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+] .
 
 <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8773,7 +8778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8787,23 +8792,6 @@
 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/3e3db864-1586-43c1-aa20-a3f79b2d227b_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8813,7 +8801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8833,9 +8821,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/ea783c68-0278-484c-a724-8930a89fdf8a_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/59c86a29-57ed-42bf-8e65-e6bbb70ef95b_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -8843,7 +8831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8854,13 +8842,24 @@
 <http://model.geneontology.org/reaction_DAHPSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_59ad3b0b-4912-441d-933c-3880436c966e_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8876,7 +8875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8887,7 +8886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8902,7 +8901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -8916,7 +8915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8932,7 +8931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8947,7 +8946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8964,7 +8963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8978,7 +8977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8995,7 +8994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9013,7 +9012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9030,7 +9029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9043,7 +9042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9055,7 +9054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9069,23 +9068,12 @@
 <http://model.geneontology.org/reaction_3-DEHYDROQUINATE-DEHYDRATASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_ff288625-7e6e-49d4-a791-ae0dcea062f5_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.6.1.58-RXN_RO_0002234_CHEBI_57972_2.6.1.58-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9100,7 +9088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9113,7 +9101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9121,23 +9109,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/4b3638d1-974e-4a38-8dbb-5974a20dd79b_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52913> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -9148,7 +9119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9165,7 +9136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9173,13 +9144,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_12f723c1-c584-4779-bbb5-62680724db88_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9199,7 +9181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9216,7 +9198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9238,7 +9220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9257,7 +9239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9268,12 +9250,34 @@
           <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_RO_0002413_PREPHENATEDEHYDRAT-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9288,7 +9292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9296,24 +9300,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000066_reaction_H2NEOPTERINALDOL-RXN_location_lociGO_0005829_null_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9324,16 +9317,22 @@
           <http://model.geneontology.org/CHEBI_16526_IGPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/be8bd22e-6eaf-4178-9bd2-ee42382fc7c5_RXN3O-9789>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_37565> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9344,7 +9343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9358,7 +9357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9381,15 +9380,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/59ad3b0b-4912-441d-933c-3880436c966e_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/be8bd22e-6eaf-4178-9bd2-ee42382fc7c5_RXN3O-9789> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9411,7 +9410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9428,7 +9427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9445,7 +9444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9465,7 +9464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9481,7 +9480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9492,7 +9491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9504,7 +9503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9524,13 +9523,24 @@
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002233_CHEBI_145989_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9541,23 +9551,12 @@
           <http://model.geneontology.org/CHEBI_145989_2.5.1.19-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002413_CHORISMATE-SYNTHASE-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9572,9 +9571,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/50878544-b430-4ede-9d7c-4ba4adeb6e02_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/9189d030-91e0-443b-9bf4-2cf1519c9ef5_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -9582,7 +9581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9595,7 +9594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9612,7 +9611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9630,30 +9629,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53355> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9664,7 +9646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9681,7 +9663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9701,7 +9683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9709,20 +9691,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58095> ;
+<http://model.geneontology.org/9807ce05-858e-4b1a-8ffe-e9e3f336c8ac_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "phe" ;
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53305> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -9733,7 +9715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9741,12 +9723,46 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/CHEBI_58095_2.6.1.58-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58095> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phe" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53305> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ea783c68-0278-484c-a724-8930a89fdf8a_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9758,7 +9774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9769,12 +9785,12 @@
           <http://model.geneontology.org/CHEBI_57972_RXN3O-4157>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_50878544-b430-4ede-9d7c-4ba4adeb6e02_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9785,7 +9801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9799,7 +9815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9815,7 +9831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9827,7 +9843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9847,7 +9863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9858,13 +9874,30 @@
           <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/1c21a21b-727f-4aee-b21a-272074bff233_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9880,7 +9913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9895,7 +9928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9909,7 +9942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9928,7 +9961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9939,24 +9972,13 @@
           <http://model.geneontology.org/PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-SYNTHASE-RXN_RO_0002234_CHEBI_32364_3-DEHYDROQUINATE-SYNTHASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9972,7 +9994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9984,7 +10006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10001,7 +10023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10014,11 +10036,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_9189d030-91e0-443b-9bf4-2cf1519c9ef5_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10026,7 +10048,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/9189d030-91e0-443b-9bf4-2cf1519c9ef5_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
@@ -10034,7 +10056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10045,7 +10067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10056,7 +10078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10071,7 +10093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10084,7 +10106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10095,20 +10117,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_a3df0bd4-267a-4012-9bd2-8cc7aa1e0595_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -10121,7 +10132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10137,7 +10148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10157,7 +10168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10173,7 +10184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10203,13 +10214,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1BiochemicalReaction53598> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/59ad3b0b-4912-441d-933c-3880436c966e_RXN3O-9789>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58359_PABASYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58359> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10220,7 +10248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10234,7 +10262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10252,7 +10280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10265,7 +10293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10279,7 +10307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10301,7 +10329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10309,11 +10337,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_1c21a21b-727f-4aee-b21a-272074bff233_1.5.1.15-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10321,7 +10349,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN>
+          <http://model.geneontology.org/1c21a21b-727f-4aee-b21a-272074bff233_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
@@ -10333,7 +10361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10348,7 +10376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10362,7 +10390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10378,7 +10406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10393,7 +10421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10407,7 +10435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10424,7 +10452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10443,7 +10471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10463,7 +10491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10479,7 +10507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10490,7 +10518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10505,7 +10533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10522,7 +10550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10540,7 +10568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10553,7 +10581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10566,7 +10594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10580,7 +10608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10596,7 +10624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -10606,7 +10634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10619,11 +10647,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ee7f8855-fdb6-4062-ac73-e6f0c2d7e7ce_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10631,7 +10659,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0b12cee0-21a6-475e-b084-3d60141e4906_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/ee7f8855-fdb6-4062-ac73-e6f0c2d7e7ce_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000004902>
@@ -10646,7 +10674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10661,7 +10689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10678,7 +10706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10701,7 +10729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10718,7 +10746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10731,7 +10759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10746,7 +10774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10762,7 +10790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10777,7 +10805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10796,7 +10824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10807,7 +10835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10819,7 +10847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10835,7 +10863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10846,7 +10874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10859,7 +10887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10872,7 +10900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10888,7 +10916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10902,7 +10930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10919,7 +10947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10940,7 +10968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10957,7 +10985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10970,7 +10998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10982,7 +11010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11002,7 +11030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11015,7 +11043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11030,7 +11058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11047,7 +11075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11060,7 +11088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11072,7 +11100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11092,7 +11120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11108,7 +11136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11120,7 +11148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11136,7 +11164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11147,9 +11175,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/431c64a3-4190-4b9a-82b2-994734f63a0a_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -11157,7 +11202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11174,7 +11219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11190,7 +11235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11215,7 +11260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11232,7 +11277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11246,7 +11291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11263,7 +11308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11280,7 +11325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11303,7 +11348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11316,7 +11361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11331,7 +11376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11350,7 +11395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11370,7 +11415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11399,7 +11444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11412,7 +11457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11427,7 +11472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11444,7 +11489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11460,7 +11505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11471,7 +11516,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_5ba6f979-cf6d-4b05-bbba-c1b994b9882c_DIHYDROFOLATEREDUCT-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_4ee5c976-c002-4be8-a0f1-5427ff517eff_THYMIDYLATESYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_431c64a3-4190-4b9a-82b2-994734f63a0a_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11479,11 +11557,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_59ad3b0b-4912-441d-933c-3880436c966e_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11491,7 +11569,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789>
+          <http://model.geneontology.org/59ad3b0b-4912-441d-933c-3880436c966e_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
@@ -11499,7 +11577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11514,7 +11592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11527,7 +11605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11539,7 +11617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11555,7 +11633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11570,7 +11648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11583,7 +11661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11595,7 +11673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11611,7 +11689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11623,7 +11701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11634,6 +11712,23 @@
           <http://model.geneontology.org/ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1>
 ] .
 
+<http://model.geneontology.org/b391fde8-64d5-4ee9-ae2c-3a49c427795b_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_456216_SHIKIMATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11643,28 +11738,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/2065ff91-49d2-4ea4-90f2-b1ee60c99afe_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -11674,7 +11752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11690,7 +11768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11705,7 +11783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11722,7 +11800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11739,7 +11817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11755,39 +11833,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_e59157fc-1c61-4372-a8b4-5bc14187ec6c_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/2b1d0903-0bf2-48c0-b0f4-8d62bbfb2196_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -11795,7 +11845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11811,7 +11861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11823,7 +11873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11839,7 +11889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11856,7 +11906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11870,7 +11920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11887,7 +11937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11904,7 +11954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11924,7 +11974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11938,7 +11988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11955,7 +12005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11975,7 +12025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11986,16 +12036,20 @@
 <http://purl.obolibrary.org/obo/GO_0004425>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005316> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aminodeoxychorismate synthase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53168> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -12005,7 +12059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12016,27 +12070,23 @@
           <http://model.geneontology.org/3-DEHYDROQUINATE-DEHYDRATASE-RXN>
 ] .
 
-<http://model.geneontology.org/YNR033W-MONOMER_PABASYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005316> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aminodeoxychorismate synthase" ;
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1Protein53168> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12051,7 +12101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12067,7 +12117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12078,7 +12128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12093,7 +12143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12107,7 +12157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12123,7 +12173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12141,7 +12191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12152,6 +12202,17 @@
           <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_9189d030-91e0-443b-9bf4-2cf1519c9ef5_GLYOHMETRANS-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_59776>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -12161,7 +12222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12177,7 +12238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12189,7 +12250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12205,7 +12266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12219,7 +12280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12235,7 +12296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12249,7 +12310,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_9807ce05-858e-4b1a-8ffe-e9e3f336c8ac_METHENYLTHFCYCLOHYDRO-RXN_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12258,13 +12330,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/50878544-b430-4ede-9d7c-4ba4adeb6e02_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12281,7 +12370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12295,23 +12384,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_null_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12326,7 +12404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12340,7 +12418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12357,7 +12435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12373,7 +12451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12388,7 +12466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12405,7 +12483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12422,7 +12500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12438,7 +12516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12450,7 +12528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12467,7 +12545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12487,7 +12565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12503,7 +12581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12517,7 +12595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12533,7 +12611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12548,7 +12626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12564,7 +12642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12575,7 +12653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12590,7 +12668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12607,7 +12685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12624,7 +12702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12640,7 +12718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12659,7 +12737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12668,24 +12746,13 @@
 <http://model.geneontology.org/reaction_GTP-CYCLOHYDRO-I-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12705,7 +12772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12725,7 +12792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12738,7 +12805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12750,7 +12817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12770,7 +12837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12783,7 +12850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12797,7 +12864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12820,7 +12887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12833,7 +12900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12847,7 +12914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12865,7 +12932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12881,7 +12948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12898,7 +12965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12908,23 +12975,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58702_DAHPSYN-RXN>
 ] .
-
-<http://model.geneontology.org/b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52660> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PRAISOM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004640> ;
@@ -12945,7 +12995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12962,7 +13012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12973,24 +13023,13 @@
           <http://model.geneontology.org/CHEBI_17001_H2NEOPTERINALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_619efe33-c887-43aa-9c31-d0eb411672b3_FORMATETHFLIG-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13006,7 +13045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13019,7 +13058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13036,7 +13075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13049,7 +13088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13061,7 +13100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13077,7 +13116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13089,7 +13128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13106,7 +13145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13122,7 +13161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13137,7 +13176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13150,7 +13189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13165,7 +13204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13181,7 +13220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13198,7 +13237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13215,7 +13254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13235,28 +13274,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule53087> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52758> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -13265,7 +13287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13280,7 +13302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13294,7 +13316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13310,7 +13332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13321,7 +13343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13338,7 +13360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13354,7 +13376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13365,7 +13387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13380,7 +13402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13394,7 +13416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13417,7 +13439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13430,7 +13452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13442,7 +13464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13453,29 +13475,12 @@
           <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
 ] .
 
-<http://model.geneontology.org/5480fdb5-20cb-49b4-b6c5-56c273b31f29_RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13487,7 +13492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13506,7 +13511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13519,7 +13524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13536,7 +13541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13552,7 +13557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13564,7 +13569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13580,7 +13585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13592,7 +13597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13611,7 +13616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13623,7 +13628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13634,29 +13639,29 @@
           <http://model.geneontology.org/CHEBI_29888_H2PTEROATESYNTH-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_ALL-CHORISMATE-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
-] .
+<http://model.geneontology.org/3a068d14-0d2c-40c1-90ae-18ff20f8a2a5_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52588> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_15378_ANTHRANSYN-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13668,7 +13673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13679,23 +13684,29 @@
           <http://model.geneontology.org/CHEBI_57783_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-630_THYMIDYLATESYN-RXN_controller_BFO_0000051_SGD_S000005600_CPLX3O-630_component_SGD_ALL-CHORISMATE-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000005600_CPLX3O-630_component>
+] .
+
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002333_YDR035W-MONOMER_DAHPSYN-RXN_controller_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_a816c24b-f355-4cd1-9f31-2f6fe3ad2d34_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13710,7 +13721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13727,7 +13738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13741,7 +13752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13757,7 +13768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13769,7 +13780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13786,7 +13797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13806,9 +13817,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/9e14098c-bb9c-4119-9e61-ff0b145277ec_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/3a068d14-0d2c-40c1-90ae-18ff20f8a2a5_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/b0535dd3-f6b5-45cd-8b39-c4e83d106124_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/1c21a21b-727f-4aee-b21a-272074bff233_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -13816,7 +13827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13833,7 +13844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13850,7 +13861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13866,7 +13877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13877,7 +13888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13892,7 +13903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13905,7 +13916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13920,7 +13931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13936,7 +13947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13953,7 +13964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13983,7 +13994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14003,7 +14014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14014,6 +14025,23 @@
           <http://model.geneontology.org/CHEBI_30616_SHIKIMATE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ee7f8855-fdb6-4062-ac73-e6f0c2d7e7ce_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52895> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0003849>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -14022,18 +14050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14045,7 +14062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14075,7 +14092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14093,7 +14110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14108,7 +14125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14127,7 +14144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -14140,7 +14157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14160,7 +14177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14175,7 +14192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14189,7 +14206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14206,7 +14223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14222,7 +14239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14234,7 +14251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14254,7 +14271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14271,23 +14288,23 @@
 <http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_ALL-CHORISMATE-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14299,7 +14316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14315,7 +14332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14332,7 +14349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14343,13 +14360,24 @@
           <http://model.geneontology.org/ANTHRANSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ALL-CHORISMATE-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_431c64a3-4190-4b9a-82b2-994734f63a0a_METHYLENETHFDEHYDROG-NADP-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14357,19 +14385,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/41e11c9e-b445-4fde-9ead-61ceb88c20ac_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/431c64a3-4190-4b9a-82b2-994734f63a0a_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000050_ALL-CHORISMATE-PWY-1/ALL-CHORISMATE-PWY-1_SGD_ALL-CHORISMATE-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002534>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -14379,7 +14396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALL-CHORISMATE-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14391,7 +14408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14404,11 +14421,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_59c86a29-57ed-42bf-8e65-e6bbb70ef95b_GCVMULTI-RXN_SGD_ALL-CHORISMATE-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14416,25 +14433,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e3d042d3-d472-431c-bd7b-6e5de8acd7e8_GCVMULTI-RXN>
+          <http://model.geneontology.org/59c86a29-57ed-42bf-8e65-e6bbb70ef95b_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/d48c5972-4aea-4c5c-a1e3-902890924d49_RXN3O-9789>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ALL-CHORISMATE-PWY-1SmallMolecule52623> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -14444,7 +14444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALL-CHORISMATE-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/ALLANTOINDEG-PWY-ALLANTOINDEG-PWY.ttl
+++ b/models/ALLANTOINDEG-PWY-ALLANTOINDEG-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of allantoin degradation in yeast - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1175,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1574,7 +1574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1605,7 +1605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1632,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1661,7 +1661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1684,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1697,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1720,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1790,7 +1790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1821,7 +1821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1837,7 +1837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1865,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1896,7 +1896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1913,7 +1913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1958,7 +1958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1975,7 +1975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2008,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ALLANTOINDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ALLANTOINDEG-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARG-PRO-PWY-ARG-PRO-PWY.ttl
+++ b/models/ARG-PRO-PWY-ARG-PRO-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -481,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine degradation VI (arginase 2 pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1181,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,7 +1336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1405,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1436,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARG-PRO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARG-PRO-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARGDEG-YEAST-PWY-ARGDEG-YEAST-PWY.ttl
+++ b/models/ARGDEG-YEAST-PWY-ARGDEG-YEAST-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,21 +88,6 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -116,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -256,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,11 +411,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_31ea0342-95dc-4c20-8c0d-6ab7c5b0e9fb_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +423,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903>
+          <http://model.geneontology.org/31ea0342-95dc-4c20-8c0d-6ab7c5b0e9fb_RXN-14903>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -452,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -576,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -593,23 +578,6 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55393> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_57540_RXN-14116>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -619,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,16 +595,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_ARGDEG-YEAST-PWY/ARGDEG-YEAST-PWY_SGD_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15377_SPONTPRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55393> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -644,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,20 +629,16 @@
           <http://model.geneontology.org/CHEBI_16199_ARGINASE-RXN>
 ] .
 
-<http://model.geneontology.org/0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
+<http://model.geneontology.org/ev_w_id_RXN-14116_BFO_0000050_ARGDEG-YEAST-PWY/ARGDEG-YEAST-PWY_SGD_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-14116>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -679,11 +649,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55393> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/31ea0342-95dc-4c20-8c0d-6ab7c5b0e9fb_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55304> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -696,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -797,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -845,9 +830,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
+                <http://model.geneontology.org/31ea0342-95dc-4c20-8c0d-6ab7c5b0e9fb_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
+                <http://model.geneontology.org/9d080b10-84b1-4b7e-adea-076454bf947a_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -855,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,41 +848,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_BFO_0000066_reaction_SPONTPRO-RXN_location_lociGO_0005829_null_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14116_RO_0002234_CHEBI_57945_RXN-14116_SGD_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_9d080b10-84b1-4b7e-adea-076454bf947a_RXN-14903_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,7 +890,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903>
+          <http://model.geneontology.org/9d080b10-84b1-4b7e-adea-076454bf947a_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -914,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -952,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1076,6 +1061,17 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16810_ORNITHINE-GLU-AMINOTRANSFERASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1085,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1093,23 +1089,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_17388_PYRROLINECARBREDUCT-RXN_SGD_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000066_reaction_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_location_lociGO_0005829_null_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,7 +1125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1172,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1219,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1253,13 +1238,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/9d080b10-84b1-4b7e-adea-076454bf947a_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ARGDEG-YEAST-PWYSmallMolecule55328> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PYRROLINECARBREDUCT-RXN_RO_0002234_CHEBI_15378_PYRROLINECARBREDUCT-RXN_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1293,12 +1293,23 @@
           <http://model.geneontology.org/CHEBI_15377_ARGINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_31ea0342-95dc-4c20-8c0d-6ab7c5b0e9fb_RXN-14903_SGD_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ARGINASE-RXN_RO_0002234_CHEBI_46911_ARGINASE-RXN_SGD_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1313,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1333,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1379,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1449,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1461,7 +1472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1511,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1525,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1556,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1585,7 +1596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,23 +1604,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_0d4444ab-ea71-461b-96ae-aed3c8638ce0_RXN-14903_SGD_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15377_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1624,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1669,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1696,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_9d080b10-84b1-4b7e-adea-076454bf947a_RXN-14903_SGD_ARGDEG-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1717,7 +1728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1748,7 +1759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1765,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1809,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1824,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1844,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "arginine degradation (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1857,7 +1868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1869,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1886,7 +1897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1916,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1968,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1983,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2011,16 +2022,13 @@
           <http://model.geneontology.org/CHEBI_60039_RXN-14903>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002411_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,16 +2039,8 @@
           <http://model.geneontology.org/SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_09abfec2-3da5-4a30-8b10-fcd219a8f6e7_RXN-14903_SGD_ARGDEG-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2050,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2084,7 +2084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2098,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2132,7 +2132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2143,23 +2143,12 @@
           <http://model.geneontology.org/CHEBI_32682_ARGINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGDEG-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_BFO_0000050_ARGDEG-YEAST-PWY/ARGDEG-YEAST-PWY_SGD_ARGDEG-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2174,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2182,12 +2171,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_SPONTPRO-RXN_RO_0002233_CHEBI_15378_SPONTPRO-RXN_SGD_ARGDEG-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGDEG-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ORNITHINE-GLU-AMINOTRANSFERASE-RXN_RO_0002413_RXN-14116_null_ARGDEG-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2198,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2210,7 +2210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2300,7 +2300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARGSPECAT-PWY-ARGSPECAT-PWY.ttl
+++ b/models/ARGSPECAT-PWY-ARGSPECAT-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,18 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ARGSPECAT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_ARGSPECAT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -528,12 +517,23 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002234_CHEBI_45725_SPERMINE-SYNTHASE-RXN_SGD_ARGSPECAT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ARGSPECAT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SPERMINE-SYNTHASE-RXN_SGD_ARGSPECAT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -718,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSPECAT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSPECAT-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ARGSYNBSUB-PWY-ARGSYNBSUB-PWY.ttl
+++ b/models/ARGSYNBSUB-PWY-ARGSYNBSUB-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -924,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1250,7 +1250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1265,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,7 +1279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1384,7 +1384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1450,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1499,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1552,7 +1552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1605,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1654,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,7 +1671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1691,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1705,7 +1705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1735,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1782,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,7 +1833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1849,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1864,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1913,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1958,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-arginine biosynthesis II (acetyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1975,7 +1975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1989,7 +1989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2017,7 +2017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2036,7 +2036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2090,7 +2090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,7 +2120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2133,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2145,7 +2145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2190,7 +2190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2223,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2232,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2273,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2288,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2301,7 +2301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2335,7 +2335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2349,7 +2349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2365,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2379,7 +2379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2390,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2403,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2417,7 +2417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2437,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2478,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2490,7 +2490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2510,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2529,7 +2529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2545,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2560,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2576,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2591,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2610,7 +2610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2627,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2657,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2670,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2682,7 +2682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2698,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2712,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2727,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2740,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2758,7 +2758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2799,7 +2799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2822,7 +2822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2850,7 +2850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2865,7 +2865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2885,7 +2885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2903,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2917,7 +2917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2933,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2947,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2962,7 +2962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2982,7 +2982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2998,7 +2998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3010,7 +3010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3028,7 +3028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3045,7 +3045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3060,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3076,7 +3076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3092,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3103,7 +3103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3114,7 +3114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3128,7 +3128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3144,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3159,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3179,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3196,7 +3196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3212,7 +3212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3223,7 +3223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3239,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3256,7 +3256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3272,7 +3272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3287,7 +3287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3300,7 +3300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3315,7 +3315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3342,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3355,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3367,7 +3367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3393,7 +3393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3413,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3430,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3444,7 +3444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3464,7 +3464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3484,7 +3484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3498,7 +3498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3514,7 +3514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3532,7 +3532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3546,7 +3546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3565,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3579,7 +3579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3595,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3606,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3621,7 +3621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3648,7 +3648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3664,7 +3664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3676,7 +3676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3692,7 +3692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3709,7 +3709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3725,7 +3725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3736,7 +3736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3748,7 +3748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3764,7 +3764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3779,7 +3779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3793,7 +3793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3813,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3827,7 +3827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3849,7 +3849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3872,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3886,7 +3886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3902,7 +3902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3914,7 +3914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3930,7 +3930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARGSYNBSUB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3945,7 +3945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARGSYNBSUB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ARO-PWY-1-ARO-PWY-1.ttl
+++ b/models/ARO-PWY-1-ARO-PWY-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1042,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1056,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1153,7 +1153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1221,7 +1221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,7 +1237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1389,7 +1389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1470,7 +1470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1500,7 +1500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1604,7 +1604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1664,7 +1664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1686,7 +1686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1751,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chorismate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1845,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1908,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,7 +1939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1987,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2051,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2081,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,7 +2123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2134,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2152,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2166,7 +2166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2234,7 +2234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,7 +2251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2284,7 +2284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2302,7 +2302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2346,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2361,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2379,7 +2379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2406,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2437,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2462,7 +2462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2476,7 +2476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2492,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2515,7 +2515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2545,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2556,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2567,7 +2567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/ASPARAGINE-BIOSYNTHESIS-1-ASPARAGINE-BIOSYNTHESIS-1.ttl
+++ b/models/ASPARAGINE-BIOSYNTHESIS-1-ASPARAGINE-BIOSYNTHESIS-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-asparagine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,7 +1041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-BIOSYNTHESIS-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/ASPARAGINE-DEG2-PWY-ASPARAGINE-DEG2-PWY.ttl
+++ b/models/ASPARAGINE-DEG2-PWY-ASPARAGINE-DEG2-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,24 +497,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_ASPARAGINE-DEG2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ASPARAGINE-DEG2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARAGHYD-RXN_RO_0002233_CHEBI_58048_ASPARAGHYD-RXN_SGD_ASPARAGINE-DEG2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,6 +513,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58048_ASPARAGHYD-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002233_CHEBI_16810_ASPAMINOTRANS-RXN_SGD_ASPARAGINE-DEG2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ASPARAGINE-DEG2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002729>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "asparagine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARAGINE-DEG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/ASPARTATESYN-PWY-ASPARTATESYN-PWY.ttl
+++ b/models/ASPARTATESYN-PWY-ASPARTATESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPARTATESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPARTATESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ASPBIO-PWY-ASPBIO-PWY.ttl
+++ b/models/ASPBIO-PWY-ASPBIO-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -70,7 +70,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,7 +87,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ASPBIO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "aspartate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ASPBIO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/BIOTIN-SYNTHESIS-PWY-BIOTIN-SYNTHESIS-PWY.ttl
+++ b/models/BIOTIN-SYNTHESIS-PWY-BIOTIN-SYNTHESIS-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "biotin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1083,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,7 +1243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1268,7 +1268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1285,7 +1285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1321,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,7 +1375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1555,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1617,7 +1617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1699,7 +1699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1715,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1730,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1764,7 +1764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1807,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1840,7 +1840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1859,7 +1859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BIOTIN-SYNTHESIS-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/BRANCHED-CHAIN-AA-SYN-PWY-1-BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
+++ b/models/BRANCHED-CHAIN-AA-SYN-PWY-1-BRANCHED-CHAIN-AA-SYN-PWY-1.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -825,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,23 +842,23 @@
 <http://model.geneontology.org/reaction_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_THREDEHYD-RXN_RO_0002333_YER086W-MONOMER_THREDEHYD-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACETOOHBUTREDUCTOISOM-RXN_RO_0002333_YLR355C-MONOMER_ACETOOHBUTREDUCTOISOM-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,17 +1018,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_DIHYDROXYMETVALDEHYDRAT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1038,13 +1027,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55836> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1055,7 +1055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1151,7 +1151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1498,7 +1498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1565,7 +1565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1609,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1638,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1652,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1703,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1785,7 +1785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1807,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1840,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1871,7 +1871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1902,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1927,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1968,7 +1968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2002,7 +2002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2019,7 +2019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2038,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2056,7 +2056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2101,7 +2101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,7 +2117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2129,7 +2129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2145,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2160,7 +2160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,7 +2177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2247,7 +2247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2281,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2294,7 +2294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2308,28 +2308,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
-] .
 
 <http://identifiers.org/sgd/S000000515>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2351,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2361,11 +2344,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002233_CHEBI_57288_2-ISOPROPYLMALATESYN-RXN_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2-ISOPROPYLMALATESYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57288_2-ISOPROPYLMALATESYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-13158_RO_0002233_CHEBI_35121_RXN-13158_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2399,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2464,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2477,7 +2477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2489,7 +2489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2506,7 +2506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2554,7 +2554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2594,7 +2594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2611,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2628,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2641,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2656,7 +2656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2669,7 +2669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2681,7 +2681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2699,7 +2699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2714,7 +2714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2730,7 +2730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2746,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2758,7 +2758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2775,7 +2775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2791,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2802,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2813,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2824,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2836,7 +2836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2863,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2874,7 +2874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2886,7 +2886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2912,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2929,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2945,7 +2945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2962,7 +2962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2978,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2989,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3000,7 +3000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3011,7 +3011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3023,7 +3023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3043,7 +3043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of branched chain amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3060,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3077,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3091,7 +3091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3107,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3118,7 +3118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3129,7 +3129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3140,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3152,7 +3152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3172,7 +3172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3187,7 +3187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3200,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3211,7 +3211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3227,7 +3227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3244,7 +3244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3261,7 +3261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3295,7 +3295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3321,7 +3321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3347,7 +3347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3361,7 +3361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3377,7 +3377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3415,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3435,7 +3435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3451,7 +3451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3487,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3501,7 +3501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3517,7 +3517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3528,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3540,7 +3540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3560,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3577,7 +3577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3594,7 +3594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3613,7 +3613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3624,7 +3624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3635,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3646,7 +3646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3658,7 +3658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3674,7 +3674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3687,7 +3687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3710,7 +3710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3724,7 +3724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3741,7 +3741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3760,7 +3760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3774,7 +3774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,13 +3788,30 @@
 <http://identifiers.org/sgd/S000002977>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55805> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller_SGD_BRANCHED-CHAIN-AA-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3805,23 +3822,6 @@
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_controller>
 ] .
 
-<http://model.geneontology.org/CHEBI_35146_BRANCHED-CHAINAMINOTRANSFERILEU-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_35146> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "(<i>S</i>)-3-methyl-2-oxopentanoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=BRANCHED-CHAIN-AA-SYN-PWY-1SmallMolecule55805> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -3830,7 +3830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,7 +3862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3879,7 +3879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3892,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3903,7 +3903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3915,7 +3915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3931,7 +3931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3954,7 +3954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3970,7 +3970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3987,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4001,7 +4001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4019,7 +4019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4033,7 +4033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4056,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4076,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4092,7 +4092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4122,7 +4122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4136,7 +4136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4153,7 +4153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4169,7 +4169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4180,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4195,7 +4195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4214,7 +4214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4231,7 +4231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4249,7 +4249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4262,7 +4262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4275,7 +4275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4289,7 +4289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4309,7 +4309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4324,7 +4324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4340,7 +4340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4360,7 +4360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4374,7 +4374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4394,7 +4394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4413,7 +4413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4425,7 +4425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4445,7 +4445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4458,7 +4458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4470,7 +4470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4486,7 +4486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4498,7 +4498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4520,7 +4520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4540,7 +4540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4557,7 +4557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4574,7 +4574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4588,7 +4588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4604,7 +4604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4615,7 +4615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4627,7 +4627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4657,7 +4657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4674,7 +4674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4691,7 +4691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4709,7 +4709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4724,7 +4724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4738,7 +4738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4758,7 +4758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4775,7 +4775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4795,7 +4795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,7 +4811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4823,7 +4823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4843,7 +4843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4856,7 +4856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4871,7 +4871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4888,7 +4888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BRANCHED-CHAIN-AA-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/BSUBPOLYAMSYN-PWY-BSUBPOLYAMSYN-PWY.ttl
+++ b/models/BSUBPOLYAMSYN-PWY-BSUBPOLYAMSYN-PWY.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "spermidine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=BSUBPOLYAMSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/CITRUL-BIO2-PWY-CITRUL-BIO2-PWY.ttl
+++ b/models/CITRUL-BIO2-PWY-CITRUL-BIO2-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "citrulline biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -884,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -939,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -995,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1063,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1074,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1112,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CITRUL-BIO2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CITRUL-BIO2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/COMPLETE-ARO-PWY-1-COMPLETE-ARO-PWY-1.ttl
+++ b/models/COMPLETE-ARO-PWY-1-COMPLETE-ARO-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -54,24 +54,13 @@
 <http://purl.obolibrary.org/obo/GO_0004764>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002233_CHEBI_15378_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,6 +71,17 @@
           <http://model.geneontology.org/CHEBI_15378_IGPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_RO_0002234_CHEBI_29985_ANTHRANSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_18277_PRAISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_18277> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,16 +434,13 @@
           <http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-5-DEHYDROGENASE-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ANTHRANSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,6 +450,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/reaction_SHIKIMATE-5-DEHYDROGENASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -465,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -563,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -826,18 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -849,7 +838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -860,13 +849,24 @@
           <http://model.geneontology.org/CHORISMATEMUT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_RO_0002234_CHEBI_145989_SHIKIMATE-KINASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -956,41 +956,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRYPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SHIKIMATE-5-DEHYDROGENASE-RXN_RO_0002233_CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,12 +973,40 @@
           <http://model.geneontology.org/CHEBI_36208_SHIKIMATE-5-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRYPSYN-RXN_RO_0002333_YGL026C-MONOMER_TRYPSYN-RXN_controller_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRYPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGL026C-MONOMER_TRYPSYN-RXN_controller>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002233_CHEBI_15361_RXN3O-4157_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1039,34 +1039,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_15377_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1>
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_PREPHENATE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_29934_PREPHENATE-DEHYDROGENASE-NADP+-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1081,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1103,29 +1109,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_18005_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PREPHENATEDEHYDRAT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18005_PREPHENATEDEHYDRAT-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000066_reaction_CHORISMATEMUT-RXN_location_lociGO_0005829_null_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_IGPSYN-RXN_RO_0002234_CHEBI_16526_IGPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1291,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1311,7 +1311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1330,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1370,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1390,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1403,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1420,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1592,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,7 +1647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1680,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1695,7 +1695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,7 +1712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,7 +1814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,7 +1828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1905,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1933,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1947,7 +1947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1964,7 +1964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2001,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2028,7 +2028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2048,7 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2102,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2129,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2141,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2172,7 +2172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2226,7 +2226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2243,7 +2243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2259,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,7 +2347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2363,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2378,7 +2378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2392,7 +2392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2412,7 +2412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2427,7 +2427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2447,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2464,7 +2464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2494,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2507,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2542,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2573,7 +2573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2589,7 +2589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2600,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2611,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2620,7 +2620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2631,11 +2631,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-dehydroquinate synthase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Protein57047> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2643,7 +2658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2653,21 +2668,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_IGPSYN-RXN>
 ] .
-
-<http://model.geneontology.org/YDR127W-MONOMER_SHIKIMATE-KINASE-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-dehydroquinate synthase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1Protein57047> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://purl.obolibrary.org/obo/GO_0004640>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2691,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2705,7 +2705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2724,7 +2724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2740,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2758,7 +2758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2774,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2789,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2802,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2813,7 +2813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2825,7 +2825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,7 +2842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,7 +2861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2872,7 +2872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2890,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2906,7 +2906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2923,7 +2923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2940,7 +2940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2957,7 +2957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2973,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2989,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3002,7 +3002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3017,7 +3017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3034,7 +3034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3054,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3071,7 +3071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3088,7 +3088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3104,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3118,7 +3118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3130,7 +3130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3147,7 +3147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3163,7 +3163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3183,7 +3183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3198,7 +3198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3214,7 +3214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3226,7 +3226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3245,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3256,7 +3256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3268,7 +3268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3285,7 +3285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3301,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3316,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,7 +3330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3349,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3360,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3372,7 +3372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3402,7 +3402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3418,7 +3418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3438,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3465,7 +3465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3478,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3489,7 +3489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3503,7 +3503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3520,7 +3520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3539,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3550,7 +3550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3561,7 +3561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3573,7 +3573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3589,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3601,7 +3601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3618,7 +3618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3635,7 +3635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3655,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3675,7 +3675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3688,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3703,7 +3703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3721,7 +3721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3738,7 +3738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3751,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3765,7 +3765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3777,7 +3777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3797,7 +3797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3810,7 +3810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3825,7 +3825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3839,22 +3839,16 @@
 <http://model.geneontology.org/reaction_CHORISMATE-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_145989> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "shikimate 3-phosphate" ;
+<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57026> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58315_RXN3O-4157>
         a       <http://purl.obolibrary.org/obo/CHEBI_58315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3865,7 +3859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3873,16 +3867,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROQUINATE-DEHYDRATASE-RXN_RO_0002411_SHIKIMATE-5-DEHYDROGENASE-RXN_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_145989_SHIKIMATE-KINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_145989> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "shikimate 3-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule57026> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YDR127W-MONOMER_2.5.1.19-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002534> ;
@@ -3891,7 +3891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3907,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3930,7 +3930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3944,7 +3944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3960,6 +3960,23 @@
 
 <http://purl.obolibrary.org/obo/GO_0004400>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16567> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "anthranilate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56892> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3983,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3991,29 +4008,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_16567_ANTHRANSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16567> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "anthranilate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=COMPLETE-ARO-PWY-1SmallMolecule56892> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002411_TYROSINE-AMINOTRANSFERASE-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4025,7 +4025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4043,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4066,7 +4066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4083,7 +4083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4103,7 +4103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4120,7 +4120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4136,7 +4136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4147,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4162,7 +4162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4175,7 +4175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4189,7 +4189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4209,7 +4209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4226,7 +4226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4248,7 +4248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4264,32 +4264,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_58394>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58394>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002233_CHEBI_15377_DAHPSYN-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4299,31 +4299,12 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DAHPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4334,12 +4315,31 @@
           <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'phospho<i>enol</i>pyruvate + D-erythrose 4-phosphate + H<sub>2</sub>O &harr; 3-deoxy-D-arabino-heptulosonate 7-phosphate + phosphate' 'null' '3-deoxy-D-arabino-heptulosonate 7-phosphate &rarr; 3-dehydroquinate + phosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_RO_0002413_3-DEHYDROQUINATE-SYNTHASE-RXN_null_COMPLETE-ARO-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DAHPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/3-DEHYDROQUINATE-SYNTHASE-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_SHIKIMATE-KINASE-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4350,7 +4350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4362,7 +4362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4378,7 +4378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4397,7 +4397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4414,7 +4414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4428,7 +4428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4444,7 +4444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4458,7 +4458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4475,7 +4475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4495,7 +4495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4508,7 +4508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4523,7 +4523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4540,7 +4540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4553,7 +4553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4564,7 +4564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4579,7 +4579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4598,7 +4598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4618,7 +4618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4638,7 +4638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4655,7 +4655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4672,7 +4672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of aromatic amino acid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -4689,7 +4689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4706,7 +4706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4729,7 +4729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4742,7 +4742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4757,7 +4757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4774,7 +4774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4793,7 +4793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4804,7 +4804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4816,7 +4816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4833,7 +4833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4852,7 +4852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4877,7 +4877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4894,7 +4894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4914,7 +4914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4928,7 +4928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4947,7 +4947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4958,7 +4958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4973,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4987,7 +4987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5005,7 +5005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5019,7 +5019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5042,7 +5042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5059,7 +5059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5076,7 +5076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5092,7 +5092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5104,7 +5104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5121,7 +5121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5137,7 +5137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5146,7 +5146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5161,7 +5161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5178,7 +5178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5192,7 +5192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5208,7 +5208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5222,7 +5222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5252,7 +5252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5265,7 +5265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5277,7 +5277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5294,7 +5294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5310,7 +5310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5321,7 +5321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5333,7 +5333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5353,7 +5353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5380,7 +5380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5394,7 +5394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5411,7 +5411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5431,7 +5431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5448,7 +5448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5465,7 +5465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5481,7 +5481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5492,7 +5492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5504,7 +5504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5521,7 +5521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5537,7 +5537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5552,7 +5552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5565,7 +5565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5576,7 +5576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5591,7 +5591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5605,7 +5605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5621,7 +5621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5632,7 +5632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5648,7 +5648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5661,7 +5661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5673,7 +5673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5693,7 +5693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5709,7 +5709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5723,7 +5723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5749,7 +5749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5769,7 +5769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5782,7 +5782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5800,7 +5800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5816,7 +5816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5830,7 +5830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5850,7 +5850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5867,7 +5867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5887,7 +5887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5915,7 +5915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5929,7 +5929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5945,7 +5945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5959,7 +5959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5976,7 +5976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5992,7 +5992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6010,7 +6010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6023,7 +6023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6038,7 +6038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6055,7 +6055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6073,7 +6073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6087,7 +6087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6104,7 +6104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6127,7 +6127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6141,7 +6141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6158,7 +6158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6177,7 +6177,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6189,7 +6200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6200,23 +6211,12 @@
           <http://model.geneontology.org/COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PREPHENATEDEHYDRAT-RXN_RO_0002234_CHEBI_16526_PREPHENATEDEHYDRAT-RXN_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.5.1.19-RXN_RO_0002234_CHEBI_43474_2.5.1.19-RXN_SGD_COMPLETE-ARO-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6227,7 +6227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6239,7 +6239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6255,7 +6255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6269,7 +6269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6280,7 +6280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6291,7 +6291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6306,7 +6306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6319,7 +6319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6332,7 +6332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6349,7 +6349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6365,7 +6365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6383,7 +6383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6397,7 +6397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6415,7 +6415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6432,7 +6432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6448,7 +6448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6460,7 +6460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6483,7 +6483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6502,7 +6502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6519,7 +6519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6535,7 +6535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6560,7 +6560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6577,7 +6577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6590,7 +6590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6605,7 +6605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6621,7 +6621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6633,7 +6633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6650,7 +6650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6678,7 +6678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6693,7 +6693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6706,7 +6706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6717,7 +6717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6728,7 +6728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6743,7 +6743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6756,7 +6756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6768,7 +6768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6784,7 +6784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6795,7 +6795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6807,7 +6807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6826,7 +6826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6842,7 +6842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6857,7 +6857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6873,7 +6873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6884,7 +6884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6896,7 +6896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6929,7 +6929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6943,7 +6943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6959,7 +6959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6973,7 +6973,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_COMPLETE-ARO-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:COMPLETE-ARO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6998,7 +7009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7006,24 +7017,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4157_RO_0002333_YHR137W-MONOMER_RXN3O-4157_controller_SGD_COMPLETE-ARO-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:COMPLETE-ARO-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DAHPSYN-RXN_BFO_0000050_COMPLETE-ARO-PWY-1/COMPLETE-ARO-PWY-1_SGD_COMPLETE-ARO-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7040,7 +7040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7063,7 +7063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7077,7 +7077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=COMPLETE-ARO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/CYSTEINE-SYN2-PWY-CYSTEINE-SYN2-PWY.ttl
+++ b/models/CYSTEINE-SYN2-PWY-CYSTEINE-SYN2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "cysteine biosynthesis from homocysteine - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:CYSTEINE-SYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=CYSTEINE-SYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/DENOVOPURINE2-PWY-DENOVOPURINE2-PWY.ttl
+++ b/models/DENOVOPURINE2-PWY-DENOVOPURINE2-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -618,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,11 +770,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_d18bfae4-de4c-4e42-823a-dd7053ff92fa_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN>
+          <http://model.geneontology.org/d18bfae4-de4c-4e42-823a-dd7053ff92fa_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
@@ -794,11 +794,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/936c25d9-c48c-4ef0-b7e3-496aaa147bfc_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -807,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -822,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -865,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1068,7 +1085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1119,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1147,7 +1164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1227,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1240,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1274,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1296,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1307,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1346,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1389,7 +1406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1470,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1481,7 +1498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1493,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1526,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1538,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1572,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,11 +1602,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_9392e694-b1f7-473f-8e83-ee4f87961074_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,7 +1614,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/9392e694-b1f7-473f-8e83-ee4f87961074_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57945_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY>
@@ -1605,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1650,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1661,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1672,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1700,7 +1717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1712,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1773,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1784,7 +1801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1795,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1842,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1856,7 +1873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1873,7 +1890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1889,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,7 +1937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1940,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1957,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1973,7 +1990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1993,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,9 +2047,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
+                <http://model.geneontology.org/2a3d9d5f-8ae7-497c-950e-7b235517c44d_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/d18bfae4-de4c-4e42-823a-dd7053ff92fa_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2040,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2057,7 +2074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2075,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2090,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2107,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2123,7 +2140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2138,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2158,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2175,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2192,28 +2209,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57913> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2226,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2268,7 +2268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2288,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2303,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2317,7 +2317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2340,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2359,7 +2359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2376,7 +2376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2392,7 +2392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2429,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2462,7 +2462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2475,7 +2475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2491,7 +2491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2503,7 +2503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,7 +2522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2545,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2560,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2588,7 +2588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2608,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2621,7 +2621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2634,7 +2634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2654,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2667,7 +2667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2679,7 +2679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2709,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2722,7 +2722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2733,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2748,7 +2748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2771,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2798,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2812,7 +2812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2828,7 +2828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2840,7 +2840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,7 +2858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2872,7 +2872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2889,7 +2889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2906,7 +2906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2922,7 +2922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2937,7 +2937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2956,7 +2956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2989,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3001,7 +3001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3020,7 +3020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3050,7 +3050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3073,7 +3073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3086,7 +3086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3100,7 +3100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3114,7 +3114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3132,7 +3132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3149,7 +3149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3162,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3177,7 +3177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3197,7 +3197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3217,7 +3217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3234,7 +3234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3251,7 +3251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3267,7 +3267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3279,7 +3279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3299,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3314,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3328,7 +3328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3344,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3359,7 +3359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3379,7 +3379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3409,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3425,7 +3425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3442,7 +3442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3458,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3469,7 +3469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3481,7 +3481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3500,7 +3500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3514,7 +3514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3525,7 +3525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3537,7 +3537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3557,7 +3557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3570,7 +3570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3585,7 +3585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3599,7 +3599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3615,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3630,7 +3630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3644,7 +3644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3667,7 +3667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3684,7 +3684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3700,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3712,7 +3712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3732,7 +3732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3749,7 +3749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3763,7 +3763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3794,7 +3794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3808,7 +3808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3825,7 +3825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3845,7 +3845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3858,7 +3858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3869,7 +3869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3880,7 +3880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3895,7 +3895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3908,7 +3908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3921,7 +3921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3940,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3952,7 +3952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3972,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3989,7 +3989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4003,7 +4003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4025,7 +4025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4048,7 +4048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4067,7 +4067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4084,7 +4084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4101,7 +4101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4120,7 +4120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4136,7 +4136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4147,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4161,7 +4161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4173,7 +4173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4193,7 +4193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4212,7 +4212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4225,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4239,7 +4239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4255,7 +4255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4270,7 +4270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4283,7 +4283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4297,7 +4297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4312,7 +4312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4328,7 +4328,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_936c25d9-c48c-4ef0-b7e3-496aaa147bfc_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4343,7 +4354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4360,7 +4371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4373,7 +4384,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_2a3d9d5f-8ae7-497c-950e-7b235517c44d_GART-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4398,7 +4420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4414,7 +4436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4439,7 +4461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4454,7 +4476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4467,7 +4489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4478,7 +4500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4490,7 +4512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4507,7 +4529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4527,7 +4549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4541,7 +4563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4557,7 +4579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4572,7 +4594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4586,7 +4608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4605,7 +4627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4625,7 +4647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4639,7 +4661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4659,7 +4681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4675,7 +4697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4687,7 +4709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4703,7 +4725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4718,7 +4740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4731,7 +4753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4746,7 +4768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4761,7 +4783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4777,7 +4799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4798,7 +4820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4811,7 +4833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4822,7 +4844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4834,7 +4856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4850,7 +4872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4861,7 +4883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4873,7 +4895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4890,7 +4912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4907,7 +4929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4927,7 +4949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4940,7 +4962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4951,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4966,7 +4988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4982,7 +5004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4997,7 +5019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5011,7 +5033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5028,7 +5050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5048,7 +5070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5064,7 +5086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5080,7 +5102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5092,7 +5114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5108,7 +5130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5125,7 +5147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5136,7 +5158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5161,7 +5183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5178,7 +5200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5191,7 +5213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5206,7 +5228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5225,7 +5247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5239,7 +5261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5253,7 +5275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5271,7 +5293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5284,7 +5306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5293,12 +5315,15 @@
 <http://identifiers.org/sgd/S000000070>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_29806>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002233_CHEBI_58189_GDPKIN-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5313,7 +5338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5321,8 +5346,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_9392e694-b1f7-473f-8e83-ee4f87961074_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004018>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5333,7 +5366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5350,7 +5383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5366,7 +5399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5377,7 +5410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5389,7 +5422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5405,7 +5438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5417,7 +5450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5434,7 +5467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5451,7 +5484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5467,7 +5500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5481,7 +5514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5497,7 +5530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5509,7 +5542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5529,7 +5562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5547,7 +5580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5574,7 +5607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5587,7 +5620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5598,7 +5631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5612,7 +5645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5623,7 +5656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5634,7 +5667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5646,7 +5679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5664,7 +5697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5684,7 +5717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5701,7 +5734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5714,11 +5747,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_936c25d9-c48c-4ef0-b7e3-496aaa147bfc_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5726,7 +5759,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/936c25d9-c48c-4ef0-b7e3-496aaa147bfc_AICARTRANSFORM-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5735,7 +5768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5752,7 +5785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5772,7 +5805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5786,7 +5819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5805,7 +5838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5822,7 +5855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5842,7 +5875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5861,7 +5894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5878,7 +5911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5894,7 +5927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5905,7 +5938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5920,7 +5953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5933,28 +5966,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004644>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5964,7 +5980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5985,7 +6001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5998,7 +6014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6013,7 +6029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6029,7 +6045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6044,7 +6060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6060,7 +6076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6071,18 +6087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6097,7 +6102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6113,7 +6118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6124,7 +6129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6136,7 +6141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6152,7 +6157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -6162,7 +6167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6179,7 +6184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6195,7 +6200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6207,7 +6212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6224,7 +6229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6244,7 +6249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6261,7 +6266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6275,7 +6280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6294,7 +6299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6306,7 +6311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6326,7 +6331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6346,7 +6351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6359,7 +6364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6377,7 +6382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6390,7 +6395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6401,7 +6406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6412,7 +6417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6429,7 +6434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6445,7 +6450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6459,7 +6464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6470,7 +6475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6481,7 +6486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6496,11 +6501,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57769> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/d18bfae4-de4c-4e42-823a-dd7053ff92fa_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6509,7 +6531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6524,7 +6546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6544,7 +6566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6557,7 +6579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6571,7 +6593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6583,7 +6605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6602,7 +6624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6618,7 +6640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6632,7 +6654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6644,7 +6666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6661,7 +6683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6680,7 +6702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6691,7 +6713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6706,7 +6728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6725,7 +6747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6748,7 +6770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6761,7 +6783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6773,7 +6795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6791,7 +6813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6808,7 +6830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6822,7 +6844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6838,7 +6860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6850,7 +6872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6870,7 +6892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6887,7 +6909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6900,7 +6922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6915,7 +6937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6928,7 +6950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6939,7 +6961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6952,7 +6974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6965,7 +6987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6976,7 +6998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6993,7 +7015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7007,7 +7029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7018,7 +7040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7029,7 +7051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -7042,7 +7064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7057,7 +7079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7070,7 +7092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7081,7 +7103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7092,7 +7114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7104,7 +7126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7117,11 +7139,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002411_DADPKIN-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7137,7 +7176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7148,7 +7187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7163,30 +7202,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57322> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002411_IMP-DEHYDROG-RXN_SGD_DENOVOPURINE2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/IMPCYCLOHYDROLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/IMP-DEHYDROG-RXN>
-] .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004019> ;
@@ -7207,13 +7229,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYBiochemicalReaction57531> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/2a3d9d5f-8ae7-497c-950e-7b235517c44d_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7223,7 +7262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7240,7 +7279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7259,7 +7298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7273,7 +7312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7287,7 +7326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7299,7 +7338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7316,7 +7355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7332,7 +7371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7350,7 +7389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7369,7 +7408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7380,23 +7419,6 @@
           <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57872> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7406,7 +7428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7427,7 +7449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7440,7 +7462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7451,7 +7473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7466,7 +7488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7481,7 +7503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7494,7 +7516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7509,7 +7531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7522,7 +7544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7534,7 +7556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7554,7 +7576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7570,7 +7592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7584,7 +7606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7600,7 +7622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7611,7 +7633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7622,7 +7644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7634,7 +7656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7650,7 +7672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7665,7 +7687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7681,7 +7703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7693,7 +7715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7713,7 +7735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7730,7 +7752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7747,7 +7769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7763,7 +7785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7780,7 +7802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7800,7 +7822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7813,7 +7835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7825,7 +7847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7842,7 +7864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7859,7 +7881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7879,7 +7901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7893,7 +7915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7909,7 +7931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7924,7 +7946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7944,7 +7966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7957,7 +7979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7968,7 +7990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7986,7 +8008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8006,9 +8028,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> , <http://model.geneontology.org/936c25d9-c48c-4ef0-b7e3-496aaa147bfc_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/9392e694-b1f7-473f-8e83-ee4f87961074_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -8016,7 +8038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8029,7 +8051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8044,7 +8066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8069,7 +8091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8082,7 +8104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8107,7 +8129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8121,7 +8143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8144,7 +8166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8160,7 +8182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8172,7 +8194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8192,7 +8214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8209,7 +8231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8225,7 +8247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8237,7 +8259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8254,7 +8276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8270,7 +8292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8282,7 +8304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8293,23 +8315,12 @@
           <http://model.geneontology.org/DENOVOPURINE2-PWY/DENOVOPURINE2-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8321,7 +8332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8338,7 +8349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8358,7 +8369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8371,7 +8382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8384,7 +8395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8401,7 +8412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8415,7 +8426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8431,7 +8442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8442,7 +8453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8457,7 +8468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8484,7 +8495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8497,35 +8508,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/6a33b824-097c-44cf-b184-92d3f7bc607c_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8536,7 +8530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8553,7 +8547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8565,7 +8559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8581,7 +8575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8595,7 +8589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8613,7 +8607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8626,7 +8620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8638,7 +8632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8655,7 +8649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8671,7 +8665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8686,7 +8680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8703,7 +8697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8719,7 +8713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8731,7 +8725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8748,7 +8742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8765,7 +8759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8781,7 +8775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8796,7 +8790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8812,7 +8806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8828,7 +8822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8840,7 +8834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8856,7 +8850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8867,7 +8861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8882,7 +8876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8895,7 +8889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8906,7 +8900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8921,7 +8915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8934,7 +8928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8961,7 +8955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8988,7 +8982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9005,7 +8999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9018,7 +9012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9039,7 +9033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9052,7 +9046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9063,7 +9057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9074,7 +9068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9086,7 +9080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9105,7 +9099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9120,7 +9114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9139,7 +9133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9156,7 +9150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9169,11 +9163,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_2a3d9d5f-8ae7-497c-950e-7b235517c44d_GART-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9181,15 +9175,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/edab7ed4-187f-4b16-a2b5-782d257f9a59_GART-RXN>
+          <http://model.geneontology.org/2a3d9d5f-8ae7-497c-950e-7b235517c44d_GART-RXN>
 ] .
+
+<http://model.geneontology.org/9392e694-b1f7-473f-8e83-ee4f87961074_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE2-PWYSmallMolecule57894> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_DENOVOPURINE2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9203,7 +9214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9220,7 +9231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9237,7 +9248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9253,7 +9264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9265,7 +9276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9281,7 +9292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9293,7 +9304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9311,7 +9322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9324,7 +9335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9340,7 +9351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9353,20 +9364,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_a767ecbb-c123-4c74-a592-21486820a7de_GART-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -9376,7 +9376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9392,7 +9392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9403,7 +9403,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_d18bfae4-de4c-4e42-823a-dd7053ff92fa_GART-RXN_SGD_DENOVOPURINE2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9421,7 +9432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9434,7 +9445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9446,7 +9457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9463,7 +9474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9483,7 +9494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9506,7 +9517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9517,24 +9528,13 @@
           <http://model.geneontology.org/CHEBI_57540_IMP-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_bb2aa93a-ff66-41c8-8075-069fce01dcb3_AICARTRANSFORM-RXN_SGD_DENOVOPURINE2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002234_CHEBI_137981_AIRS-RXN_SGD_DENOVOPURINE2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9564,7 +9564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9584,7 +9584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9597,7 +9597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9609,7 +9609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9626,7 +9626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9643,7 +9643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9660,7 +9660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9677,7 +9677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9693,7 +9693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9704,7 +9704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/DENOVOPURINE3-PWY-DENOVOPURINE3-PWY.ttl
+++ b/models/DENOVOPURINE3-PWY-DENOVOPURINE3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,7 +623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -707,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -774,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -837,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,11 +870,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_68e6aa43-10cd-458f-a11c-d6dd530a14f6_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN>
+          <http://model.geneontology.org/68e6aa43-10cd-458f-a11c-d6dd530a14f6_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_GMP-SYN-GLUT-RXN>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -922,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,29 +933,12 @@
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
-<http://model.geneontology.org/14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1055,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1138,7 +1121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1208,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1259,7 +1242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1291,7 +1274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,23 +1285,6 @@
           <http://model.geneontology.org/CHEBI_456216_AIRS-RXN>
 ] .
 
-<http://model.geneontology.org/2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_456216_ADPREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1328,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1362,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,18 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1398,7 +1353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,24 +1401,13 @@
 <http://purl.obolibrary.org/obo/GO_0004019>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002234_CHEBI_456216_GUANYL-KIN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1511,7 +1455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1567,7 +1511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1595,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1612,7 +1556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1639,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1654,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1668,7 +1612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1681,11 +1625,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_b0dcefd8-ae7d-4375-8647-e0269b9da756_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1637,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/b0dcefd8-ae7d-4375-8647-e0269b9da756_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-745>
@@ -1705,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1718,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1733,7 +1677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1746,7 +1690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1757,7 +1701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1779,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1790,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,7 +1763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1849,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1880,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1902,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1967,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1986,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +1949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2021,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2036,7 +1980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2049,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2064,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,7 +2044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,7 +2061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2140,9 +2084,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
+                <http://model.geneontology.org/68d9e422-3acf-48dc-811a-7e3f9b1e4e96_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/68e6aa43-10cd-458f-a11c-d6dd530a14f6_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2150,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2163,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2175,7 +2119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2208,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2224,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2236,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2252,7 +2196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2267,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2287,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2300,7 +2244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2326,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2342,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2362,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2375,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2390,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2407,7 +2351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2456,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2470,7 +2414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,7 +2430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2501,7 +2445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2521,7 +2465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2537,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2549,7 +2493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2572,7 +2516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2611,7 +2555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2624,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2637,7 +2581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,7 +2598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,7 +2617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2696,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2711,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2724,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2739,7 +2683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2759,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2772,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2783,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2796,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2816,7 +2760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2840,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2851,7 +2795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2862,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2874,7 +2818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2904,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2924,7 +2868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2937,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2955,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2982,7 +2926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2996,7 +2940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3013,7 +2957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3031,7 +2975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3045,7 +2989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3062,7 +3006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3079,7 +3023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3099,7 +3043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3115,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3129,7 +3073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3149,7 +3093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3162,7 +3106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3173,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3185,7 +3129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3196,17 +3140,6 @@
           <http://model.geneontology.org/YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -3215,7 +3148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3225,6 +3158,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002413_GUANYL-KIN-RXN_null_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004639> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3245,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3268,7 +3212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3281,7 +3225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3295,7 +3239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3306,7 +3250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3320,7 +3264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3332,7 +3276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3355,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3372,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3385,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3400,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3420,7 +3364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3440,7 +3384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3457,7 +3401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3476,7 +3420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3493,7 +3437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3509,7 +3453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3524,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3539,7 +3483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3553,7 +3497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3573,7 +3517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3589,7 +3533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3604,7 +3548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3634,7 +3578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3647,7 +3591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3658,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3672,7 +3616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,7 +3633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3705,7 +3649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3716,7 +3660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3727,7 +3671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3738,7 +3682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3750,7 +3694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3766,7 +3710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3775,30 +3719,13 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002234_CHEBI_61429_RXN0-746_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3817,11 +3744,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/2d82c9e6-93db-4f0c-8ff5-15f2d065e7d8_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3829,7 +3773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3849,7 +3793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3862,7 +3806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3877,7 +3821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3891,7 +3835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3911,7 +3855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3927,7 +3871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3950,7 +3894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3966,7 +3910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3977,7 +3921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3989,7 +3933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4006,7 +3950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4026,7 +3970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4043,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4060,7 +4004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4088,7 +4032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4101,7 +4045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4113,7 +4057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4130,7 +4074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4150,7 +4094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4167,7 +4111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4180,18 +4124,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/68e6aa43-10cd-458f-a11c-d6dd530a14f6_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002411_SAICARSYN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4204,7 +4165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4217,7 +4178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4235,7 +4196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4255,7 +4216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4272,7 +4233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4289,7 +4250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4303,7 +4264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4322,7 +4283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4336,7 +4297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4359,7 +4320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4378,7 +4339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4395,7 +4356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4412,7 +4373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4431,7 +4392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4447,7 +4408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4458,7 +4419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4472,7 +4433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4483,7 +4444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4495,7 +4456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4515,7 +4476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4531,7 +4492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4546,7 +4507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4562,7 +4523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4573,7 +4534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4584,7 +4545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4599,7 +4560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4612,7 +4573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4623,7 +4584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4643,7 +4604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4663,7 +4624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4680,7 +4641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4697,7 +4658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4710,7 +4671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4735,7 +4696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4749,7 +4710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4765,7 +4726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4779,7 +4740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4804,7 +4765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4819,7 +4780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4827,29 +4788,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FGAMSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
-] .
-
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002233_CHEBI_57305_GLYRIBONUCSYN-RXN_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4864,7 +4808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4877,7 +4821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4885,11 +4829,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_58359_FGAMSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FGAMSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58359_FGAMSYN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002234_Red-Thioredoxin_GDPREDUCT-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4909,7 +4870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4923,7 +4884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4943,7 +4904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4957,7 +4918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4976,7 +4937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4996,7 +4957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5010,7 +4971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5021,13 +4982,16 @@
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
+<http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AICARSYN-RXN_RO_0002234_CHEBI_29806_AICARSYN-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5038,15 +5002,12 @@
           <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_AIRS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5057,7 +5018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5069,7 +5030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5080,12 +5041,29 @@
           <http://model.geneontology.org/CHEBI_58426_GART-RXN>
 ] .
 
+<http://model.geneontology.org/b0dcefd8-ae7d-4375-8647-e0269b9da756_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45982> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_BFO_0000066_reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829_null_DENOVOPURINE3-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5100,7 +5078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5117,7 +5095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5132,7 +5110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5158,7 +5136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5178,7 +5156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5191,7 +5169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5202,7 +5180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5213,7 +5191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5224,7 +5202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5235,7 +5213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5247,7 +5225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5263,7 +5241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5286,7 +5264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5300,7 +5278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5317,7 +5295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5333,7 +5311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5345,7 +5323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5365,7 +5343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5378,7 +5356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5393,7 +5371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5413,7 +5391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5427,7 +5405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5444,7 +5422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5464,7 +5442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5480,7 +5458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5496,7 +5474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5508,7 +5486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5530,7 +5508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5555,7 +5533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5568,7 +5546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5583,7 +5561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5600,7 +5578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5619,7 +5597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5630,7 +5608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5647,7 +5625,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_2d82c9e6-93db-4f0c-8ff5-15f2d065e7d8_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5658,7 +5647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5675,7 +5664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5694,7 +5683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5709,7 +5698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5725,7 +5714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5736,7 +5725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5750,7 +5739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5762,7 +5751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5778,7 +5767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5789,7 +5778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5801,7 +5790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5818,7 +5807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5834,7 +5823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5845,7 +5834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5857,7 +5846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5873,7 +5862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5884,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5896,7 +5885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5913,7 +5902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5932,7 +5921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5949,7 +5938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5968,7 +5957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5980,7 +5969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5991,6 +5980,17 @@
           <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_68d9e422-3acf-48dc-811a-7e3f9b1e4e96_GART-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YGL234W-MONOMER_AIRS-RXN_controller>
         a       <http://identifiers.org/sgd/S000003203> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5998,7 +5998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6025,7 +6025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6041,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6052,20 +6052,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_14fec936-0cde-4b90-b123-5a38faec8dac_GART-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -6074,7 +6063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6086,7 +6075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6105,7 +6094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6118,7 +6107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6138,7 +6127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6151,7 +6140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6162,7 +6151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6173,7 +6162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6188,7 +6177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6201,11 +6190,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_2d82c9e6-93db-4f0c-8ff5-15f2d065e7d8_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6213,7 +6202,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/2d82c9e6-93db-4f0c-8ff5-15f2d065e7d8_AICARTRANSFORM-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6222,7 +6211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6239,7 +6228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6259,7 +6248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6273,7 +6262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6289,7 +6278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6301,7 +6290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6318,7 +6307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6337,7 +6326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6349,7 +6338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6368,7 +6357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6388,7 +6377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of purine nucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6402,7 +6391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6418,7 +6407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6433,7 +6422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6446,7 +6435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6457,7 +6446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6481,7 +6470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6497,7 +6486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6509,7 +6498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6525,7 +6514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6536,7 +6525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6551,7 +6540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6564,7 +6553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6576,7 +6565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6599,7 +6588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6616,7 +6605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6632,7 +6621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6644,7 +6633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6660,7 +6649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -6669,7 +6658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6681,7 +6670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6698,7 +6687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6714,7 +6703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6725,7 +6714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6737,7 +6726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6754,7 +6743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6774,7 +6763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6791,7 +6780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6805,7 +6794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6824,7 +6813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6836,7 +6825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6856,7 +6845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6876,7 +6865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6896,7 +6885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6909,7 +6898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6923,7 +6912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6945,7 +6934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6960,7 +6949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6980,7 +6969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6994,7 +6983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7014,7 +7003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7025,13 +7014,30 @@
 <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/68d9e422-3acf-48dc-811a-7e3f9b1e4e96_GART-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_15377_IMPCYCLOHYDROLASE-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7047,7 +7053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7061,7 +7067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7077,7 +7083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7091,7 +7097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7103,7 +7109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7120,7 +7126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7143,7 +7149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7162,7 +7168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7172,17 +7178,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_FGAMSYN-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:DENOVOPURINE3-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -7196,7 +7191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7209,7 +7204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7221,7 +7216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7239,7 +7234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7256,7 +7251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7270,7 +7265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7287,7 +7282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7307,7 +7302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7324,7 +7319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7341,7 +7336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7358,7 +7353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -7371,7 +7366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7384,7 +7379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7397,7 +7392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7417,7 +7412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -7427,7 +7422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7438,23 +7433,6 @@
           <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DENOVOPURINE3-PWYSmallMolecule45960> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_58053_IMP-DEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58053> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7464,7 +7442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7479,7 +7457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7492,7 +7470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7503,7 +7481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7514,7 +7492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7525,7 +7503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7536,7 +7514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7548,7 +7526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7565,7 +7543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7581,7 +7559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7596,7 +7574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7610,7 +7588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7640,7 +7618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7654,7 +7632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7676,7 +7654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7695,7 +7673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7710,7 +7688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7726,7 +7704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7738,7 +7716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7754,7 +7732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7771,7 +7749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7783,7 +7761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7802,7 +7780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7822,7 +7800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7843,7 +7821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7856,7 +7834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7867,7 +7845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7882,7 +7860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7897,7 +7875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7910,7 +7888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7925,7 +7903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7938,7 +7916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7952,7 +7930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7968,7 +7946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7983,7 +7961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8000,7 +7978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8017,7 +7995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8033,7 +8011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8044,7 +8022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8058,7 +8036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8074,7 +8052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8089,7 +8067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8105,7 +8083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8117,7 +8095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8137,7 +8115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8150,7 +8128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8165,7 +8143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8178,7 +8156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8193,7 +8171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8207,7 +8185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8218,13 +8196,24 @@
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_68e6aa43-10cd-458f-a11c-d6dd530a14f6_GART-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRS-RXN_RO_0002233_CHEBI_18413_AIRS-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8240,7 +8229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8255,7 +8244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8268,7 +8257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8279,7 +8268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8291,7 +8280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8308,7 +8297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8325,7 +8314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8345,7 +8334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8358,7 +8347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8370,7 +8359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8386,7 +8375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8401,7 +8390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8421,7 +8410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8434,7 +8423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8445,7 +8434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8456,7 +8445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8474,7 +8463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8494,9 +8483,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4f5002a2-c314-4291-956d-88bf75c59d1b_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/2d82c9e6-93db-4f0c-8ff5-15f2d065e7d8_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/a8556309-56ba-47dc-ac4e-31591763b8b4_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/b0dcefd8-ae7d-4375-8647-e0269b9da756_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -8504,7 +8493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8517,7 +8506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8528,7 +8517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8543,7 +8532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8568,7 +8557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8581,7 +8570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8592,7 +8581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8603,7 +8592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8614,7 +8603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8639,7 +8628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8652,7 +8641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8664,7 +8653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8683,7 +8672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8698,7 +8687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8715,7 +8704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8731,7 +8720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8745,7 +8734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8757,7 +8746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8774,7 +8763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8790,7 +8779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8802,7 +8791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8819,7 +8808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8835,7 +8824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8847,7 +8836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8863,7 +8852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8875,7 +8864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8891,7 +8880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -8903,7 +8892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8923,7 +8912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8938,7 +8927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8955,7 +8944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8969,7 +8958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8985,7 +8974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9000,7 +8989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9027,7 +9016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9040,7 +9029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9058,7 +9047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9074,7 +9063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9095,7 +9084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9108,7 +9097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9120,7 +9109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9137,7 +9126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9157,7 +9146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9174,7 +9163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9191,7 +9180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9210,7 +9199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9227,7 +9216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9238,12 +9227,23 @@
           <http://model.geneontology.org/DENOVOPURINE3-PWY/DENOVOPURINE3-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_b0dcefd8-ae7d-4375-8647-e0269b9da756_AICARTRANSFORM-RXN_SGD_DENOVOPURINE3-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:DENOVOPURINE3-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_BFO_0000050_DENOVOPURINE3-PWY/DENOVOPURINE3-PWY_SGD_DENOVOPURINE3-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9258,7 +9258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9271,7 +9271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9285,7 +9285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9301,7 +9301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9313,7 +9313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9329,7 +9329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9344,7 +9344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9357,7 +9357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9372,7 +9372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9386,7 +9386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9418,7 +9418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9445,7 +9445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9462,7 +9462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9485,7 +9485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9498,7 +9498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9509,7 +9509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9520,7 +9520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9532,7 +9532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9555,7 +9555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9574,7 +9574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9590,7 +9590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9602,7 +9602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9615,11 +9615,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_68d9e422-3acf-48dc-811a-7e3f9b1e4e96_GART-RXN_SGD_DENOVOPURINE3-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9627,7 +9627,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2d11a4f2-994d-441d-aee8-91c75d2dc1dd_GART-RXN>
+          <http://model.geneontology.org/68d9e422-3acf-48dc-811a-7e3f9b1e4e96_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_RO_0002233_CHEBI_30616_GMP-SYN-NH3-RXN_SGD_DENOVOPURINE3-PWY>
@@ -9635,7 +9635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9646,7 +9646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9660,7 +9660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9677,7 +9677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9693,7 +9693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9704,7 +9704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9716,7 +9716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9733,7 +9733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9750,7 +9750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9768,7 +9768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9781,7 +9781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9795,7 +9795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9808,7 +9808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9821,7 +9821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9832,7 +9832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9843,7 +9843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9855,7 +9855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9871,7 +9871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9882,7 +9882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9894,7 +9894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9913,7 +9913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9928,7 +9928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9942,7 +9942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9958,7 +9958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -9970,7 +9970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9990,7 +9990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10013,7 +10013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10043,7 +10043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10057,7 +10057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10073,7 +10073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10091,7 +10091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10105,7 +10105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10121,7 +10121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10133,7 +10133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10150,7 +10150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10167,7 +10167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10183,7 +10183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DENOVOPURINE3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -10195,7 +10195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DENOVOPURINE3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/DETOX1-PWY-DETOX1-PWY.ttl
+++ b/models/DETOX1-PWY-DETOX1-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,23 +50,6 @@
           <http://model.geneontology.org/SUPEROX-DISMUT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/MONOMER3O-1642_SUPEROX-DISMUT-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15379_CATAL-RXN_SGD_DETOX1-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CATAL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_CATAL-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_SUPEROX-DISMUT-RXN>
@@ -78,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,13 +78,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=DETOX1-PWYSmallMolecule28324> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CATAL-RXN_RO_0002234_CHEBI_15379_CATAL-RXN_SGD_DETOX1-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CATAL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15379_CATAL-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superoxide radicals degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -792,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=DETOX1-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:DETOX1-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/ERGOSTEROL-SYN-PWY-1-ERGOSTEROL-SYN-PWY-1.ttl
+++ b/models/ERGOSTEROL-SYN-PWY-1-ERGOSTEROL-SYN-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -53,24 +53,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59199> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_null_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-232_RXN3O-9828_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004617> ;
@@ -79,13 +68,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein59180> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9828_BFO_0000066_reaction_RXN3O-9828_location_lociGO_0005829_null_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_87287_RXN3O-9822>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_87287> ;
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,11 +204,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/38b43ec0-ef06-4902-8f8e-0385198ce5b7_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_17813>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -219,7 +236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -283,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,28 +348,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9824> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1>
-] .
+<http://model.geneontology.org/reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/RXN3O-203>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -373,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,8 +384,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/reaction_MEVALONATE-KINASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9824> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -390,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -488,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,11 +530,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_25295d71-98e5-4598-abed-a2a883a45188_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +542,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825>
+          <http://model.geneontology.org/25295d71-98e5-4598-abed-a2a883a45188_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -536,7 +553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -601,7 +618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -722,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -806,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,9 +926,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_71683d91-de1b-4f3b-b8e3-151b727d8a68_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -921,7 +949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -989,9 +1017,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/25295d71-98e5-4598-abed-a2a883a45188_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/8e22def9-000b-4e8b-bc25-6a9fccfa0af2_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -999,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,13 +1107,24 @@
           <http://model.geneontology.org/ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_null_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_71683d91-de1b-4f3b-b8e3-151b727d8a68_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,19 +1132,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826>
+          <http://model.geneontology.org/71683d91-de1b-4f3b-b8e3-151b727d8a68_RXN3O-9826>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002413_RXN3O-9823_null_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1115,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1184,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1198,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1277,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1329,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1345,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1368,7 +1396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,6 +1410,17 @@
 <http://purl.obolibrary.org/obo/GO_0003838>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_30bedad2-8f3c-41c8-9659-617477bce926_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57856_RXN3O-178>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57856> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1391,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1419,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1431,7 +1470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1447,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1458,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1469,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1486,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1498,7 +1537,7 @@
 ] .
 
 <http://model.geneontology.org/CHEBI_15339_RXN3O-9816>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1506,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,7 +1559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1537,7 +1576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1634,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,7 +1690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1699,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1747,7 +1786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1780,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1795,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,7 +1847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1834,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1864,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1883,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1894,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1905,7 +1944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1919,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1931,7 +1970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1947,7 +1986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1959,7 +1998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1996,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,7 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2023,7 +2062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2043,7 +2082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,7 +2101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2079,7 +2118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2095,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2110,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2126,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2140,7 +2179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2156,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2170,7 +2209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2204,7 +2243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2243,7 +2282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2258,7 +2297,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
+                <http://model.geneontology.org/1e5a292d-6e16-4535-8920-87d0fa5a350a_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2268,7 +2307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2288,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2305,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2324,7 +2363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,7 +2380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2364,7 +2403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,7 +2459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2433,7 +2472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2445,7 +2484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2468,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2482,7 +2521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2499,7 +2538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2515,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2527,7 +2566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2547,7 +2586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2564,7 +2603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2581,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2598,7 +2637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2614,7 +2653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2626,7 +2665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2642,7 +2681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2656,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2671,11 +2710,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58464> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/71683d91-de1b-4f3b-b8e3-151b727d8a68_RXN3O-9826>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2698,7 +2754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2715,7 +2771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2741,7 +2797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2777,7 +2833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2789,7 +2845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2805,7 +2861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2816,7 +2872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2836,7 +2892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2850,29 +2906,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_18249>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002234_CHEBI_15378_RXN66-319_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2897,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2911,7 +2950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2931,7 +2970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2944,7 +2983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2958,7 +2997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2977,7 +3016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2993,7 +3032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3004,11 +3043,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_43074_1.1.1.34-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43074> ;
@@ -3019,16 +3061,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58634> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN66-281>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -3039,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3053,7 +3092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3071,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3088,7 +3127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3102,7 +3141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3122,7 +3161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3130,23 +3169,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_CHEBI_15379_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3158,7 +3186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3169,22 +3197,16 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9828>
 ] .
 
-<http://model.geneontology.org/0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3192,7 +3214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3208,7 +3230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3220,7 +3242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3236,7 +3258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3251,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3264,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3279,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3296,7 +3318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3312,7 +3334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3323,7 +3345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3341,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3358,7 +3380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3378,7 +3400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3391,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3399,23 +3421,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57623>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_1.3.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -3426,7 +3431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3440,7 +3445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3460,7 +3465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3476,7 +3481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3490,7 +3495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3502,7 +3507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3519,7 +3524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3555,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3569,7 +3574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3589,7 +3594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3605,7 +3610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3616,7 +3621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3628,7 +3633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3644,7 +3649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3652,11 +3657,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_38b43ec0-ef06-4902-8f8e-0385198ce5b7_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3664,7 +3669,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826>
+          <http://model.geneontology.org/38b43ec0-ef06-4902-8f8e-0385198ce5b7_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3673,7 +3678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3692,7 +3697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3706,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3718,7 +3723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,7 +3739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3749,7 +3754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3765,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3783,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3800,7 +3805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3816,7 +3821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3827,7 +3832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3839,7 +3844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,7 +3867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3878,7 +3883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3889,7 +3894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3904,7 +3909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3921,7 +3926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3937,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3958,7 +3963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3985,7 +3990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4001,7 +4006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4017,7 +4022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4029,7 +4034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4046,7 +4051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4065,7 +4070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4084,7 +4089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4101,7 +4106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4121,7 +4126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4138,7 +4143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4156,7 +4161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4171,7 +4176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4185,7 +4190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4202,7 +4207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4222,7 +4227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4231,7 +4236,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17499_RXN3O-9816>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24331> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4239,7 +4244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4256,7 +4261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4283,7 +4288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4296,7 +4301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4310,7 +4315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4325,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4339,7 +4344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4356,7 +4361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4379,7 +4384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4395,7 +4400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4406,7 +4411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4418,7 +4423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4434,7 +4439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4459,7 +4464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4473,7 +4478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4490,7 +4495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4512,7 +4517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4532,7 +4537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4548,7 +4553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4560,7 +4565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4577,7 +4582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4594,7 +4599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4614,7 +4619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4627,7 +4632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4639,7 +4644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4655,7 +4660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4666,7 +4671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4677,7 +4682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4700,7 +4705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4713,7 +4718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4728,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4743,7 +4748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4758,7 +4763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4785,7 +4790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4800,7 +4805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4813,7 +4818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4824,18 +4829,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_PHOSPHOMEVALONATE-KINASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4850,7 +4855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4858,23 +4863,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002233_CHEBI_58146_PHOSPHOMEVALONATE-KINASE-RXN_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9827_RO_0002234_CHEBI_52972_RXN3O-9827_SGD_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_CHEBI_13390_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4888,7 +4893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4909,7 +4914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4923,7 +4928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4939,7 +4944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4954,7 +4959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4974,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4987,7 +4992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5001,7 +5006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5018,7 +5023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5041,7 +5046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5057,7 +5062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5068,17 +5073,6 @@
           <http://model.geneontology.org/RXN66-313>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0008398>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -5088,7 +5082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5118,7 +5112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5135,7 +5129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5149,7 +5143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5166,7 +5160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5182,7 +5176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5194,7 +5188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5224,7 +5218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5241,7 +5235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5255,7 +5249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5271,7 +5265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5283,7 +5277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5303,7 +5297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5311,12 +5305,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_1e5a292d-6e16-4535-8920-87d0fa5a350a_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002333_YGR060W-MONOMER_RXN3O-9824_controller_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5327,7 +5332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5339,7 +5344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5350,12 +5355,12 @@
           <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_a98d8cd6-083f-40de-8de5-2eaca57db9f6_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_8e22def9-000b-4e8b-bc25-6a9fccfa0af2_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5370,7 +5375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5383,7 +5388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5401,7 +5406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5417,7 +5422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5432,7 +5437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5449,7 +5454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5465,7 +5470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5477,7 +5482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5493,7 +5498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5504,7 +5509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5519,7 +5524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5533,7 +5538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5555,7 +5560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5567,7 +5572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5583,7 +5588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5600,7 +5605,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
+                <http://model.geneontology.org/30bedad2-8f3c-41c8-9659-617477bce926_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5608,7 +5613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5622,7 +5627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5638,7 +5643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5649,7 +5654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5663,7 +5668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5674,24 +5679,13 @@
           <http://model.geneontology.org/IPPISOM-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_CHEBI_15377_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5708,7 +5702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5725,7 +5719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5741,7 +5735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5753,7 +5747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5773,7 +5767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5786,7 +5780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5801,7 +5795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5821,7 +5815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5834,7 +5828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5849,7 +5843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5862,7 +5856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5886,7 +5880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5899,7 +5893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5912,7 +5906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5925,7 +5919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5942,7 +5936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5975,7 +5969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5988,7 +5982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5999,7 +5993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6011,7 +6005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6027,7 +6021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6038,7 +6032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6052,7 +6046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6068,7 +6062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6079,7 +6073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6090,7 +6084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6115,7 +6109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6129,7 +6123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6145,7 +6139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6157,7 +6151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6174,7 +6168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6190,7 +6184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6201,7 +6195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6209,11 +6203,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_30bedad2-8f3c-41c8-9659-617477bce926_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6221,7 +6215,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824>
+          <http://model.geneontology.org/30bedad2-8f3c-41c8-9659-617477bce926_RXN3O-9824>
 ] .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
@@ -6233,7 +6227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6253,7 +6247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6272,7 +6266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6289,7 +6283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6306,7 +6300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6326,7 +6320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6343,7 +6337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6356,7 +6350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6367,7 +6361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6381,7 +6375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6392,7 +6386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6405,7 +6399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6421,7 +6415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6442,7 +6436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6458,7 +6452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6472,7 +6466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6490,7 +6484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6507,7 +6501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6520,7 +6514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6535,7 +6529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6552,7 +6546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6566,7 +6560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6577,6 +6571,17 @@
           <http://model.geneontology.org/CHEBI_136486_RXN66-313>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YMR202W-MONOMER_RXN3O-203_controller>
         a       <http://identifiers.org/sgd/S000004815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -6584,7 +6589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6592,23 +6597,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_CHEBI_13390_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_25295d71-98e5-4598-abed-a2a883a45188_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6620,7 +6625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6636,7 +6641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6647,7 +6652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6658,7 +6663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6669,7 +6674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6680,7 +6685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6692,7 +6697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6708,7 +6713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6722,7 +6727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6738,7 +6743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6749,7 +6754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6764,7 +6769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6778,7 +6783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6794,7 +6799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6808,7 +6813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6825,7 +6830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6842,7 +6847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6859,7 +6864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6877,7 +6882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6891,7 +6896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6911,7 +6916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6925,7 +6930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6948,7 +6953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6961,7 +6966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6976,7 +6981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6989,7 +6994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7000,7 +7005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7011,7 +7016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7023,7 +7028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7043,7 +7048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7059,7 +7064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7070,7 +7075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7082,7 +7087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7100,7 +7105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7117,7 +7122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7137,7 +7142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7150,7 +7155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7161,7 +7166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7173,7 +7178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7189,7 +7194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7203,7 +7208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7222,7 +7227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7234,7 +7239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7254,7 +7259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7268,7 +7273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7285,7 +7290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7304,7 +7309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7321,7 +7326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7337,7 +7342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7349,7 +7354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7369,7 +7374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7386,7 +7391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7400,7 +7405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7416,7 +7421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7431,7 +7436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7453,7 +7458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7472,7 +7477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7483,35 +7488,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002333_YGR060W-MONOMER_RXN3O-9825_controller_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7526,7 +7514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7539,7 +7527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7550,7 +7538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7561,7 +7549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7572,7 +7560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7583,7 +7571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7594,7 +7582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7609,7 +7597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7620,13 +7608,30 @@
           <http://model.geneontology.org/RXN3O-9821>
 ] .
 
+<http://model.geneontology.org/30bedad2-8f3c-41c8-9659-617477bce926_RXN3O-9824>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002333_YML075C-MONOMER_1.1.1.34-RXN_controller_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7646,7 +7651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7654,13 +7659,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_38b43ec0-ef06-4902-8f8e-0385198ce5b7_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002234_CHEBI_136486_RXN66-314_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7676,7 +7692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7687,7 +7703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7702,7 +7718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7715,7 +7731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7726,7 +7742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7737,7 +7753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7748,7 +7764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7760,7 +7776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7771,12 +7787,29 @@
           <http://model.geneontology.org/ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/8e22def9-000b-4e8b-bc25-6a9fccfa0af2_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002234_CHEBI_13390_RXN66-281_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7791,9 +7824,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/38b43ec0-ef06-4902-8f8e-0385198ce5b7_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
+                <http://model.geneontology.org/71683d91-de1b-4f3b-b8e3-151b727d8a68_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7801,7 +7834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7815,7 +7848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7832,7 +7865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7849,7 +7882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7865,7 +7898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7878,7 +7911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7892,7 +7925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7911,7 +7944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7931,7 +7964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7947,7 +7980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7963,7 +7996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7977,7 +8010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7994,7 +8027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8005,6 +8038,23 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9820>
 ] .
 
+<http://model.geneontology.org/1e5a292d-6e16-4535-8920-87d0fa5a350a_RXN66-318>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_58146_MEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58146> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8014,7 +8064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8031,7 +8081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8044,7 +8094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8059,7 +8109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8075,7 +8125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8095,7 +8145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8108,7 +8158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8126,7 +8176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8143,7 +8193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8170,7 +8220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8183,7 +8233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8194,7 +8244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8206,7 +8256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8225,7 +8275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8243,7 +8293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8257,7 +8307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8273,7 +8323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8285,7 +8335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8302,7 +8352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8322,7 +8372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8335,11 +8385,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/25295d71-98e5-4598-abed-a2a883a45188_RXN3O-9825>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58965> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8349,7 +8416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8360,16 +8427,13 @@
           <http://model.geneontology.org/RXN3O-9825>
 ] .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IPPISOM-RXN_RO_0002233_CHEBI_128769_IPPISOM-RXN_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8380,6 +8444,9 @@
           <http://model.geneontology.org/CHEBI_128769_IPPISOM-RXN>
 ] .
 
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004821> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -8387,24 +8454,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1Protein58574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YGL001C-MONOMER_RXN66-318_controller>
         a       <http://identifiers.org/sgd/S000002969> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -8413,7 +8469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8426,7 +8482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8441,7 +8497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8468,7 +8524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8482,7 +8538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8499,7 +8555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8519,7 +8575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8533,7 +8589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8553,7 +8609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8566,7 +8622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8581,7 +8637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8601,7 +8657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8614,7 +8670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8626,7 +8682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8642,7 +8698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8657,7 +8713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8684,7 +8740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8697,7 +8753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8712,7 +8768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8728,7 +8784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8739,7 +8795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8750,7 +8806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8761,7 +8817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8772,7 +8828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8787,7 +8843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8801,7 +8857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8820,7 +8876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8832,7 +8888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8848,7 +8904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8861,7 +8917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8871,11 +8927,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_1e5a292d-6e16-4535-8920-87d0fa5a350a_RXN66-318_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8883,7 +8939,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/feede58a-6392-4383-b7ed-b4bb031c2fb7_RXN66-318>
+          <http://model.geneontology.org/1e5a292d-6e16-4535-8920-87d0fa5a350a_RXN66-318>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1>
@@ -8891,7 +8947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8902,7 +8958,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8917,7 +8984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8934,7 +9001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8942,24 +9009,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_87289_RXN3O-9821_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9823_BFO_0000050_ERGOSTEROL-SYN-PWY-1/ERGOSTEROL-SYN-PWY-1_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8978,7 +9034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8998,7 +9054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9015,7 +9071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9029,7 +9085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9046,7 +9102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9066,7 +9122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9080,7 +9136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9097,7 +9153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9114,7 +9170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9137,7 +9193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9150,7 +9206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9161,7 +9217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9173,7 +9229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9193,7 +9249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9207,7 +9263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9227,7 +9283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9240,7 +9296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9251,7 +9307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9266,7 +9322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9293,7 +9349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9310,7 +9366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9327,7 +9383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9341,7 +9397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9357,7 +9413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9372,7 +9428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9385,7 +9441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9396,7 +9452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9408,7 +9464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9419,23 +9475,23 @@
           <http://model.geneontology.org/CHEBI_29888_RXN66-281>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_15378_RXN66-281_SGD_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9821_RO_0002234_CHEBI_13390_RXN3O-9821_SGD_ERGOSTEROL-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9450,7 +9506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9463,7 +9519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9475,7 +9531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9505,7 +9561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9518,7 +9574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9530,7 +9586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9546,7 +9602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9562,7 +9618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9576,7 +9632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9593,7 +9649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9612,7 +9668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9628,14 +9684,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24331>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_456216_MEVALONATE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -9646,7 +9699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9659,7 +9712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9667,11 +9720,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_8e22def9-000b-4e8b-bc25-6a9fccfa0af2_RXN3O-9825_SGD_ERGOSTEROL-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9679,7 +9732,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0adc96b5-b139-4ea4-83e7-db29a849196f_RXN3O-9825>
+          <http://model.geneontology.org/8e22def9-000b-4e8b-bc25-6a9fccfa0af2_RXN3O-9825>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -9688,7 +9741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9704,7 +9757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9719,7 +9772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9736,7 +9789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9750,7 +9803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9767,7 +9820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9787,7 +9840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9804,7 +9857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9820,7 +9873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9843,7 +9896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9857,7 +9910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9876,7 +9929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9890,7 +9943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9901,7 +9954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9912,7 +9965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9927,7 +9980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9954,7 +10007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9981,7 +10034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9994,7 +10047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10010,7 +10063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10024,7 +10077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10042,7 +10095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10057,7 +10110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10074,7 +10127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10092,7 +10145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10106,7 +10159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10122,7 +10175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10137,7 +10190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -10150,7 +10203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10161,7 +10214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10186,7 +10239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10199,7 +10252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10214,7 +10267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10234,7 +10287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10248,7 +10301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10267,7 +10320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10279,7 +10332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10301,7 +10354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10321,28 +10374,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58832> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58941> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -10352,7 +10388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10368,7 +10404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10382,7 +10418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10399,7 +10435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10415,7 +10451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10430,7 +10466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10449,7 +10485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10459,6 +10495,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GPPSYN-RXN>
 ] .
+
+<http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004337> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -10479,30 +10532,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1BiochemicalReaction58739> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_15377_RXN3O-9825>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58680> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN66-314>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
@@ -10513,7 +10549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10526,7 +10562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10541,7 +10577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10555,7 +10591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10574,7 +10610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10586,17 +10622,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_94299ed7-8d0c-4116-852d-7452d90bbd2e_RXN3O-9824_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15441_LANOSTEROL-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15441> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10606,7 +10631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10622,7 +10647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10642,7 +10667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10658,7 +10683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10673,7 +10698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10689,7 +10714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10701,7 +10726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10723,7 +10748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10737,7 +10762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10751,7 +10776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10769,7 +10794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10783,7 +10808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10799,7 +10824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10827,7 +10852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10843,7 +10868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10862,7 +10887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10878,7 +10903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10892,7 +10917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10909,7 +10934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10926,7 +10951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10942,7 +10967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10953,7 +10978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10964,7 +10989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10979,7 +11004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10993,7 +11018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11010,7 +11035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11026,7 +11051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11037,7 +11062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11048,7 +11073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11062,7 +11087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11073,7 +11098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11084,7 +11109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11099,7 +11124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11112,7 +11137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11127,7 +11152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11142,7 +11167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11159,7 +11184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11175,7 +11200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11190,7 +11215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11207,7 +11232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11221,7 +11246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11237,7 +11262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11254,7 +11279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11266,7 +11291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11296,7 +11321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11313,7 +11338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11330,7 +11355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11346,7 +11371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11357,7 +11382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11368,7 +11393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11380,7 +11405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11397,7 +11422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11414,7 +11439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11434,7 +11459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11453,7 +11478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11473,7 +11498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11490,7 +11515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11509,7 +11534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11521,7 +11546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11541,7 +11566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11554,7 +11579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11569,7 +11594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11585,35 +11610,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/3b69e5eb-df9d-47dc-98e2-a046e2d9e7aa_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=ERGOSTEROL-SYN-PWY-1SmallMolecule58948> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_BFO_0000066_reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829_null_ERGOSTEROL-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11627,7 +11635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11641,7 +11649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11660,7 +11668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11671,7 +11679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11686,7 +11694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11703,7 +11711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11720,7 +11728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11736,7 +11744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11751,7 +11759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11764,7 +11772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11775,18 +11783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_fc4a29f6-14e4-4224-aa08-426864ee3559_RXN3O-9826_SGD_ERGOSTEROL-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11800,7 +11797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11819,7 +11816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11839,7 +11836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11855,7 +11852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11875,7 +11872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11889,7 +11886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11910,7 +11907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11923,7 +11920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11935,7 +11932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11951,7 +11948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11963,7 +11960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11983,7 +11980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11996,7 +11993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12008,7 +12005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12025,7 +12022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12042,7 +12039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12058,7 +12055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ERGOSTEROL-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/FASYN-ELONG2-PWY-FASYN-ELONG2-PWY.ttl
+++ b/models/FASYN-ELONG2-PWY-FASYN-ELONG2-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -580,7 +580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid elongation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -788,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -862,7 +862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1055,7 +1055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1133,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1289,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1311,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1326,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1415,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1524,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,7 +1538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1582,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1627,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1658,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1704,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1718,7 +1718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,7 +1738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1794,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1848,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1920,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1947,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1961,7 +1961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +1978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2011,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2027,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2058,7 +2058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2094,7 +2094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2110,7 +2110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2122,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2138,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2153,7 +2153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2170,7 +2170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,7 +2192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2226,7 +2226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2263,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2277,7 +2277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2293,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FASYN-ELONG2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FASYN-ELONG2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/FOLSYN-PWY-1-FOLSYN-PWY-1.ttl
+++ b/models/FOLSYN-PWY-1-FOLSYN-PWY-1.ttl
@@ -1,10 +1,10 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2e70b809-8995-4dd4-8f4c-21c19ca52718_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12,7 +12,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/2e70b809-8995-4dd4-8f4c-21c19ca52718_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,28 +121,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59833> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -152,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,13 +169,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_17071>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/2c16e102-0645-47ee-9d83-5a7268f64f95_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002333_YNL256W-MONOMER_H2PTERIDINEPYROPHOSPHOKIN-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,15 +222,12 @@
           <http://model.geneontology.org/H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,40 +267,43 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/74ff0a16-a131-41db-ac71-4b8cb800f829_RXN3O-9789>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002413_H2NEOPTERINALDOL-RXN_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,6 +343,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9789>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_3d73a83c-6c15-4eaa-b968-4c76b13c9f76_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -351,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,11 +466,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_74ff0a16-a131-41db-ac71-4b8cb800f829_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +478,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9789> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789>
+          <http://model.geneontology.org/74ff0a16-a131-41db-ac71-4b8cb800f829_RXN3O-9789>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
@@ -475,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,12 +618,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/144ece2f-f9be-4b2d-868a-f6f7534f488c_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -623,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -634,7 +662,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_74ff0a16-a131-41db-ac71-4b8cb800f829_RXN3O-9789_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,11 +732,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_3d73a83c-6c15-4eaa-b968-4c76b13c9f76_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,16 +744,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/3d73a83c-6c15-4eaa-b968-4c76b13c9f76_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_0c492fda-2497-4ba1-a78c-a9105d24524b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,41 +761,36 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/0c492fda-2497-4ba1-a78c-a9105d24524b_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/1dcad048-6ff1-4809-8049-b4695c36eb27_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_56538964-745b-4be7-9a75-3afa80b801e2_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,8 +798,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/56538964-745b-4be7-9a75-3afa80b801e2_DIHYDROFOLATEREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_29888_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -773,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -811,18 +856,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/2e70b809-8995-4dd4-8f4c-21c19ca52718_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002413_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -836,18 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -858,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -869,18 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -890,7 +930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +1003,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_1dcad048-6ff1-4809-8049-b4695c36eb27_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -974,13 +1025,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004150>
+<http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -989,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,50 +1051,16 @@
           <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004487>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/CHEBI_33384>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1052,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,59 +1094,31 @@
           <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/GO_0004487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002413_H2PTERIDINEPYROPHOSPHOKIN-RXN_null_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -1138,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1183,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,7 +1226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1255,7 +1244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1339,7 +1328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1355,11 +1344,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_1dcad048-6ff1-4809-8049-b4695c36eb27_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,8 +1356,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN>
+          <http://model.geneontology.org/1dcad048-6ff1-4809-8049-b4695c36eb27_1.5.1.15-RXN>
 ] .
+
+<http://model.geneontology.org/4fc11d2f-7533-42f3-ad84-98685330bff6_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1376,7 +1382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1392,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1415,7 +1421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,17 +1432,6 @@
           <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1446,9 +1441,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> , <http://model.geneontology.org/3d73a83c-6c15-4eaa-b968-4c76b13c9f76_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/7c606b67-e0fa-4299-828f-355843f195c8_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1456,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,12 +1459,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15378_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1483,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1498,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1514,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1559,12 +1565,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_56538964-745b-4be7-9a75-3afa80b801e2_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1575,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1598,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1652,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1669,7 +1686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,33 +1697,33 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/7c606b67-e0fa-4299-828f-355843f195c8_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60091> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15740>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1719,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1734,7 +1751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1769,7 +1786,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1781,7 +1828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,53 +1839,12 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9789>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_456215_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1849,28 +1855,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1884,9 +1873,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/4204a454-b68e-4844-a4b2-a30a23310a9b_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/0c492fda-2497-4ba1-a78c-a9105d24524b_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1894,7 +1883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1911,7 +1900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,24 +1911,13 @@
           <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_2fbce882-41ce-45e2-b442-f1f9b03613b2_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1947,8 +1925,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/2fbce882-41ce-45e2-b442-f1f9b03613b2_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/THYMIDYLATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004799> ;
@@ -1959,9 +1948,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/40088615-d04b-4498-b781-f99b30e542c4_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/4fc11d2f-7533-42f3-ad84-98685330bff6_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1969,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1985,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1996,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2011,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,7 +2013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2052,7 +2041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,7 +2054,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_7c606b67-e0fa-4299-828f-355843f195c8_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2074,12 +2074,29 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2094,7 +2111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2105,22 +2122,22 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002233_CHEBI_37565_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GTP-CYCLOHYDRO-I-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_37565_GTP-CYCLOHYDRO-I-RXN>
-] .
+<http://model.geneontology.org/2851bf1b-7423-4f27-b2cb-b297402532f4_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2128,7 +2145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2168,7 +2185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2185,7 +2202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2196,23 +2213,12 @@
           <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2227,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2240,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2252,7 +2258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2269,7 +2275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2286,7 +2292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,7 +2308,40 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_40088615-d04b-4498-b781-f99b30e542c4_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_144ece2f-f9be-4b2d-868a-f6f7534f488c_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_2c16e102-0645-47ee-9d83-5a7268f64f95_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2313,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2324,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2336,7 +2375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2383,7 +2422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2398,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2411,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2423,7 +2462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2442,7 +2481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2462,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2470,46 +2509,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_4ad6d5b3-3ecb-4874-b4f6-7f622e926356_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2521,7 +2537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2538,7 +2554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2558,9 +2574,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/2fbce882-41ce-45e2-b442-f1f9b03613b2_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/2c16e102-0645-47ee-9d83-5a7268f64f95_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2568,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2582,7 +2598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,7 +2617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2617,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2632,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2652,7 +2668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2669,7 +2685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2692,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2706,7 +2722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2722,11 +2738,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/3d73a83c-6c15-4eaa-b968-4c76b13c9f76_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2734,7 +2767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2750,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2759,13 +2792,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_63528>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4fc11d2f-7533-42f3-ad84-98685330bff6_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2781,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2793,7 +2837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2807,12 +2851,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_17001>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_6381089a-6f26-4245-8f5f-5141356be481_RXN3O-9789_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2824,7 +2868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2843,7 +2887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2859,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2877,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2890,7 +2934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2905,7 +2949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2918,7 +2962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2935,7 +2979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2947,7 +2991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2966,7 +3010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +3027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3002,7 +3046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3016,7 +3060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3033,7 +3077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3049,7 +3093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3060,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3072,7 +3116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3091,7 +3135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3107,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3115,23 +3159,6 @@
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -3141,7 +3168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3159,7 +3186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3173,7 +3200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3189,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3201,7 +3228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3222,7 +3249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3232,11 +3259,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_6381089a-6f26-4245-8f5f-5141356be481_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9789> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/6381089a-6f26-4245-8f5f-5141356be481_RXN3O-9789>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3247,29 +3291,29 @@
           <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9789> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789>
-] .
+<http://model.geneontology.org/4204a454-b68e-4844-a4b2-a30a23310a9b_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3281,7 +3325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3300,7 +3344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3316,7 +3360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3331,7 +3375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3342,17 +3386,6 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58462_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58462> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3362,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3373,23 +3406,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3398,27 +3420,44 @@
 <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000066_reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_CHEBI_57783_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/2fbce882-41ce-45e2-b442-f1f9b03613b2_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3428,7 +3467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3439,29 +3478,12 @@
           <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3476,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3484,24 +3506,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002333_YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3512,12 +3523,12 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_17839_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3530,7 +3541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3543,7 +3554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3558,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of tetrahydrofolate biosynthesis and salvage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3575,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3583,13 +3594,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002234_CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3600,24 +3622,13 @@
           <http://model.geneontology.org/CHEBI_15378_H2PTERIDINEPYROPHOSPHOKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_BFO_0000066_reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3635,7 +3646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3652,7 +3663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3665,7 +3676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3673,11 +3684,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_7c606b67-e0fa-4299-828f-355843f195c8_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3685,7 +3696,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/33f28f36-9e0c-4b84-b5fe-91d842258f33_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/7c606b67-e0fa-4299-828f-355843f195c8_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YGR204W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1>
@@ -3693,7 +3704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3713,7 +3724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3724,11 +3735,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_4ad6d5b3-3ecb-4874-b4f6-7f622e926356_DIHYDROFOLATEREDUCT-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3736,7 +3747,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/4ad6d5b3-3ecb-4874-b4f6-7f622e926356_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3745,7 +3756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3761,7 +3772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3772,7 +3783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3781,28 +3792,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17071_H2NEOPTERINALDOL-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17071> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3813,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3827,7 +3821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3846,7 +3840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3866,9 +3860,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/2851bf1b-7423-4f27-b2cb-b297402532f4_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2e70b809-8995-4dd4-8f4c-21c19ca52718_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3876,24 +3870,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction59994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57945> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3904,7 +3887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3914,11 +3897,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_144ece2f-f9be-4b2d-868a-f6f7534f488c_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +3909,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN>
+          <http://model.geneontology.org/144ece2f-f9be-4b2d-868a-f6f7534f488c_GCVMULTI-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3935,7 +3918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3954,7 +3937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3965,7 +3948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3977,7 +3960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3993,7 +3976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4001,11 +3984,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_40088615-d04b-4498-b781-f99b30e542c4_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4013,22 +3996,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7524c603-748b-4a0f-8454-f7a92453a7ad_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/40088615-d04b-4498-b781-f99b30e542c4_THYMIDYLATESYN-RXN>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4039,13 +4011,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60158> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_CHEBI_13392_RXN3O-9789_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4058,7 +4041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4069,23 +4052,6 @@
           <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/MONOMER3O-131_ADCLY-RXN_controller>
         a       <http://identifiers.org/sgd/S000004902> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4093,7 +4059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4109,7 +4075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4120,29 +4086,12 @@
           <http://model.geneontology.org/THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_RO_0002234_CHEBI_15378_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4156,7 +4105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4179,7 +4128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4187,13 +4136,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2e70b809-8995-4dd4-8f4c-21c19ca52718_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4213,7 +4173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4224,24 +4184,13 @@
 <http://identifiers.org/sgd/S000005600>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002233_CHEBI_17001_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4252,17 +4201,6 @@
           <http://model.geneontology.org/CHEBI_17001_H2NEOPTERINALDOL-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4272,7 +4210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4285,7 +4223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4299,7 +4237,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_2851bf1b-7423-4f27-b2cb-b297402532f4_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4314,7 +4263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4328,7 +4277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4345,7 +4294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4363,7 +4312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4374,14 +4323,22 @@
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4391,7 +4348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4402,22 +4359,14 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/H2PTEROATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
-] .
+<http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004146>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4434,9 +4383,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/3ad6bfc7-4006-4d0e-a10e-210c8d4a37e9_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/1dcad048-6ff1-4809-8049-b4695c36eb27_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4444,7 +4393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4463,7 +4412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4480,7 +4429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4496,7 +4445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4507,28 +4456,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ed436b8d-1b1f-4b4f-9809-370f93036c92_GLYOHMETRANS-RXN>
-] .
+<http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/reaction_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -4542,7 +4477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4550,8 +4485,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_2851bf1b-7423-4f27-b2cb-b297402532f4_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2851bf1b-7423-4f27-b2cb-b297402532f4_GLYOHMETRANS-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4559,7 +4508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4589,7 +4538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4597,36 +4546,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
+<http://purl.obolibrary.org/obo/CHEBI_13390>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_13390>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -4637,7 +4569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4650,18 +4582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002233_CHEBI_44841_H2PTERIDINEPYROPHOSPHOKIN-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4669,11 +4590,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_2c16e102-0645-47ee-9d83-5a7268f64f95_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4681,7 +4619,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/68d7dedf-f9bd-4faa-8133-84925478e2fa_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/2c16e102-0645-47ee-9d83-5a7268f64f95_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
@@ -4689,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4707,7 +4645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4721,7 +4659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4737,7 +4675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4748,7 +4686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4761,7 +4699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4774,7 +4712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4785,7 +4723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4800,7 +4738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4820,7 +4758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4834,38 +4772,13 @@
 <http://identifiers.org/sgd/S000001788>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/RXN3O-9789>
-        a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate + NAD(P)H + H<SUP>+</SUP> &rarr; a 5-methyltetrahydrofolate + NAD(P)<sup>+</sup>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> , <http://model.geneontology.org/7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> , <http://model.geneontology.org/4dbbb17a-7732-4f93-8c6f-e5c1c3645de3_RXN3O-9789> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction59760> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4876,13 +4789,55 @@
           <http://model.geneontology.org/CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN>
 ] .
 
+<http://model.geneontology.org/RXN3O-9789>
+        a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate + NAD(P)H + H<SUP>+</SUP> &rarr; a 5-methyltetrahydrofolate + NAD(P)<sup>+</sup>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/74ff0a16-a131-41db-ac71-4b8cb800f829_RXN3O-9789> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9789> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/6381089a-6f26-4245-8f5f-5141356be481_RXN3O-9789> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9789> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller> , <http://model.geneontology.org/YPL023C-MONOMER_RXN3O-9789_controller> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1BiochemicalReaction59760> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/40088615-d04b-4498-b781-f99b30e542c4_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4898,7 +4853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4910,7 +4865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4927,7 +4882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4938,33 +4893,33 @@
           <http://model.geneontology.org/RXN3O-9789>
 ] .
 
+<http://model.geneontology.org/56538964-745b-4be7-9a75-3afa80b801e2_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/cc9d4bba-5aa9-4398-ad89-e8ed1472c007_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57305> ;
@@ -4975,7 +4930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4988,7 +4943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4999,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5011,7 +4966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5028,7 +4983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5047,18 +5002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5067,13 +5011,24 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5083,6 +5038,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_eb75628b-32f2-4c0d-90c9-98fb90295dde_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5102,7 +5068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5119,7 +5085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5133,7 +5099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5152,7 +5118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5174,7 +5140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5194,7 +5160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5208,7 +5174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5227,7 +5193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5242,7 +5208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5255,7 +5221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5266,7 +5232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5278,7 +5244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5294,7 +5260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5305,7 +5271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5316,7 +5282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5328,7 +5294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5345,7 +5311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5361,7 +5327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5374,7 +5340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5388,7 +5354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5404,7 +5370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5418,7 +5384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5427,28 +5393,6 @@
 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YGL125W-MONOMER_RXN3O-9789_controller>
         a       <http://identifiers.org/sgd/S000003093> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5456,7 +5400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5470,7 +5414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5481,13 +5425,35 @@
           <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADCLY-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4fc11d2f-7533-42f3-ad84-98685330bff6_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5495,7 +5461,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/4fc11d2f-7533-42f3-ad84-98685330bff6_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_17839_H2PTEROATESYNTH-RXN>
@@ -5507,7 +5473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5524,7 +5490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5537,11 +5503,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_4204a454-b68e-4844-a4b2-a30a23310a9b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5549,7 +5515,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c05ca1f1-efaf-4018-9518-6e0dff5c77d3_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/4204a454-b68e-4844-a4b2-a30a23310a9b_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -5559,7 +5525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5576,7 +5542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5603,7 +5569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5616,7 +5582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5627,7 +5593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5641,7 +5607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5658,7 +5624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5669,13 +5635,24 @@
           <http://model.geneontology.org/FOLSYN-PWY-1/FOLSYN-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_4204a454-b68e-4844-a4b2-a30a23310a9b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_17071_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5695,7 +5672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5708,7 +5685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5720,7 +5697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5737,7 +5714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5753,11 +5730,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/eb75628b-32f2-4c0d-90c9-98fb90295dde_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59937> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5765,7 +5759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5776,24 +5770,13 @@
           <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_61fecabc-a954-4a0f-81e0-d60a416714e2_FORMATETHFLIG-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_73083_H2PTEROATESYNTH-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5804,12 +5787,34 @@
           <http://model.geneontology.org/CHEBI_73083_H2PTEROATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_3ad6bfc7-4006-4d0e-a10e-210c8d4a37e9_1.5.1.15-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_2fbce882-41ce-45e2-b442-f1f9b03613b2_METHENYLTHFCYCLOHYDRO-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5824,7 +5829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5841,7 +5846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5854,7 +5859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5866,7 +5871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5877,12 +5882,29 @@
           <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
 ] .
 
+<http://model.geneontology.org/4ad6d5b3-3ecb-4874-b4f6-7f622e926356_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule60073> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5897,7 +5919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5913,7 +5935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5928,7 +5950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5945,7 +5967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5962,7 +5984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5976,7 +5998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5996,7 +6018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6016,9 +6038,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/eb75628b-32f2-4c0d-90c9-98fb90295dde_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/72e5545f-d0aa-41ed-87b0-c74fb54008f8_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/144ece2f-f9be-4b2d-868a-f6f7534f488c_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6026,7 +6048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6040,7 +6062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6051,7 +6073,22 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/52d671f2-a3ea-42c8-89c5-beebd4a80b4e_1.5.1.15-RXN>
+<http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "mitochondrial C1-tetrahydrofolate synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein59867> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/0c492fda-2497-4ba1-a78c-a9105d24524b_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -6060,28 +6097,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "mitochondrial C1-tetrahydrofolate synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1Protein59867> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003499> ;
@@ -6090,7 +6112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6098,13 +6120,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/6381089a-6f26-4245-8f5f-5141356be481_RXN3O-9789>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59802> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002234_CHEBI_17001_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6120,11 +6159,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_3ad6bfc7-4006-4d0e-a10e-210c8d4a37e9_1.5.1.15-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6132,7 +6171,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/885dca10-6726-4f2c-a8bf-21ced16bc520_1.5.1.15-RXN>
+          <http://model.geneontology.org/3ad6bfc7-4006-4d0e-a10e-210c8d4a37e9_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58406_ADCLY-RXN>
@@ -6144,7 +6183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6163,7 +6202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6175,7 +6214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6195,9 +6234,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d2708873-c7fe-4adc-8ba6-7386ca421ca1_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/56538964-745b-4be7-9a75-3afa80b801e2_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/71afa31c-e188-4816-9123-0dc1b40e3531_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/4ad6d5b3-3ecb-4874-b4f6-7f622e926356_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -6205,7 +6244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6213,30 +6252,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ef017b3c-b497-4816-aa4e-a05228e4ff67_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59839> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002411_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6256,7 +6278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6273,7 +6295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6290,7 +6312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6307,7 +6329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6318,17 +6340,6 @@
           <http://model.geneontology.org/YGR267C-MONOMER_GTP-CYCLOHYDRO-I-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1140d922-561c-4d2f-bad2-1c8ee4897704_GLYOHMETRANS-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_PABASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
@@ -6337,7 +6348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6352,7 +6363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6368,7 +6379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6379,7 +6390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6391,7 +6402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6408,7 +6419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6436,7 +6447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6447,23 +6458,12 @@
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002333_YNL256W-MONOMER_H2NEOPTERINALDOL-RXN_controller_SGD_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6472,13 +6472,24 @@
 <http://model.geneontology.org/reaction_RXN3O-9789_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_RO_0002234_CHEBI_15740_GTP-CYCLOHYDRO-I-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6495,7 +6506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6511,7 +6522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -6526,7 +6537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6540,7 +6551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6558,7 +6569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6573,7 +6584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6590,7 +6601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6607,7 +6618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6620,7 +6631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6635,7 +6646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6648,7 +6659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6660,7 +6671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6676,7 +6687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6687,7 +6698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6707,7 +6718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6722,7 +6733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6739,7 +6750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6758,7 +6769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6775,7 +6786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6786,6 +6797,17 @@
           <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_0c492fda-2497-4ba1-a78c-a9105d24524b_METHYLENETHFDEHYDROG-NADP-RXN_SGD_FOLSYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -6795,7 +6817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6812,7 +6834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6823,23 +6845,12 @@
           <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_f3516c7d-7918-4f3d-a023-309e39ed1eed_THYMIDYLATESYN-RXN_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6864,7 +6875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6881,7 +6892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6895,7 +6906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6914,7 +6925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6925,24 +6936,13 @@
           <http://model.geneontology.org/reaction_H2PTERIDINEPYROPHOSPHOKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002233_7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789_SGD_FOLSYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_RO_0002234_CHEBI_44841_H2NEOPTERINALDOL-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6962,7 +6962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6975,7 +6975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6986,7 +6986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7001,7 +7001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7018,7 +7018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7031,11 +7031,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_eb75628b-32f2-4c0d-90c9-98fb90295dde_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7043,7 +7043,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2097aeb8-9588-4715-b9ff-18b59afe2fc3_GCVMULTI-RXN>
+          <http://model.geneontology.org/eb75628b-32f2-4c0d-90c9-98fb90295dde_GCVMULTI-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -7052,7 +7052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7068,7 +7068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7079,11 +7079,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/3ad6bfc7-4006-4d0e-a10e-210c8d4a37e9_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -7091,7 +7108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7108,7 +7125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7125,7 +7142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7145,7 +7162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7153,11 +7170,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/BFO_0000066>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 <http://purl.obolibrary.org/obo/GO_0004329>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/BFO_0000066>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/YNL256W-MONOMER_H2PTEROATESYNTH-RXN_controller>
         a       <http://identifiers.org/sgd/S000005200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7166,7 +7183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7174,24 +7191,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_FOLSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7211,7 +7217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7219,22 +7225,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/7f331048-da3d-4df5-8b15-3e0a1005bbcc_RXN3O-9789>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=FOLSYN-PWY-1SmallMolecule59767> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -7245,7 +7245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7253,14 +7253,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9789_RO_0002234_CHEBI_13390_RXN3O-9789_SGD_FOLSYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000066_reaction_GLYOHMETRANS-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
+                "null:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -7270,7 +7270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7286,7 +7286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7301,7 +7301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7314,7 +7314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7327,7 +7327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7340,7 +7340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7352,7 +7352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7369,7 +7369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7385,7 +7385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7403,7 +7403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7414,25 +7414,25 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:FOLSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_BFO_0000066_reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829_null_FOLSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:FOLSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GTP-CYCLOHYDRO-I-RXN_BFO_0000050_FOLSYN-PWY-1/FOLSYN-PWY-1_SGD_FOLSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -7445,7 +7445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7458,7 +7458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7469,7 +7469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7480,7 +7480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=FOLSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:FOLSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLNSYN-PWY-GLNSYN-PWY.ttl
+++ b/models/GLNSYN-PWY-GLNSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,7 +228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -478,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/GLUCFERMEN-PWY-GLUCFERMEN-PWY.ttl
+++ b/models/GLUCFERMEN-PWY-GLUCFERMEN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,16 +373,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_4170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,12 +390,15 @@
           <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002233_CHEBI_17478_ALDHDEHYDROG-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,6 +836,17 @@
 <http://identifiers.org/sgd/S000000036>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_4167_GLUCOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_4167> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -845,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,23 +864,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ALDHDEHYDROG-RXN_RO_0002333_YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -934,7 +934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,7 +1008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1055,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,7 +1134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1162,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1294,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1306,7 +1306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1343,7 +1343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,17 +1354,6 @@
           <http://model.geneontology.org/CHEBI_58272_3PGAREARR-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YPL061W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
         a       <http://identifiers.org/sgd/S000005982> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1372,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1380,12 +1369,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_BFO_0000066_reaction_PHOSGLYPHOS-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1398,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1504,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1516,7 +1516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,15 +1584,6 @@
 <http://model.geneontology.org/reaction_RXN-15513_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
-        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_32966_6PFRUCTPHOS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32966> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1602,13 +1593,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule37281> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
+        a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1658,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1674,7 +1674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1700,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1717,7 +1717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1733,7 +1733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1750,7 +1750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1791,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1820,7 +1820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1837,7 +1837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1856,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1911,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2001,7 +2001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2032,7 +2032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2052,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2079,18 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2100,7 +2089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,13 +2100,24 @@
           <http://model.geneontology.org/CHEBI_29067_ALDHDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUCOKIN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2134,7 +2134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2161,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2199,7 +2199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2211,7 +2211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2242,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2258,7 +2258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2269,7 +2269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2280,7 +2280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2291,7 +2291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2303,7 +2303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2342,7 +2342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2361,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2372,7 +2372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2381,30 +2381,13 @@
 <http://identifiers.org/sgd/S000003222>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36910> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-274_RO_0002233_CHEBI_15343_RXN3O-274_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,13 +2398,30 @@
           <http://model.geneontology.org/CHEBI_15343_RXN3O-274>
 ] .
 
+<http://model.geneontology.org/CHEBI_15378_PEPDEPHOS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36910> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002411_3PGAREARR-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2437,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2455,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2472,7 +2472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2489,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2519,7 +2519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2531,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2551,7 +2551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,7 +2568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2588,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2604,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2619,7 +2619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2635,7 +2635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2647,7 +2647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2663,7 +2663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2674,7 +2674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2688,7 +2688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2706,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2725,7 +2725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2758,7 +2758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2772,7 +2772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2787,7 +2787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2804,7 +2804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2854,7 +2854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2871,7 +2871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2898,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2910,7 +2910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2927,7 +2927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2947,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2964,7 +2964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2981,7 +2981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2998,7 +2998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3028,7 +3028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3042,7 +3042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3061,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3079,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3092,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3123,7 +3123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3137,7 +3137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3156,7 +3156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3175,7 +3175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3203,7 +3203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3217,7 +3217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3237,7 +3237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glucose fermentation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3253,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3269,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3286,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3299,7 +3299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3311,7 +3311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3328,7 +3328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3344,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3359,7 +3359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3386,7 +3386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3404,7 +3404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3418,7 +3418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3436,7 +3436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3453,7 +3453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3470,7 +3470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3490,7 +3490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3505,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3518,7 +3518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3529,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3556,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3570,7 +3570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3587,7 +3587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3607,7 +3607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3618,19 +3618,19 @@
           <http://model.geneontology.org/CHEBI_456216_GLUCOKIN-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000004688>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000004688>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YHR174W-MONOMER_2PGADEHYDRAT-RXN_controller>
         a       <http://identifiers.org/sgd/S000001217> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3639,7 +3639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3653,7 +3653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3669,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3682,69 +3682,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37265> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15343_RXN-6161>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36882> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_30616_6PFRUCTPHOS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3755,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3763,13 +3707,69 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CHEBI_15343_RXN-6161>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36882> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_F16BDEPHOS-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_RO_0002234_CHEBI_59776_F16ALDOLASE-RXN_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_59776_F16ALDOLASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_PHOSGLYPHOS-RXN_RO_0002333_YCR012W-MONOMER_PHOSGLYPHOS-RXN_controller_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002234_CHEBI_57783_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3805,7 +3805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3835,7 +3835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3847,7 +3847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3885,7 +3885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3898,7 +3898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3913,7 +3913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3933,7 +3933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3946,7 +3946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3959,7 +3959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3976,7 +3976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3989,7 +3989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4008,7 +4008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4021,7 +4021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4036,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4050,7 +4050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4066,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4077,7 +4077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4092,7 +4092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4106,7 +4106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4122,7 +4122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4133,7 +4133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4147,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4158,7 +4158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4173,7 +4173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4190,7 +4190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4206,7 +4206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4218,7 +4218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4237,7 +4237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4253,7 +4253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4264,7 +4264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4275,7 +4275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4296,7 +4296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4310,7 +4310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4326,9 +4326,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_null_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4338,7 +4349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4349,17 +4360,6 @@
           <http://model.geneontology.org/CHEBI_57540_ALCOHOL-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_6PFRUCTPHOS-RXN_RO_0002413_F16BDEPHOS-RXN_null_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16236>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4368,7 +4368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4379,7 +4379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4393,7 +4393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4409,7 +4409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4424,7 +4424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4438,7 +4438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4457,7 +4457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4471,7 +4471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4482,7 +4482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4497,7 +4497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4511,7 +4511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4528,7 +4528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4545,7 +4545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4567,7 +4567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4593,7 +4593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4607,7 +4607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4630,7 +4630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4645,7 +4645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4662,7 +4662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4676,7 +4676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4696,7 +4696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4716,7 +4716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4733,7 +4733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4746,7 +4746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4757,7 +4757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4780,7 +4780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4794,7 +4794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4811,7 +4811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4834,7 +4834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4851,7 +4851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4873,7 +4873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4888,7 +4888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4904,7 +4904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4916,7 +4916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4932,7 +4932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4957,7 +4957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4973,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4988,7 +4988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5007,7 +5007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5026,7 +5026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5037,16 +5037,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5057,7 +5057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5070,7 +5070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5078,30 +5078,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_RO_0002233_CHEBI_17478_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_3PGAREARR-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5109,7 +5106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5120,12 +5117,15 @@
           <http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/reaction_PEPDEPHOS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002234_CHEBI_57945_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5136,7 +5136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5148,7 +5148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5165,7 +5165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5182,7 +5182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5202,7 +5202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5215,7 +5215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5230,7 +5230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5238,13 +5238,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
+        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "pyruvate decarboxylase / decarboxylase" ;
+        <http://purl.obolibrary.org/obo/BFO_0000051>
+                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYComplex37066> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Complex" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PEPDEPHOS-RXN_RO_0002333_YOR347C-MONOMER_PEPDEPHOS-RXN_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5260,35 +5277,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
-        a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "pyruvate decarboxylase / decarboxylase" ;
-        <http://purl.obolibrary.org/obo/BFO_0000051>
-                <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYComplex37066> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Complex" .
 
 <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_RO_0002233_CHEBI_59776_GAPOXNPHOSPHN-RXN_SGD_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5300,7 +5300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5328,7 +5328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5336,43 +5336,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_GLUCFERMEN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCFERMEN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2PGADEHYDRAT-RXN_RO_0002234_CHEBI_15377_2PGADEHYDRAT-RXN_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5383,12 +5353,42 @@
           <http://model.geneontology.org/CHEBI_15377_2PGADEHYDRAT-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GAPOXNPHOSPHN-RXN_BFO_0000066_reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829_null_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GAPOXNPHOSPHN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_GAPOXNPHOSPHN-RXN_location_lociGO_0005829>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_GLUCFERMEN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCFERMEN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002413_RXN3O-274_null_GLUCFERMEN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5399,7 +5399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5417,7 +5417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5430,11 +5430,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
+        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aldehyde dehydrogenase (minor mitochondrial)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5442,7 +5457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5472,28 +5487,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYBiochemicalReaction37229> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/YER073W-MONOMER_ALDEHYDE-DEHYDROGENASE-NADP+-RXN_controller>
-        a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aldehyde dehydrogenase (minor mitochondrial)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5503,7 +5503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5520,7 +5520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5540,7 +5540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5553,7 +5553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5567,7 +5567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5586,7 +5586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5606,7 +5606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5623,7 +5623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5639,7 +5639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5651,7 +5651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5671,7 +5671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5684,7 +5684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5696,7 +5696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5716,7 +5716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5736,7 +5736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5753,7 +5753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5771,7 +5771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5784,7 +5784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5799,7 +5799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5815,7 +5815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5831,7 +5831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5848,7 +5848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5862,7 +5862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5881,7 +5881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5893,7 +5893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5909,7 +5909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5923,7 +5923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5935,7 +5935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5954,7 +5954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5974,7 +5974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5991,6 +5991,21 @@
 <http://purl.obolibrary.org/obo/GO_0004618>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005901> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "aldehyde dehydrogenase (major mitochondrial)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37117> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'D-glucopyranose 6-phosphate &harr; &beta;-D-fructofuranose 6-phosphate' 'null' 'ATP + &beta;-D-fructofuranose 6-phosphate &rarr; &beta;-D-fructose 1,6-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -5999,7 +6014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6010,28 +6025,13 @@
           <http://model.geneontology.org/6PFRUCTPHOS-RXN>
 ] .
 
-<http://model.geneontology.org/YOR374W-MONOMER_ALDHDEHYDROG-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005901> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "aldehyde dehydrogenase (major mitochondrial)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37117> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-58_RXN-6161_controller_SGD_GLUCFERMEN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6047,7 +6047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6058,7 +6058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6079,7 +6079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6092,7 +6092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6104,7 +6104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6120,7 +6120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6132,7 +6132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6149,7 +6149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6165,7 +6165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6180,7 +6180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6197,7 +6197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6213,7 +6213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6224,7 +6224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6235,7 +6235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6250,7 +6250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6267,7 +6267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6284,7 +6284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6298,7 +6298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6317,7 +6317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6328,7 +6328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6343,7 +6343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6356,7 +6356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6373,7 +6373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6393,7 +6393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6410,7 +6410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6423,7 +6423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6437,7 +6437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6448,7 +6448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6459,7 +6459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6476,7 +6476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6493,7 +6493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6513,7 +6513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6530,7 +6530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6547,7 +6547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6566,7 +6566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6581,7 +6581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6597,7 +6597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6610,7 +6610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6624,7 +6624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6641,7 +6641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6657,7 +6657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6671,7 +6671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6686,7 +6686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6706,7 +6706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6723,7 +6723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6741,11 +6741,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37123> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
+] .
+
+<http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000545> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glucokinase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37008> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -6758,45 +6790,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYSmallMolecule36866> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/YCL040W-MONOMER_GLUCOKIN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000545> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glucokinase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCFERMEN-PWYProtein37008> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_F16ALDOLASE-RXN_BFO_0000050_GLUCFERMEN-PWY/GLUCFERMEN-PWY_SGD_GLUCFERMEN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/F16ALDOLASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCFERMEN-PWY/GLUCFERMEN-PWY>
-] .
 
 <http://model.geneontology.org/YER073W-MONOMER_RXN3O-274_controller>
         a       <http://identifiers.org/sgd/S000000875> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6805,7 +6805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6821,7 +6821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6838,7 +6838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6861,7 +6861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6877,7 +6877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6889,7 +6889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6909,7 +6909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6928,7 +6928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6939,7 +6939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6950,7 +6950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6961,7 +6961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6975,7 +6975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6992,7 +6992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7008,7 +7008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7022,7 +7022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7045,7 +7045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7059,7 +7059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7075,7 +7075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCFERMEN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -7100,7 +7100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7115,7 +7115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCFERMEN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLUCONEO-PWY-1-GLUCONEO-PWY-1.ttl
+++ b/models/GLUCONEO-PWY-1-GLUCONEO-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -993,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1183,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1197,7 +1197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1265,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,7 +1279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1315,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1326,7 +1326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1339,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1370,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1384,7 +1384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1426,7 +1426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1534,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1548,7 +1548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1575,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1668,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,7 +1682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,7 +1699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1754,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1765,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1827,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1859,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1873,7 +1873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1889,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1903,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1921,7 +1921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1940,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1963,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1977,7 +1977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,7 +1994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2045,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2057,7 +2057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2074,7 +2074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2091,7 +2091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2107,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2130,7 +2130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2212,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2232,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2245,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2283,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2313,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2325,7 +2325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2370,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2383,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2394,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2407,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2438,7 +2438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2458,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2473,7 +2473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2486,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2498,7 +2498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2518,7 +2518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2531,7 +2531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2543,7 +2543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2560,7 +2560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2578,7 +2578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2592,7 +2592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2618,7 +2618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2631,7 +2631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2642,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2657,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2677,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2693,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2716,7 +2716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2732,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2744,7 +2744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2781,7 +2781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2795,7 +2795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2817,7 +2817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2833,7 +2833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2844,7 +2844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2856,7 +2856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2876,7 +2876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2890,7 +2890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,7 +2907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2924,7 +2924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2944,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2973,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2990,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3004,7 +3004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3021,7 +3021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3037,7 +3037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3055,7 +3055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3071,7 +3071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3083,7 +3083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3102,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3117,7 +3117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3134,7 +3134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3150,7 +3150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3169,7 +3169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3186,7 +3186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3202,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3216,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3229,7 +3229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3242,7 +3242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3254,7 +3254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3276,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3291,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "gluconeogenesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3310,7 +3310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3329,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3340,7 +3340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3351,7 +3351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3363,7 +3363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,7 +3380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3400,7 +3400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3416,7 +3416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3433,7 +3433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3452,7 +3452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3464,7 +3464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3481,7 +3481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3514,7 +3514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3527,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3538,7 +3538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3552,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3564,7 +3564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3584,7 +3584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3598,7 +3598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3614,7 +3614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3629,7 +3629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3645,7 +3645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3657,7 +3657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3673,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3684,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3698,7 +3698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3719,7 +3719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3732,7 +3732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3759,7 +3759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3774,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3791,7 +3791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3816,7 +3816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3836,7 +3836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,7 +3862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3878,7 +3878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3893,7 +3893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3909,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3921,7 +3921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3937,7 +3937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3949,7 +3949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3969,7 +3969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3986,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4002,7 +4002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4018,7 +4018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4032,7 +4032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4044,7 +4044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4060,7 +4060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4075,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4098,7 +4098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4114,7 +4114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4129,7 +4129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4145,7 +4145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4160,7 +4160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4180,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4197,7 +4197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4217,7 +4217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4237,7 +4237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4251,7 +4251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4267,7 +4267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4278,7 +4278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4293,7 +4293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4307,7 +4307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4324,7 +4324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4340,7 +4340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4352,7 +4352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4372,7 +4372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4386,7 +4386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4406,7 +4406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4422,7 +4422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4432,7 +4432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4462,7 +4462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4475,7 +4475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCONEO-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCONEO-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLUCOSE-MANNOSYL-CHITO-DOLICHOL-GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
+++ b/models/GLUCOSE-MANNOSYL-CHITO-DOLICHOL-GLUCOSE-MANNOSYL-CHITO-DOLICHOL.ttl
@@ -1,10 +1,10 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_5ba1d282-76dc-44fb-84f6-04faf6612051_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12,23 +12,23 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413>
+          <http://model.geneontology.org/5ba1d282-76dc-44fb-84f6-04faf6612051_RXN3O-413>
 ] .
 
-<http://model.geneontology.org/eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/001ac64d-5b61-47fd-b4e1-b804e72d0034_RXN3O-9818>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(5)GlcNAc(2)-PP-Dol" ;
+                "Man(1)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -110,22 +110,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/c55f7335-1c23-44a9-9797-801c33ab9b95_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(1)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -135,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,12 +169,23 @@
           <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_a0838253-7f34-4cd1-9f2c-3ade190e4d40_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002413_2.4.1.131-RXN_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -176,11 +193,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_880968ce-be97-43d5-82b7-20b044941315_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_c8cf61ed-b2a8-484f-9d7e-2805eddcd486_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,19 +205,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/880968ce-be97-43d5-82b7-20b044941315_RXN3O-411>
+          <http://model.geneontology.org/c8cf61ed-b2a8-484f-9d7e-2805eddcd486_RXN3O-411>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -214,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,11 +230,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_e1c54665-51e2-4865-b4e7-9749e8af3dae_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,15 +242,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291>
+          <http://model.geneontology.org/e1c54665-51e2-4865-b4e7-9749e8af3dae_RXN3O-291>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_db0d96da-af4b-414e-9990-5ed09ca4cdd7_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_CHEBI_57525_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -277,11 +294,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_66356465-c5d5-445f-a334-ae948fdaafff_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +306,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN>
+          <http://model.geneontology.org/66356465-c5d5-445f-a334-ae948fdaafff_2.4.1.132-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -298,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,25 +410,25 @@
           <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3>
+<http://model.geneontology.org/cd80ac96-502f-4c79-a410-cb7780f8a15e_RXN3O-291>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(7)GlcNAc(2)-PP-Dol" ;
+                "Man(5)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28207> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/GO_0052925>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -425,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -449,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -461,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,27 +506,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_1d3c73bd-ac6c-4a4e-9e50-27070aa2cd77_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +523,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379>
+          <http://model.geneontology.org/1d3c73bd-ac6c-4a4e-9e50-27070aa2cd77_RXN3O-379>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -528,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,12 +562,23 @@
           <http://model.geneontology.org/CHEBI_57705_2.4.1.141-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_099f6aae-0c02-4f65-99b9-fb6b3b37c9d7_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_18278_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -587,35 +604,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004993> ;
@@ -624,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,16 +627,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/d40c43e6-91fe-4713-961b-38c62b7a3ba2_RXN3O-411>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/2.4.1.131-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -652,9 +653,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.131-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> ;
+                <http://model.geneontology.org/c54d2b49-18f2-49aa-9323-0bee7261c69c_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_57527_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> , <http://model.geneontology.org/eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN> ;
+                <http://model.geneontology.org/788e9862-6f72-4a0e-94e9-ee0238c39c4c_2.4.1.131-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.131-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_2.4.1.131-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -662,30 +663,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLBiochemicalReaction28203> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(6)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBR243C-MONOMER_2.7.8.15-RXN_controller>
         a       <http://identifiers.org/sgd/S000000447> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -694,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -772,9 +756,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-3_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3> , <http://model.geneontology.org/0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3> ;
+                <http://model.geneontology.org/dfba2c65-db75-4e74-bd3b-8c553ce868de_RXN3O-3> , <http://model.geneontology.org/38d1419f-a39c-45e7-a58d-d1ae90ac9f85_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3> , <http://model.geneontology.org/CHEBI_16214_RXN3O-3> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-3> , <http://model.geneontology.org/e7085130-5d8c-4dad-91d9-de7f0020a7fc_RXN3O-3> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-3_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -782,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,35 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(2)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -833,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -889,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,18 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -927,18 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -949,9 +883,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_c1304c5f-83fb-4e9a-ac0a-9d76839be0a8_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -960,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -975,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,29 +928,51 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412>
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_c8cf61ed-b2a8-484f-9d7e-2805eddcd486_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/bf561303-505e-40f9-a4be-91c1469b6677_RXN3O-11>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
+                "Man(8)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_c6b4a98f-60e4-4b7a-af72-a564d7959857_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-3_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,7 +1004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,11 +1020,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_e050a675-88a4-4e66-97be-1383aa5ce914_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1032,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259>
+          <http://model.geneontology.org/e050a675-88a4-4e66-97be-1383aa5ce914_RXN3O-259>
 ] .
 
 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829>
@@ -1078,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,12 +1053,40 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/38d1419f-a39c-45e7-a58d-d1ae90ac9f85_RXN3O-3>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(6)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_e050a675-88a4-4e66-97be-1383aa5ce914_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_CHEBI_57527_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,11 +1111,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_c54d2b49-18f2-49aa-9323-0bee7261c69c_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,68 +1123,23 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN>
+          <http://model.geneontology.org/c54d2b49-18f2-49aa-9323-0bee7261c69c_2.4.1.131-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(8)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_ff130f09-00d6-428b-a94e-9ac25f8c922a_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1199,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,33 +1160,27 @@
           <http://model.geneontology.org/CHEBI_16214_RXN3O-411>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-291_BFO_0000066_reaction_RXN3O-291_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002333_YGR227W-MONOMER_RXN3O-413_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(4)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57525_RXN3O-413>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57525> ;
@@ -1247,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,7 +1208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,9 +1231,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-11_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11> , <http://model.geneontology.org/b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11> ;
+                <http://model.geneontology.org/d933b028-30a6-459b-9fb6-1842255364b1_RXN3O-11> , <http://model.geneontology.org/a0838253-7f34-4cd1-9f2c-3ade190e4d40_RXN3O-11> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11> , <http://model.geneontology.org/CHEBI_16214_RXN3O-11> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-11> , <http://model.geneontology.org/bf561303-505e-40f9-a4be-91c1469b6677_RXN3O-11> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-256_RXN3O-11_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1297,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1334,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,7 +1310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,16 +1341,22 @@
 <http://purl.obolibrary.org/obo/GO_0004578>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/db0d96da-af4b-414e-9990-5ed09ca4cdd7_RXN3O-412>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1414,7 +1364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,23 +1378,6 @@
 <http://identifiers.org/sgd/S000000447>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_16214_RXN3O-3>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16214> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1454,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,11 +1400,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_001ac64d-5b61-47fd-b4e1-b804e72d0034_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1479,7 +1412,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9818> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818>
+          <http://model.geneontology.org/001ac64d-5b61-47fd-b4e1-b804e72d0034_RXN3O-9818>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -1497,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1530,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1545,9 +1478,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-378_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
+                <http://model.geneontology.org/c1304c5f-83fb-4e9a-ac0a-9d76839be0a8_RXN3O-378> , <http://model.geneontology.org/CHEBI_57527_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_RXN3O-378> , <http://model.geneontology.org/78777294-3fba-498c-8060-147650e8f41e_RXN3O-378> ;
+                <http://model.geneontology.org/CHEBI_58189_RXN3O-378> , <http://model.geneontology.org/cb8b291c-3175-4324-b4b1-29af18d0c0b2_RXN3O-378> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_RXN3O-378_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1555,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,7 +1502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,19 +1566,36 @@
           <http://model.geneontology.org/2.4.1.131-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57705>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/5ba1d282-76dc-44fb-84f6-04faf6612051_RXN3O-413>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002233_880968ce-be97-43d5-82b7-20b044941315_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_5ba1d282-76dc-44fb-84f6-04faf6612051_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_57705>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1655,14 +1605,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/c8cf61ed-b2a8-484f-9d7e-2805eddcd486_RXN3O-411>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1670,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1686,7 +1636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1717,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1734,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1751,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,19 +1717,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/099f6aae-0c02-4f65-99b9-fb6b3b37c9d7_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(8)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_ff130f09-00d6-428b-a94e-9ac25f8c922a_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,16 +1754,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412>
+          <http://model.geneontology.org/ff130f09-00d6-428b-a94e-9ac25f8c922a_RXN3O-412>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_bf561303-505e-40f9-a4be-91c1469b6677_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,29 +1771,18 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11>
+          <http://model.geneontology.org/bf561303-505e-40f9-a4be-91c1469b6677_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/reaction_RXN3O-9818_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1834,11 +1790,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_e7085130-5d8c-4dad-91d9-de7f0020a7fc_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1846,8 +1802,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3>
+          <http://model.geneontology.org/e7085130-5d8c-4dad-91d9-de7f0020a7fc_RXN3O-3>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_e888378c-5134-4e75-a883-122b43ee9326_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_12427_2.4.1.141-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_12427> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1858,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1866,29 +1833,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(3)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_001ac64d-5b61-47fd-b4e1-b804e72d0034_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002233_3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1899,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -1938,11 +1888,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/a0838253-7f34-4cd1-9f2c-3ade190e4d40_RXN3O-11>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(7)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1952,7 +1919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,11 +1932,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_099f6aae-0c02-4f65-99b9-fb6b3b37c9d7_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,7 +1944,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259>
+          <http://model.geneontology.org/099f6aae-0c02-4f65-99b9-fb6b3b37c9d7_RXN3O-259>
 ] .
 
 <http://model.geneontology.org/RXN3O-9818>
@@ -1991,7 +1958,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57527_RXN3O-9818> , <http://model.geneontology.org/CHEBI_12427_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> , <http://model.geneontology.org/4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818> ;
+                <http://model.geneontology.org/001ac64d-5b61-47fd-b4e1-b804e72d0034_RXN3O-9818> , <http://model.geneontology.org/CHEBI_58189_RXN3O-9818> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR110W-MONOMER_RXN3O-9818_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1999,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2012,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2029,7 +1996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +2013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2080,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2088,13 +2055,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_f3cf6531-3cbf-4a50-9ff7-06b4ca5b6df2_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_d40c43e6-91fe-4713-961b-38c62b7a3ba2_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,36 +2080,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-411> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411>
+          <http://model.geneontology.org/d40c43e6-91fe-4713-961b-38c62b7a3ba2_RXN3O-411>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2141,7 +2091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2158,7 +2108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,18 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_78777294-3fba-498c-8060-147650e8f41e_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2199,28 +2138,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/880968ce-be97-43d5-82b7-20b044941315_RXN3O-411>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2233,7 +2155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2250,7 +2172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2268,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2283,7 +2205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,7 +2221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2310,7 +2232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2324,7 +2246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2337,11 +2259,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_c1304c5f-83fb-4e9a-ac0a-9d76839be0a8_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2349,7 +2271,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4d97b262-f140-464f-bfe6-8017ee638cd4_RXN3O-378>
+          <http://model.geneontology.org/c1304c5f-83fb-4e9a-ac0a-9d76839be0a8_RXN3O-378>
 ] .
 
 <https://w3id.org/biolink/vocab/in_taxon>
@@ -2360,9 +2282,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_788e9862-6f72-4a0e-94e9-ee0238c39c4c_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2391,7 +2324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2406,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2423,7 +2356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2436,7 +2369,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002234_bf561303-505e-40f9-a4be-91c1469b6677_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2451,9 +2395,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-379_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_RXN3O-379> , <http://model.geneontology.org/34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379> ;
+                <http://model.geneontology.org/CHEBI_57527_RXN3O-379> , <http://model.geneontology.org/c6b4a98f-60e4-4b7a-af72-a564d7959857_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379> , <http://model.geneontology.org/CHEBI_58189_RXN3O-379> ;
+                <http://model.geneontology.org/1d3c73bd-ac6c-4a4e-9e50-27070aa2cd77_RXN3O-379> , <http://model.geneontology.org/CHEBI_58189_RXN3O-379> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-36_RXN3O-379_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2461,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2475,7 +2419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2494,7 +2438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2505,6 +2449,17 @@
           <http://model.geneontology.org/2.4.1.132-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_d40c43e6-91fe-4713-961b-38c62b7a3ba2_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57525>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2514,7 +2469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2530,7 +2485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2541,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2549,11 +2504,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_cd80ac96-502f-4c79-a410-cb7780f8a15e_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2561,44 +2516,89 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291>
+          <http://model.geneontology.org/cd80ac96-502f-4c79-a410-cb7780f8a15e_RXN3O-291>
 ] .
 
-<http://model.geneontology.org/4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(1)GlcNAc(2)-PP-Dol" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_1d3c73bd-ac6c-4a4e-9e50-27070aa2cd77_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-411_BFO_0000066_reaction_RXN3O-411_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/e1c54665-51e2-4865-b4e7-9749e8af3dae_RXN3O-291>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(6)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/e050a675-88a4-4e66-97be-1383aa5ce914_RXN3O-259>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/c6b4a98f-60e4-4b7a-af72-a564d7959857_RXN3O-379>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(3)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_c55f7335-1c23-44a9-9797-801c33ab9b95_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2606,7 +2606,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN>
+          <http://model.geneontology.org/c55f7335-1c23-44a9-9797-801c33ab9b95_2.4.1.132-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002413_RXN3O-11_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -2614,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2625,7 +2625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2640,7 +2640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2660,7 +2660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2674,7 +2674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2690,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2702,7 +2702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2721,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2732,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2746,18 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002233_a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2787,11 +2776,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_38d1419f-a39c-45e7-a58d-d1ae90ac9f85_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/1c581011-6984-4fb0-934e-cfb0abc48ba5_RXN3O-413>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000274>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2802,7 +2819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,7 +2839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,9 +2859,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-259_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259> , <http://model.geneontology.org/ecc729c4-a91b-4a60-8488-2ce58946f4ec_RXN3O-259> ;
+                <http://model.geneontology.org/e050a675-88a4-4e66-97be-1383aa5ce914_RXN3O-259> , <http://model.geneontology.org/099f6aae-0c02-4f65-99b9-fb6b3b37c9d7_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
+                <http://model.geneontology.org/b7052b94-5e9a-45e4-82eb-b635fddf4097_RXN3O-259> , <http://model.geneontology.org/CHEBI_16214_RXN3O-259> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2852,7 +2869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2862,11 +2879,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002234_788e9862-6f72-4a0e-94e9-ee0238c39c4c_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2874,7 +2891,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.131-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/eade90c2-ad9a-47a3-9c69-0bace7df2bc6_2.4.1.131-RXN>
+          <http://model.geneontology.org/788e9862-6f72-4a0e-94e9-ee0238c39c4c_2.4.1.131-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57705_2.7.8.15-RXN>
@@ -2886,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2894,23 +2911,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_CHEBI_57525_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2922,7 +2928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2938,11 +2944,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/f3cf6531-3cbf-4a50-9ff7-06b4ca5b6df2_RXN3O-291>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2950,7 +2973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2967,7 +2990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -2994,26 +3017,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(1)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27974> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3021,7 +3027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3041,9 +3047,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/880968ce-be97-43d5-82b7-20b044941315_RXN3O-411> , <http://model.geneontology.org/CHEBI_57525_RXN3O-411> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-411> , <http://model.geneontology.org/c8cf61ed-b2a8-484f-9d7e-2805eddcd486_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-411> , <http://model.geneontology.org/b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411> ;
+                <http://model.geneontology.org/CHEBI_16214_RXN3O-411> , <http://model.geneontology.org/d40c43e6-91fe-4713-961b-38c62b7a3ba2_RXN3O-411> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR002W-MONOMER_RXN3O-411_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3051,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3068,7 +3074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3084,7 +3090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3101,7 +3107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3112,13 +3118,35 @@
           <http://model.geneontology.org/CHEBI_57525_RXN3O-413>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_cd80ac96-502f-4c79-a410-cb7780f8a15e_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_RO_0002233_c54d2b49-18f2-49aa-9323-0bee7261c69c_2.4.1.131-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_CHEBI_58189_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3129,8 +3157,8 @@
           <http://model.geneontology.org/CHEBI_58189_RXN3O-378>
 ] .
 
-<http://model.geneontology.org/8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/788e9862-6f72-4a0e-94e9-ee0238c39c4c_2.4.1.131-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3138,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3146,12 +3174,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/cb8b291c-3175-4324-b4b1-29af18d0c0b2_RXN3O-378>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(3)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_b7052b94-5e9a-45e4-82eb-b635fddf4097_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3159,11 +3204,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_1c581011-6984-4fb0-934e-cfb0abc48ba5_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3171,7 +3216,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-413> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413>
+          <http://model.geneontology.org/1c581011-6984-4fb0-934e-cfb0abc48ba5_RXN3O-413>
 ] .
 
 <http://model.geneontology.org/CHEBI_16214_RXN3O-11>
@@ -3183,7 +3228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3196,11 +3241,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_78777294-3fba-498c-8060-147650e8f41e_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_cb8b291c-3175-4324-b4b1-29af18d0c0b2_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3208,19 +3253,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-378> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/78777294-3fba-498c-8060-147650e8f41e_RXN3O-378>
+          <http://model.geneontology.org/cb8b291c-3175-4324-b4b1-29af18d0c0b2_RXN3O-378>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002234_b87098eb-fb95-4f1e-a66b-5d0f1fb60bd4_RXN3O-411_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3230,7 +3264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3258,30 +3292,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002234_CHEBI_58223_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3298,7 +3315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3317,7 +3334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3334,7 +3351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3345,40 +3362,34 @@
           <http://model.geneontology.org/reaction_RXN3O-411_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_66356465-c5d5-445f-a334-ae948fdaafff_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/a2da7a6f-b47a-4360-9ed0-429cecdb89e7_RXN3O-259>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-411_RO_0002333_YOR002W-MONOMER_RXN3O-411_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.7.8.15-RXN_RO_0002333_YBR243C-MONOMER_2.7.8.15-RXN_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3386,11 +3397,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002233_f3cf6531-3cbf-4a50-9ff7-06b4ca5b6df2_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3398,22 +3409,50 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-291> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291>
+          <http://model.geneontology.org/f3cf6531-3cbf-4a50-9ff7-06b4ca5b6df2_RXN3O-291>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002234_4ab2426a-e3b8-4641-9958-f415ad9adfb1_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002234_cb8b291c-3175-4324-b4b1-29af18d0c0b2_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_d933b028-30a6-459b-9fb6-1842255364b1_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ff130f09-00d6-428b-a94e-9ac25f8c922a_RXN3O-412>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Glc(1)Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3421,7 +3460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3432,51 +3471,23 @@
           <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-11_BFO_0000066_reaction_RXN3O-11_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(6)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28254> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_CHEBI_16214_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3484,11 +3495,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_db0d96da-af4b-414e-9990-5ed09ca4cdd7_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3496,41 +3507,36 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-412> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412>
+          <http://model.geneontology.org/db0d96da-af4b-414e-9990-5ed09ca4cdd7_RXN3O-412>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-413_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002234_cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/c1304c5f-83fb-4e9a-ac0a-9d76839be0a8_RXN3O-378>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(2)GlcNAc(2)-PP-Dol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3540,7 +3546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3554,22 +3560,16 @@
 <http://identifiers.org/sgd/S000000178>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-413_RO_0002233_1c581011-6984-4fb0-934e-cfb0abc48ba5_RXN3O-413_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3599,35 +3599,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(2)Man(9)GlcNac(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28136> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-259_BFO_0000066_reaction_RXN3O-259_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3639,7 +3622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3655,7 +3638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3670,7 +3653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lipid-linked oligosaccharide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3683,7 +3666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3694,11 +3677,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002233_c6b4a98f-60e4-4b7a-af72-a564d7959857_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3706,25 +3689,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-379> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/34242726-0af2-4b81-b04b-bc9f482b08fc_RXN3O-379>
+          <http://model.geneontology.org/c6b4a98f-60e4-4b7a-af72-a564d7959857_RXN3O-379>
 ] .
-
-<http://model.geneontology.org/b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(7)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57527_RXN3O-378>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57527> ;
@@ -3735,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3746,12 +3712,23 @@
 <http://identifiers.org/sgd/S000003459>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002233_c55f7335-1c23-44a9-9797-801c33ab9b95_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3766,7 +3743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3776,11 +3753,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-259_RO_0002234_b7052b94-5e9a-45e4-82eb-b635fddf4097_RXN3O-259_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,7 +3765,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-259> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1ce614de-4190-468d-b79e-e71102e1ad37_RXN3O-259>
+          <http://model.geneontology.org/b7052b94-5e9a-45e4-82eb-b635fddf4097_RXN3O-259>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3799,7 +3776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3819,7 +3796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3833,7 +3810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3849,11 +3826,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/c54d2b49-18f2-49aa-9323-0bee7261c69c_2.4.1.131-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(4)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-291>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0052925> ;
@@ -3864,9 +3858,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-291_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/8a26b8af-a0ff-48cf-9397-ea399888180d_RXN3O-291> , <http://model.geneontology.org/edfc6392-6c56-472c-b263-fc78b907bf8b_RXN3O-291> ;
+                <http://model.geneontology.org/cd80ac96-502f-4c79-a410-cb7780f8a15e_RXN3O-291> , <http://model.geneontology.org/f3cf6531-3cbf-4a50-9ff7-06b4ca5b6df2_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291> , <http://model.geneontology.org/CHEBI_16214_RXN3O-291> ;
+                <http://model.geneontology.org/e1c54665-51e2-4865-b4e7-9749e8af3dae_RXN3O-291> , <http://model.geneontology.org/CHEBI_16214_RXN3O-291> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3874,7 +3868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3890,7 +3884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3901,12 +3895,29 @@
           <http://model.geneontology.org/RXN3O-412>
 ] .
 
+<http://model.geneontology.org/e7085130-5d8c-4dad-91d9-de7f0020a7fc_RXN3O-3>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(7)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_RO_0002233_CHEBI_57705_2.4.1.141-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3920,7 +3931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3937,7 +3948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3948,12 +3959,29 @@
           <http://model.geneontology.org/CHEBI_18278_2.7.8.15-RXN>
 ] .
 
+<http://model.geneontology.org/dfba2c65-db75-4e74-bd3b-8c553ce868de_RXN3O-3>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28221> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002233_CHEBI_57527_RXN3O-378_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -3971,9 +3999,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-412_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3d3066a5-8a54-4c6e-add2-4398b9bdb40b_RXN3O-412> , <http://model.geneontology.org/CHEBI_57525_RXN3O-412> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-412> , <http://model.geneontology.org/ff130f09-00d6-428b-a94e-9ac25f8c922a_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412> , <http://model.geneontology.org/CHEBI_16214_RXN3O-412> ;
+                <http://model.geneontology.org/db0d96da-af4b-414e-9990-5ed09ca4cdd7_RXN3O-412> , <http://model.geneontology.org/CHEBI_16214_RXN3O-412> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR067C-MONOMER_RXN3O-412_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3981,7 +4009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3991,11 +4019,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_a0838253-7f34-4cd1-9f2c-3ade190e4d40_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4003,7 +4031,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b660c469-63b1-4455-8c37-a900d1d80589_RXN3O-11>
+          <http://model.geneontology.org/a0838253-7f34-4cd1-9f2c-3ade190e4d40_RXN3O-11>
 ] .
 
 <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN>
@@ -4015,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4028,14 +4056,17 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/d933b028-30a6-459b-9fb6-1842255364b1_RXN3O-11>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4043,7 +4074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4051,15 +4082,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9818_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4072,24 +4100,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLProtein28129> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002234_50b8d82b-c058-4dc6-ad9a-3a75c814c722_RXN3O-412_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_12427_RXN3O-9818>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_12427> ;
@@ -4100,7 +4117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4113,7 +4130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4128,7 +4145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4144,7 +4161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4153,13 +4170,24 @@
 <http://purl.obolibrary.org/obo/GO_0042283>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_e1c54665-51e2-4865-b4e7-9749e8af3dae_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002333_YGL065C-MONOMER_RXN3O-378_controller_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4177,7 +4205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4194,7 +4222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4205,12 +4233,12 @@
           <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-379_RO_0002234_35a3e979-610a-423f-9516-69b0eff76abb_RXN3O-379_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_e7085130-5d8c-4dad-91d9-de7f0020a7fc_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4221,7 +4249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4233,7 +4261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4252,7 +4280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4266,22 +4294,11 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_57527>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_RXN3O-3_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/CHEBI_57527>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4289,7 +4306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4300,6 +4317,34 @@
           <http://model.geneontology.org/CHEBI_57525_RXN3O-411>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-378_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/1d3c73bd-ac6c-4a4e-9e50-27070aa2cd77_RXN3O-379>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(4)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YNL219C-MONOMER_RXN3O-259_controller>
         a       <http://identifiers.org/sgd/S000005163> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4307,7 +4352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4324,7 +4369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4337,7 +4382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4349,7 +4394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4363,33 +4408,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_57865>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/b7052b94-5e9a-45e4-82eb-b635fddf4097_RXN3O-259>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(9)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28117> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-378_RO_0002413_RXN3O-379_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/85bc8492-8471-4d8d-ad2d-5543076f97cf_RXN3O-11>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(8)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28226> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBL082C-MONOMER_RXN3O-291_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000178> ;
@@ -4398,7 +4443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4411,7 +4456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4419,11 +4464,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_e888378c-5134-4e75-a883-122b43ee9326_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4431,7 +4476,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.132-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN>
+          <http://model.geneontology.org/e888378c-5134-4e75-a883-122b43ee9326_2.4.1.132-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4440,7 +4485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4456,7 +4501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4468,7 +4513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4484,7 +4529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4499,7 +4544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4516,7 +4561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4527,13 +4572,30 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_16214_RXN3O-291>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16214> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9818_RO_0002233_CHEBI_57527_RXN3O-9818_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4544,46 +4606,23 @@
           <http://model.geneontology.org/CHEBI_57527_RXN3O-9818>
 ] .
 
-<http://model.geneontology.org/CHEBI_16214_RXN3O-291>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16214> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl phosphate" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_dfba2c65-db75-4e74-bd3b-8c553ce868de_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Glc(3)Man(9)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28150> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.131-RXN_BFO_0000066_reaction_2.4.1.131-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4598,7 +4637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4618,28 +4657,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule27967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/299587f2-37f3-47eb-959c-e65bf5c9c3a3_2.4.1.131-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(4)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28183> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4649,7 +4671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4666,7 +4688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4682,7 +4704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4693,7 +4715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4704,7 +4726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4719,7 +4741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4732,7 +4754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4747,24 +4769,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28079> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-291_RO_0002234_76ef4a8f-0ddd-4b6b-a984-c241c8905466_RXN3O-291_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4774,7 +4785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4790,7 +4801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -4805,7 +4816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4816,47 +4827,13 @@
           <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
 ] .
 
-<http://model.geneontology.org/bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(2)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_dfba2c65-db75-4e74-bd3b-8c553ce868de_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.4.1.132-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4864,7 +4841,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0f6e0fa6-acf2-4dff-8dc2-1764eceb0853_RXN3O-3>
+          <http://model.geneontology.org/dfba2c65-db75-4e74-bd3b-8c553ce868de_RXN3O-3>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4873,7 +4850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4884,44 +4861,33 @@
           <http://model.geneontology.org/CHEBI_57865_2.7.8.15-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002234_36cc8307-8e92-499e-a664-fd3a8549e974_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_BFO_0000050_GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.4.1.132-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSE-MANNOSYL-CHITO-DOLICHOL/GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
+] .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.132-RXN_RO_0002234_CHEBI_58189_2.4.1.132-RXN_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/78777294-3fba-498c-8060-147650e8f41e_RXN3O-378>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "Man(3)GlcNAc(2)-PP-Dol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28169> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/2.7.8.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003975> ;
@@ -4942,7 +4908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4958,7 +4924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4981,15 +4947,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-413_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57525_RXN3O-413> , <http://model.geneontology.org/75d8b394-79fa-4782-8ae4-9185a486416e_RXN3O-413> ;
+                <http://model.geneontology.org/CHEBI_57525_RXN3O-413> , <http://model.geneontology.org/1c581011-6984-4fb0-934e-cfb0abc48ba5_RXN3O-413> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16214_RXN3O-413> , <http://model.geneontology.org/cb6ab071-a71d-4ff9-be6a-ebd6ae0536db_RXN3O-413> ;
+                <http://model.geneontology.org/5ba1d282-76dc-44fb-84f6-04faf6612051_RXN3O-413> , <http://model.geneontology.org/CHEBI_16214_RXN3O-413> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR227W-MONOMER_RXN3O-413_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4999,11 +4965,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-11_RO_0002233_d933b028-30a6-459b-9fb6-1842255364b1_RXN3O-11_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5011,16 +4977,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-11> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/785822fb-0d47-47be-8a6e-a9c7eddb602a_RXN3O-11>
+          <http://model.geneontology.org/d933b028-30a6-459b-9fb6-1842255364b1_RXN3O-11>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-3_RO_0002233_38d1419f-a39c-45e7-a58d-d1ae90ac9f85_RXN3O-3_SGD_GLUCOSE-MANNOSYL-CHITO-DOLICHOL> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5028,7 +4994,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-3> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7d4546ca-28cc-4873-9ede-aaa743db438c_RXN3O-3>
+          <http://model.geneontology.org/38d1419f-a39c-45e7-a58d-d1ae90ac9f85_RXN3O-3>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-412_RO_0002413_RXN3O-413_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
@@ -5036,7 +5002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -5047,18 +5013,52 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/e888378c-5134-4e75-a883-122b43ee9326_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a lipid-linked &alpha;(1->3)-D-mannosyl-D-mannose-oligosaccharide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28197> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/66356465-c5d5-445f-a334-ae948fdaafff_2.4.1.132-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "Man(2)GlcNAc(2)-PP-Dol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUCOSE-MANNOSYL-CHITO-DOLICHOLSmallMolecule28164> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.4.1.141-RXN_BFO_0000066_reaction_2.4.1.141-RXN_location_lociGO_0005829_null_GLUCOSE-MANNOSYL-CHITO-DOLICHOL>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -5069,7 +5069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/pav/providedBy>
@@ -5087,9 +5087,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.4.1.132-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> , <http://model.geneontology.org/5515a468-62e7-49c4-b5ab-352b2c8b54e2_2.4.1.132-RXN> ;
+                <http://model.geneontology.org/CHEBI_57527_2.4.1.132-RXN> , <http://model.geneontology.org/c55f7335-1c23-44a9-9797-801c33ab9b95_2.4.1.132-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/976ff544-650c-4d3c-9d28-9afd13d5ef17_2.4.1.132-RXN> , <http://model.geneontology.org/bb24963e-0482-4f44-b999-5786d92ba497_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
+                <http://model.geneontology.org/66356465-c5d5-445f-a334-ae948fdaafff_2.4.1.132-RXN> , <http://model.geneontology.org/e888378c-5134-4e75-a883-122b43ee9326_2.4.1.132-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.132-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL065C-MONOMER_2.4.1.132-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5097,7 +5097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUCOSE-MANNOSYL-CHITO-DOLICHOL" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLUDEG-I-PWY-1-GLUDEG-I-PWY-1.ttl
+++ b/models/GLUDEG-I-PWY-1-GLUDEG-I-PWY-1.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -995,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1074,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUDEG-I-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUDEG-I-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLUGLNSYN-PWY-GLUGLNSYN-PWY.ttl
+++ b/models/GLUGLNSYN-PWY-GLUGLNSYN-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-glutamate biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUGLNSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUGLNSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLUNH3-PWY-GLUNH3-PWY.ttl
+++ b/models/GLUNH3-PWY-GLUNH3-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -74,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate biosynthesis from ammonia - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUNH3-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUNH3-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLUT-REDOX2-PWY-GLUT-REDOX2-PWY.ttl
+++ b/models/GLUT-REDOX2-PWY-GLUT-REDOX2-PWY.ttl
@@ -1,14 +1,3 @@
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -21,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -52,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,9 +51,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GLUTATHIONE-PEROXIDASE-RXN>
 ] .
-
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000001476>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -79,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,22 +73,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN_SGD_GLUT-REDOX2-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTATHIONE-PEROXIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YLL060C-MONOMER_GSHTRAN-RXN_controller>
         a       <http://identifiers.org/sgd/S000003983> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -111,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,16 +116,8 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-REDUCT-NADPH-RXN_RO_0002333_YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller_SGD_GLUT-REDOX2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://identifiers.org/sgd/S000006012>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006012> ;
@@ -154,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,15 +134,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://identifiers.org/sgd/S000006012>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002234_CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN_SGD_GLUT-REDOX2-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUTATHIONE-PEROXIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YBR244W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -185,9 +171,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GSHTRAN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN> , <http://model.geneontology.org/CHEBI_57925_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57925_GSHTRAN-RXN> , <http://model.geneontology.org/ebf41a57-04ee-44fb-bf1e-cb7154f4a31d_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN> , <http://model.geneontology.org/61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN> ;
+                <http://model.geneontology.org/a8c524c7-0180-4f9c-a635-8606f8638622_GSHTRAN-RXN> , <http://model.geneontology.org/01f538ca-5e6d-438d-b681-68a5d13e14af_GSHTRAN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YIR038C-MONOMER_GSHTRAN-RXN_controller> , <http://model.geneontology.org/YLL060C-MONOMER_GSHTRAN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -195,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,26 +206,35 @@
           <http://model.geneontology.org/YIR038C-MONOMER_GSHTRAN-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/01f538ca-5e6d-438d-b681-68a5d13e14af_GSHTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glutathione-<i>S</i>-conjugate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002411_GLUTATHIONE-REDUCT-NADPH-RXN_SGD_GLUT-REDOX2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -345,6 +340,17 @@
 
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_01f538ca-5e6d-438d-b681-68a5d13e14af_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0004364>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -359,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -418,24 +424,13 @@
           <http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-PEROXIDASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_null_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_01f538ca-5e6d-438d-b681-68a5d13e14af_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,11 +438,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN>
+          <http://model.geneontology.org/01f538ca-5e6d-438d-b681-68a5d13e14af_GSHTRAN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_BFO_0000066_reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829_null_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -458,33 +467,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60972> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glutathione-<i>S</i>-conjugate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60859> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -495,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin redox reactions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,13 +556,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYProtein60927> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/a8c524c7-0180-4f9c-a635-8606f8638622_GSHTRAN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "HX" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57783_GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -584,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -609,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,11 +710,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_a8c524c7-0180-4f9c-a635-8606f8638622_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,7 +722,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN>
+          <http://model.geneontology.org/a8c524c7-0180-4f9c-a635-8606f8638622_GSHTRAN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -731,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -745,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -809,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,6 +826,23 @@
           <http://model.geneontology.org/YPL091W-MONOMER_GLUTATHIONE-REDUCT-NADPH-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ebf41a57-04ee-44fb-bf1e-cb7154f4a31d_GSHTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "RX" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0004362>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -829,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,28 +868,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/61721f9a-e12b-4271-8c7d-7109675d7212_GSHTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "HX" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60865> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -876,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -887,18 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YIR038C-MONOMER_GSHTRAN-RXN_controller_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -909,7 +904,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002333_YIR038C-MONOMER_GSHTRAN-RXN_controller_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,24 +959,13 @@
           <http://model.geneontology.org/reaction_GLUTATHIONE-PEROXIDASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_9dc53d13-cb51-4d0b-8e51-988ba6335870_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLUT-REDOX2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_ebf41a57-04ee-44fb-bf1e-cb7154f4a31d_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +973,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GSHTRAN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN>
+          <http://model.geneontology.org/ebf41a57-04ee-44fb-bf1e-cb7154f4a31d_GSHTRAN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_GLUTATHIONE-PEROXIDASE-RXN>
@@ -990,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1034,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1049,7 +1044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1088,12 +1083,23 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002234_a8c524c7-0180-4f9c-a635-8606f8638622_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLUTATHIONE-PEROXIDASE-RXN_RO_0002333_YIR037W-MONOMER_GLUTATHIONE-PEROXIDASE-RXN_controller_SGD_GLUT-REDOX2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1130,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1161,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1209,23 +1215,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/cf7df75f-9282-48d2-81a2-255618720d1f_GSHTRAN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "RX" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60852> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://identifiers.org/sgd/S000003983>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1234,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1246,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,28 +1356,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-PEROXIDASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57925> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glutathione" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60815> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57925_PRODISULFREDUCT-A-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57925> ;
@@ -1399,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1416,13 +1388,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYProtein60842> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_57925_GLUTATHIONE-PEROXIDASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57925> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glutathione" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60815> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1436,7 +1425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1491,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1507,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1581,13 +1570,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLUT-REDOX2-PWYSmallMolecule60894> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/GLUTATHIONE-REDUCT-NADPH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004362> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1608,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,8 +1608,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YIR038C-MONOMER_GSHTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001477> ;
@@ -1626,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,8 +1643,16 @@
           <http://model.geneontology.org/GLUTATHIONE-REDUCT-NADPH-RXN>
 ] .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_GSHTRAN-RXN_RO_0002233_ebf41a57-04ee-44fb-bf1e-cb7154f4a31d_GSHTRAN-RXN_SGD_GLUT-REDOX2-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLUT-REDOX2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1662,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1695,7 +1695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUT-REDOX2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1707,7 +1707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUT-REDOX2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/GLUTATHIONESYN-PWY-GLUTATHIONESYN-PWY.ttl
+++ b/models/GLUTATHIONESYN-PWY-GLUTATHIONESYN-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,7 +87,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -807,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,24 +953,13 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTCYSLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_null_GLUTATHIONESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLUTATHIONESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002234_CHEBI_15378_GLUTATHIONE-SYN-RXN_SGD_GLUTATHIONESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,12 +970,23 @@
           <http://model.geneontology.org/CHEBI_15378_GLUTATHIONE-SYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_RO_0002413_GLUTATHIONE-SYN-RXN_null_GLUTATHIONESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLUTATHIONESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLUTCYSLIG-RXN_BFO_0000050_GLUTATHIONESYN-PWY/GLUTATHIONESYN-PWY_SGD_GLUTATHIONESYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLUTATHIONESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLUTATHIONESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/GLYCLEAV-PWY-GLYCLEAV-PWY.ttl
+++ b/models/GLYCLEAV-PWY-GLYCLEAV-PWY.ttl
@@ -1,3 +1,20 @@
+<http://model.geneontology.org/be75426b-bca7-4be7-abd0-2a37ca2b7096_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004801> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5,26 +22,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYProtein22703> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "dihydrolipoamide dehydrogenase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYProtein22619> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -33,11 +35,43 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "dihydrolipoamide dehydrogenase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYProtein22619> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/5e6c7efb-7db9-459b-a51d-54bde36fc917_GCVP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_57945_RXN-8629>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57945> ;
@@ -48,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,11 +92,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_be75426b-bca7-4be7-abd0-2a37ca2b7096_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +104,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN>
+          <http://model.geneontology.org/be75426b-bca7-4be7-abd0-2a37ca2b7096_GCVT-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829>
@@ -78,11 +112,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_5e6c7efb-7db9-459b-a51d-54bde36fc917_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,19 +124,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN>
+          <http://model.geneontology.org/5e6c7efb-7db9-459b-a51d-54bde36fc917_GCVP-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -115,18 +138,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_aaae7568-9e72-4d9f-aca9-4990b675eec5_RXN-8629_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +171,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/b2318403-5078-4bff-bcee-d8ef2ef0ad87_GCVT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_1fb1832d-ba12-4605-9c58-f81692c2c38c_GCVP-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -156,11 +207,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_9e85958d-09ac-45e0-b64a-df2a49fe7ffc_RXN-8629_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +219,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629>
+          <http://model.geneontology.org/9e85958d-09ac-45e0-b64a-df2a49fe7ffc_RXN-8629>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_GLYCLEAV-PWY/GLYCLEAV-PWY_SGD_GLYCLEAV-PWY>
@@ -176,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -191,9 +242,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_GCVP-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVP-RXN> , <http://model.geneontology.org/5e6c7efb-7db9-459b-a51d-54bde36fc917_GCVP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> ;
+                <http://model.geneontology.org/1fb1832d-ba12-4605-9c58-f81692c2c38c_GCVP-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR189W-MONOMER_GCVP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -201,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -245,6 +296,23 @@
 
 <http://identifiers.org/sgd/S000002426>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/aaae7568-9e72-4d9f-aca9-4990b675eec5_RXN-8629>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/GCVT-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004047> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -255,9 +323,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN> , <http://model.geneontology.org/043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN> ;
+                <http://model.geneontology.org/b2318403-5078-4bff-bcee-d8ef2ef0ad87_GCVT-RXN> , <http://model.geneontology.org/4db441ca-728f-4399-bc7d-593c7c18ab6f_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN> , <http://model.geneontology.org/89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> ;
+                <http://model.geneontology.org/7e48b917-0b03-425b-9e06-caf32cfb6dc5_GCVT-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVT-RXN> , <http://model.geneontology.org/be75426b-bca7-4be7-abd0-2a37ca2b7096_GCVT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -265,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -287,30 +355,13 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_CHEBI_28938_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,24 +372,13 @@
           <http://model.geneontology.org/CHEBI_28938_GCVT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_null_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_CHEBI_57305_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,22 +389,16 @@
           <http://model.geneontology.org/CHEBI_57305_GCVP-RXN>
 ] .
 
-<http://model.geneontology.org/89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000066_reaction_GCVT-RXN_location_lociGO_0005829_null_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -374,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +424,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_9e85958d-09ac-45e0-b64a-df2a49fe7ffc_RXN-8629_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -405,42 +450,8 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22635> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -448,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -481,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -490,8 +501,8 @@
 <http://model.geneontology.org/reaction_GCVT-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/7e48b917-0b03-425b-9e06-caf32cfb6dc5_GCVT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -499,11 +510,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22641> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/4db441ca-728f-4399-bc7d-593c7c18ab6f_GCVT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -516,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -595,11 +623,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_4db441ca-728f-4399-bc7d-593c7c18ab6f_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +635,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/60132d99-fea3-419a-83c1-3936b50a8945_GCVT-RXN>
+          <http://model.geneontology.org/4db441ca-728f-4399-bc7d-593c7c18ab6f_GCVT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -616,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,28 +655,6 @@
           <http://model.geneontology.org/CHEBI_15378_GCVP-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_8765fe07-5bf9-475b-8ab1-6ce6449fd161_GCVP-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -658,7 +664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,12 +714,12 @@
           <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_1a13ef7a-9aa4-4272-b3e5-f904c27decbe_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_4db441ca-728f-4399-bc7d-593c7c18ab6f_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,11 +792,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_b2318403-5078-4bff-bcee-d8ef2ef0ad87_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +804,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN>
+          <http://model.geneontology.org/b2318403-5078-4bff-bcee-d8ef2ef0ad87_GCVT-RXN>
 ] .
 
 <http://model.geneontology.org/YDR019C-MONOMER_GCVT-RXN_controller>
@@ -808,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,9 +853,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-8629_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
+                <http://model.geneontology.org/9e85958d-09ac-45e0-b64a-df2a49fe7ffc_RXN-8629> , <http://model.geneontology.org/CHEBI_57540_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-8629> , <http://model.geneontology.org/aaae7568-9e72-4d9f-aca9-4990b675eec5_RXN-8629> , <http://model.geneontology.org/CHEBI_57945_RXN-8629> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-8629_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -857,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -867,11 +873,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_aaae7568-9e72-4d9f-aca9-4990b675eec5_RXN-8629_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +885,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-8629> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629>
+          <http://model.geneontology.org/aaae7568-9e72-4d9f-aca9-4990b675eec5_RXN-8629>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57540>
@@ -900,13 +906,24 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_be75426b-bca7-4be7-abd0-2a37ca2b7096_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002333_YDR019C-MONOMER_GCVT-RXN_controller_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,11 +936,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002234_1fb1832d-ba12-4605-9c58-f81692c2c38c_GCVP-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -931,25 +948,53 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN>
+          <http://model.geneontology.org/1fb1832d-ba12-4605-9c58-f81692c2c38c_GCVP-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002233_f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629_SGD_GLYCLEAV-PWY>
+<http://model.geneontology.org/1fb1832d-ba12-4605-9c58-f81692c2c38c_GCVP-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002233_5e6c7efb-7db9-459b-a51d-54bde36fc917_GCVP-RXN_SGD_GLYCLEAV-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_b2318403-5078-4bff-bcee-d8ef2ef0ad87_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_GCVP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -960,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +1021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1046,21 +1091,49 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/9e85958d-09ac-45e0-b64a-df2a49fe7ffc_RXN-8629>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_7e48b917-0b03-425b-9e06-caf32cfb6dc5_GCVT-RXN_SGD_GLYCLEAV-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCLEAV-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GCVP-RXN_RO_0002413_GCVT-RXN_null_GLYCLEAV-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1078,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,11 +1164,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002234_7e48b917-0b03-425b-9e06-caf32cfb6dc5_GCVT-RXN_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,64 +1176,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/89dcf4a6-4869-44bd-b57e-78385dab7c39_GCVT-RXN>
+          <http://model.geneontology.org/7e48b917-0b03-425b-9e06-caf32cfb6dc5_GCVT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GCVT-RXN_RO_0002233_043e5aa4-1225-40d6-b185-e3a846add8eb_GCVT-RXN_SGD_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22582> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8629_RO_0002234_65919f2f-bfa4-49ac-a636-a7d34fd419d2_RXN-8629_SGD_GLYCLEAV-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCLEAV-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/f23d9c12-54c8-47a1-99cb-a3cb159a8fbd_RXN-8629>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22559> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1168,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine cleavage - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCLEAV-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1221,30 +1238,13 @@
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/83e099db-35f5-44eb-a516-7ebc7b23eda2_GCVP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [glycine-cleavage complex H protein] <i>N<sup>6</sup></i>-aminomethyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCLEAV-PWYSmallMolecule22627> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVT-RXN_BFO_0000050_GLYCLEAV-PWY/GLYCLEAV-PWY_SGD_GLYCLEAV-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCLEAV-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/GLYCOCAT-YEAST-PWY-GLYCOCAT-YEAST-PWY.ttl
+++ b/models/GLYCOCAT-YEAST-PWY-GLYCOCAT-YEAST-PWY.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -19,11 +19,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_58bc29f5-b020-471d-aa65-eba7da4eb745_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -31,7 +31,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023>
+          <http://model.geneontology.org/58bc29f5-b020-471d-aa65-eba7da4eb745_RXN-9023>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002413_PHOSPHOGLUCMUT-RXN_null_GLYCOCAT-YEAST-PWY>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -142,6 +142,17 @@
           <http://model.geneontology.org/RXN-9024>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_4ea83449-5b8f-4fd0-92ff-bb177eacecf3_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_4170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -151,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -255,11 +266,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_a4903aa1-742c-431e-914e-63483f23c497_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +278,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN>
+          <http://model.geneontology.org/a4903aa1-742c-431e-914e-63483f23c497_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN-9024>
@@ -279,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,34 +393,6 @@
           <http://model.geneontology.org/reaction_AMYLOMALT-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a debranched &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -418,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -427,30 +410,13 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_15377_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,23 +444,12 @@
           <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002413_RXN-9023_null_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -594,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,17 +560,6 @@
 <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'a &alpha;-limit dextrin with short branches + n H<sub>2</sub>O &rarr; a debranched &alpha;-limit dextrin + n D-glucopyranose' 'null' 'a debranched &alpha;-limit dextrin + n H<sub>2</sub>O &rarr; n D-glucopyranose' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -624,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,23 +621,12 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +669,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-9024> , <http://model.geneontology.org/2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024> ;
+                <http://model.geneontology.org/6f738c57-7ff8-4870-8f1c-baeb5b255a87_RXN-9024> , <http://model.geneontology.org/CHEBI_15377_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_4167_RXN-9024> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -744,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,11 +707,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_6f738c57-7ff8-4870-8f1c-baeb5b255a87_RXN-9024_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +719,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9024> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024>
+          <http://model.geneontology.org/6f738c57-7ff8-4870-8f1c-baeb5b255a87_RXN-9024>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -795,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -856,11 +789,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_a32d57f5-6324-4074-acbf-857a185e76a0_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +801,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.2.1.33-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN>
+          <http://model.geneontology.org/a32d57f5-6324-4074-acbf-857a185e76a0_3.2.1.33-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GLYCOPHOSPHORYL-RXN_location_lociGO_0005829>
@@ -880,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +852,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_24384_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/CHEBI_43474_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN> ;
+                <http://model.geneontology.org/CHEBI_58601_GLYCOPHOSPHORYL-RXN> , <http://model.geneontology.org/4ea83449-5b8f-4fd0-92ff-bb177eacecf3_GLYCOPHOSPHORYL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-10513_GLYCOPHOSPHORYL-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -927,13 +860,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYBiochemicalReaction27885> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002234_a4903aa1-742c-431e-914e-63483f23c497_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_3.2.1.3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -944,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1057,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1166,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1212,7 +1156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,11 +1169,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002234_4ea83449-5b8f-4fd0-92ff-bb177eacecf3_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,23 +1181,23 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYCOPHOSPHORYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN>
+          <http://model.geneontology.org/4ea83449-5b8f-4fd0-92ff-bb177eacecf3_GLYCOPHOSPHORYL-RXN>
 ] .
 
-<http://model.geneontology.org/c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/6f738c57-7ff8-4870-8f1c-baeb5b255a87_RXN-9024>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a &alpha;-limit dextrin with short branches" ;
+                "a debranched &alpha;-limit dextrin" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1262,31 +1206,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ef18edf9-c251-4b83-9d0c-51eb4de6b3b8_GLYCOPHOSPHORYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-limit dextrin" ;
+<https://w3id.org/biolink/vocab/in_taxon>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-9024_RO_0002233_6f738c57-7ff8-4870-8f1c-baeb5b255a87_RXN-9024_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<https://w3id.org/biolink/vocab/in_taxon>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1296,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1305,30 +1243,13 @@
 <http://purl.obolibrary.org/obo/GO_0004614>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a debranched &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002333_YPR184W-MONOMER_3.2.1.33-RXN_controller_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1350,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1399,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,7 +1354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1461,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1504,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1517,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1537,6 +1458,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_61993>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0032991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
         a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1544,36 +1471,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYProtein27746> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://purl.obolibrary.org/obo/GO_0032991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3.2.1.3-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_24384_3.2.1.3-RXN>
-] .
-
-<http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1583,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,34 +1498,29 @@
           <http://model.geneontology.org/reaction_RXN-9024_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_GLYCOCAT-YEAST-PWY>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3.2.1.3-RXN_RO_0002233_CHEBI_24384_3.2.1.3-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3.2.1.3-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_24384_3.2.1.3-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002234_58bc29f5-b020-471d-aa65-eba7da4eb745_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1633,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,12 +1543,56 @@
           <http://model.geneontology.org/GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-10513_RXN-9025_controller_BFO_0000051_SGD_S000006364_CPLX3O-10513_component_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9024_BFO_0000066_reaction_RXN-9024_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_a32d57f5-6324-4074-acbf-857a185e76a0_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9025_BFO_0000066_reaction_RXN-9025_location_lociGO_0005829_null_GLYCOCAT-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1663,7 +1606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,11 +1619,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_8e8965dc-30b5-48aa-9b85-7d44aefb7ec2_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,7 +1631,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025>
+          <http://model.geneontology.org/8e8965dc-30b5-48aa-9b85-7d44aefb7ec2_RXN-9025>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_BFO_0000050_GLYCOCAT-YEAST-PWY/GLYCOCAT-YEAST-PWY_SGD_GLYCOCAT-YEAST-PWY>
@@ -1696,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1735,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1749,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1760,28 +1703,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a &alpha;-limit dextrin with short branches" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000001610>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1794,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,7 +1737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1827,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1835,11 +1761,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_106a1215-09af-42d4-b924-42c8be033e45_RXN-9023_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1847,19 +1773,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-9023> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023>
+          <http://model.geneontology.org/106a1215-09af-42d4-b924-42c8be033e45_RXN-9023>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1867,7 +1782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1893,24 +1808,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27802> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_24384_RXN3O-4038>
         a       <http://purl.obolibrary.org/obo/CHEBI_24384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1921,13 +1825,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27857> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1941,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1958,7 +1873,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_43474_RXN-9025> , <http://model.geneontology.org/def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN-9025> , <http://model.geneontology.org/8e8965dc-30b5-48aa-9b85-7d44aefb7ec2_RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58601_RXN-9025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1968,7 +1883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1982,7 +1897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2001,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +1928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,13 +1939,24 @@
           <http://model.geneontology.org/CHEBI_4167_RXN-9024>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9023_RO_0002233_106a1215-09af-42d4-b924-42c8be033e45_RXN-9023_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYCOPHOSPHORYL-RXN_RO_0002233_CHEBI_43474_GLYCOPHOSPHORYL-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2060,7 +1986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +1997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2144,9 +2070,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.2.1.33-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/a32d57f5-6324-4074-acbf-857a185e76a0_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> , <http://model.geneontology.org/481a0048-1f0f-47c8-ad57-de74d42f4b1e_3.2.1.33-RXN> ;
+                <http://model.geneontology.org/a4903aa1-742c-431e-914e-63483f23c497_3.2.1.33-RXN> , <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_3.2.1.33-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2156,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2170,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,11 +2112,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/58bc29f5-b020-471d-aa65-eba7da4eb745_RXN-9023>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a &alpha;-limit dextrin with short branches" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2198,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,6 +2155,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_28460>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/8e8965dc-30b5-48aa-9b85-7d44aefb7ec2_RXN-9025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a debranched &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -2222,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2235,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2260,7 +2220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2276,7 +2236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2290,7 +2250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,12 +2261,29 @@
           <http://model.geneontology.org/3.2.1.33-RXN>
 ] .
 
+<http://model.geneontology.org/106a1215-09af-42d4-b924-42c8be033e45_RXN-9023>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_AMYLOMALT-RXN_RO_0002233_CHEBI_4167_AMYLOMALT-RXN_SGD_GLYCOCAT-YEAST-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2318,7 +2295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,6 +2306,23 @@
           <http://model.geneontology.org/SGD_S000006364_CPLX3O-10513_component>
 ] .
 
+<http://model.geneontology.org/a4903aa1-742c-431e-914e-63483f23c497_3.2.1.33-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a debranched &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_4167_3.2.1.33-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_4167> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2338,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2351,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2362,7 +2356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2377,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2390,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2404,7 +2398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2423,7 +2417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2443,7 +2437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2464,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2500,18 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_def02443-e5ed-4b37-bcf4-bda76138345b_RXN-9025_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2550,7 +2533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2561,7 +2544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2571,7 +2554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2588,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2608,11 +2591,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27728> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/4ea83449-5b8f-4fd0-92ff-bb177eacecf3_GLYCOPHOSPHORYL-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-limit dextrin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27840> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2622,7 +2622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2642,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2655,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2666,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2677,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2688,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2701,7 +2701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2718,9 +2718,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-9023_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f477bcb9-604f-4aa5-87ad-bf1e09474d8f_RXN-9023> ;
+                <http://model.geneontology.org/106a1215-09af-42d4-b924-42c8be033e45_RXN-9023> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/43d17fb4-0c71-47bc-860b-7718d5aacf08_RXN-9023> ;
+                <http://model.geneontology.org/58bc29f5-b020-471d-aa65-eba7da4eb745_RXN-9023> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR184W-MONOMER_RXN-9023_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2728,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2742,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2759,7 +2759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2778,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2791,6 +2791,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_4167>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/a32d57f5-6324-4074-acbf-857a185e76a0_3.2.1.33-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a &alpha;-limit dextrin with short branches" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27823> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004614> ;
@@ -2809,7 +2826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2820,41 +2837,13 @@
 <http://purl.obolibrary.org/obo/GO_0004339>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_c2ed1c50-8ab2-4abb-995d-4145e4b02ce4_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/2b324589-7e48-4f84-8ebc-7adff87ec645_RXN-9024>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a debranched &alpha;-limit dextrin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYCOCAT-YEAST-PWYSmallMolecule27761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_3.2.1.33-RXN_RO_0002233_CHEBI_15377_3.2.1.33-RXN_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2865,13 +2854,24 @@
           <http://model.geneontology.org/CHEBI_15377_3.2.1.33-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002233_8e8965dc-30b5-48aa-9b85-7d44aefb7ec2_RXN-9025_SGD_GLYCOCAT-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYCOCAT-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9025_RO_0002234_CHEBI_58601_RXN-9025_SGD_GLYCOCAT-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2887,7 +2887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2912,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2928,7 +2928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2944,7 +2944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2955,7 +2955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOCAT-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYCOLYSIS-GLYCOLYSIS.ttl
+++ b/models/GLYCOLYSIS-GLYCOLYSIS.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,7 +19,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -853,7 +853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -941,7 +941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1055,7 +1055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1070,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1101,7 +1101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1201,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1218,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1284,7 +1284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1375,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1478,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1489,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1529,7 +1529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1560,7 +1560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1627,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1646,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1674,7 +1674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1694,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1710,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,7 +1752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1768,7 +1768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1852,7 +1852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1865,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1878,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1895,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1909,7 +1909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1971,7 +1971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -1996,7 +1996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2016,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycolysis I (from glucose 6-phosphate) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2030,7 +2030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2049,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2060,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2073,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2098,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,7 +2117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2163,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2175,7 +2175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2238,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2254,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2268,7 +2268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2284,7 +2284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2295,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2304,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2334,7 +2334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2351,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2398,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2427,7 +2427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2443,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2458,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2474,7 +2474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2491,7 +2491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2527,7 +2527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2542,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2556,7 +2556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2572,7 +2572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2600,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2615,7 +2615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,7 +2638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2651,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2666,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2685,7 +2685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2701,7 +2701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2733,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2746,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2760,7 +2760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2800,7 +2800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2816,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2828,7 +2828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2862,7 +2862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2878,7 +2878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2892,7 +2892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2904,7 +2904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2923,7 +2923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2935,7 +2935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2951,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2966,7 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2979,7 +2979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -2993,7 +2993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +3010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3029,7 +3029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3040,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3052,7 +3052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3082,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3096,7 +3096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3112,7 +3112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3124,7 +3124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3144,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3160,7 +3160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3171,7 +3171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3183,7 +3183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3199,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3210,7 +3210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3221,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3233,7 +3233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3257,7 +3257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3273,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3285,7 +3285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3307,7 +3307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3323,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3338,7 +3338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3354,7 +3354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3365,7 +3365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3386,7 +3386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3406,7 +3406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3422,7 +3422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3434,7 +3434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3450,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3461,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3476,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3493,7 +3493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3506,7 +3506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3518,7 +3518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3538,7 +3538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3551,7 +3551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3566,7 +3566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3605,7 +3605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3616,7 +3616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3628,7 +3628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3650,7 +3650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3673,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3688,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3706,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,7 +3720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3736,7 +3736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3753,7 +3753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,7 +3770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3787,7 +3787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3806,7 +3806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3822,7 +3822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3837,7 +3837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3851,7 +3851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3871,7 +3871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3890,7 +3890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3902,7 +3902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3918,7 +3918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3929,7 +3929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3940,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3951,7 +3951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYCOLYSIS" ;
         <http://purl.org/pav/providedBy>
@@ -3976,7 +3976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3993,7 +3993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYCOLYSIS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYOXYLATE-BYPASS-GLYOXYLATE-BYPASS.ttl
+++ b/models/GLYOXYLATE-BYPASS-GLYOXYLATE-BYPASS.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -25,7 +25,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,23 +560,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/CHEBI_15378_CITSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSSmallMolecule16672> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -585,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,6 +578,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_CITSYN-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/CHEBI_15378_CITSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSSmallMolecule16672> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,13 +785,30 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSSmallMolecule16643> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002234_CHEBI_16383_ACONITATEDEHYDR-RXN_SGD_GLYOXYLATE-BYPASS> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,23 +819,6 @@
           <http://model.geneontology.org/CHEBI_16383_ACONITATEDEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_57288_MALSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYOXYLATE-BYPASSSmallMolecule16643> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0004474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -867,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1206,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1226,7 +1226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,7 +1243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,7 +1260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,23 +1304,23 @@
           <http://model.geneontology.org/ISOCIT-CLEAV-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_GLYOXYLATE-BYPASS>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYOXYLATE-BYPASS" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_GLYOXYLATE-BYPASS>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYOXYLATE-BYPASS" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002234_CHEBI_15378_CITSYN-RXN_SGD_GLYOXYLATE-BYPASS>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1334,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1364,7 +1364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1381,7 +1381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1455,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,7 +1505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,7 +1522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1575,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1590,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1607,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1620,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1634,7 +1634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1650,7 +1650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1678,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1703,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1716,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1728,7 +1728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1843,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1857,7 +1857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1873,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1886,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1900,7 +1900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1917,7 +1917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1940,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1959,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -1983,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1997,7 +1997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2051,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2078,7 +2078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2090,7 +2090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2104,7 +2104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2121,7 +2121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2137,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2149,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2165,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2194,7 +2194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2221,7 +2221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2251,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2263,7 +2263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2282,7 +2282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2296,7 +2296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2313,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2339,7 +2339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2356,7 +2356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2374,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2391,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2408,7 +2408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2439,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2453,7 +2453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2469,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2480,7 +2480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2514,7 +2514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2531,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2547,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2558,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2587,7 +2587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2607,7 +2607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2621,7 +2621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2637,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2652,7 +2652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2665,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYOXYLATE-BYPASS" ;
         <http://purl.org/pav/providedBy>
@@ -2691,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYOXYLATE-BYPASS" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYSYN-ALA-PWY-GLYSYN-ALA-PWY.ttl
+++ b/models/GLYSYN-ALA-PWY-GLYSYN-ALA-PWY.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-ALA-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-ALA-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYSYN-PWY-GLYSYN-PWY.ttl
+++ b/models/GLYSYN-PWY-GLYSYN-PWY.ttl
@@ -3,20 +3,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -27,7 +16,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +30,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -78,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -112,11 +101,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_5d13fa46-2435-4311-98d6-bae9ac3e22f0_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,8 +113,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/5d13fa46-2435-4311-98d6-bae9ac3e22f0_GLYOHMETRANS-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_5d13fa46-2435-4311-98d6-bae9ac3e22f0_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004048> ;
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,19 +145,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/97655654-3899-4a90-9fcc-18d075c67e9b_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:GLYSYN-PWY" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -170,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,12 +231,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_97655654-3899-4a90-9fcc-18d075c67e9b_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:GLYSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,6 +290,23 @@
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/5d13fa46-2435-4311-98d6-bae9ac3e22f0_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -281,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,40 +329,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23596> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=GLYSYN-PWYSmallMolecule23619> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -348,11 +348,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_97655654-3899-4a90-9fcc-18d075c67e9b_GLYOHMETRANS-RXN_SGD_GLYSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/97655654-3899-4a90-9fcc-18d075c67e9b_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -378,15 +378,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/577ac35e-f2f8-448c-9ce2-3aaed1763d1b_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/5d13fa46-2435-4311-98d6-bae9ac3e22f0_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/7585126b-f793-4663-bc91-6b8346222e2a_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/97655654-3899-4a90-9fcc-18d075c67e9b_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/GLYSYN-THR-PWY-GLYSYN-THR-PWY.ttl
+++ b/models/GLYSYN-THR-PWY-GLYSYN-THR-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:GLYSYN-THR-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=GLYSYN-THR-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/HEME-BIOSYNTHESIS-II-HEME-BIOSYNTHESIS-II.ttl
+++ b/models/HEME-BIOSYNTHESIS-II-HEME-BIOSYNTHESIS-II.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,6 +364,17 @@
           <http://model.geneontology.org/CHEBI_17627_PROTOHEMEFERROCHELAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_HEME-BIOSYNTHESIS-II>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEME-BIOSYNTHESIS-II" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -372,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,17 +393,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_UROGENDECARBOX-RXN_location_lociGO_0005829>
 ] .
-
-<http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_RO_0002233_CHEBI_57308_UROGENDECARBOX-RXN_SGD_HEME-BIOSYNTHESIS-II>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEME-BIOSYNTHESIS-II" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -699,7 +699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,6 +744,9 @@
           <http://model.geneontology.org/CHEBI_15378_PROTOHEMEFERROCHELAT-RXN>
 ] .
 
+<http://model.geneontology.org/reaction_RXN0-1461_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/CHEBI_57308_UROGENDECARBOX-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57308> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -753,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -761,16 +764,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_RXN0-1461_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_UROGENDECARBOX-RXN_BFO_0000050_HEME-BIOSYNTHESIS-II/HEME-BIOSYNTHESIS-II_SGD_HEME-BIOSYNTHESIS-II> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "heme <i>b</i> biosynthesis I (aerobic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1360,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,7 +1377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,7 +1397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1448,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,7 +1491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEME-BIOSYNTHESIS-II" ;
         <http://purl.org/pav/providedBy>

--- a/models/HEXPPSYN-PWY-2-HEXPPSYN-PWY-2.ttl
+++ b/models/HEXPPSYN-PWY-2-HEXPPSYN-PWY-2.ttl
@@ -4,27 +4,22 @@
 <http://purl.obolibrary.org/obo/CHEBI_58057>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:HEXPPSYN-PWY-2" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_HEXPPSYN-PWY-2/HEXPPSYN-PWY-2_SGD_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/RXN3O-9805>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -43,13 +38,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2BiochemicalReaction56080> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000050_HEXPPSYN-PWY-2/HEXPPSYN-PWY-2_SGD_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/GPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004161> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -70,13 +76,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2BiochemicalReaction56207> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -87,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,35 +123,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002234_CHEBI_57907_RXN-8813_SGD_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +204,7 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/CHEBI_29888_GPPSYN-RXN>
+<http://model.geneontology.org/CHEBI_29888_RXN-8813>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -207,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,28 +226,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_29888_RXN-8813>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56132> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,13 +263,28 @@
 <http://purl.obolibrary.org/obo/CHEBI_57907>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/HEXPPSYN-PWY-2/HEXPPSYN-PWY-2>
+        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hexaprenyl diphosphate biosynthesis" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+                "HEXPPSYN-PWY-2" ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Pathway" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,28 +295,13 @@
           <http://model.geneontology.org/CHEBI_29888_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/HEXPPSYN-PWY-2/HEXPPSYN-PWY-2>
-        a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hexaprenyl diphosphate biosynthesis" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-                "HEXPPSYN-PWY-2" ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Pathway" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002233_CHEBI_58756_RXN-8813_SGD_HEXPPSYN-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -543,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,7 +657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "hexaprenyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,17 +905,6 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:HEXPPSYN-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -924,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,6 +924,17 @@
           <http://model.geneontology.org/reaction_GPPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FPPSYN-RXN_BFO_0000066_reaction_FPPSYN-RXN_location_lociGO_0005829_null_HEXPPSYN-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:HEXPPSYN-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'isopentenyl diphosphate + (2<i>E</i>,6<i>E</i>)-farnesyl diphosphate &rarr; geranylgeranyl diphosphate + diphosphate' 'null' 'geranylgeranyl diphosphate + isopentenyl diphosphate &rarr; geranylfarnesyl diphosphate + diphosphate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1180,7 +1180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1213,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1291,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1483,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1514,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1531,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,6 +1601,23 @@
           <http://model.geneontology.org/FPPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_128769_RXN3O-9805>
@@ -1612,30 +1629,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HEXPPSYN-PWY-2SmallMolecule56107> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002234_CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN_SGD_HEXPPSYN-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_58756_FARNESYLTRANSTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58756> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1660,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1704,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HEXPPSYN-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1758,7 +1758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HEXPPSYN-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/HISTSYN-PWY-HISTSYN-PWY.ttl
+++ b/models/HISTSYN-PWY-HISTSYN-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,30 +403,30 @@
           <http://model.geneontology.org/CHEBI_15377_HISTALDEHYD-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_null_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://model.geneontology.org/reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002233_CHEBI_59457_HISTCYCLOHYD-RXN_SGD_HISTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+<http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000066_reaction_HISTAMINOTRANS-RXN_location_lociGO_0005829_null_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YCL030C-MONOMER_HISTCYCLOHYD-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000535> ;
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -888,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,28 +1286,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_HISTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_59457_HISTCYCLOHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59457> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1318,13 +1301,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24384> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HISTCYCLOHYD-RXN_RO_0002234_CHEBI_58435_HISTCYCLOHYD-RXN_SGD_HISTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HISTCYCLOHYD-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58435_HISTCYCLOHYD-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58525_PRIBFAICARPISOM-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58525> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1335,7 +1335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1349,7 +1349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1379,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,23 +1466,6 @@
           <http://model.geneontology.org/HISTIDPHOS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57699_HISTIDPHOS-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_HISTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_GLUTAMIDOTRANS-RXN>
@@ -1494,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1502,12 +1485,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HISTALDEHYD-RXN_RO_0002333_YCL030C-MONOMER_HISTALDEHYD-RXN_controller_SGD_HISTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HISTALDEHYD-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YCL030C-MONOMER_HISTALDEHYD-RXN_controller>
+] .
+
 <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_RO_0002233_CHEBI_57980_HISTAMINOTRANS-RXN_SGD_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-histidine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1614,24 +1614,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_null_HISTSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_IMIDPHOSDEHYD-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -1644,22 +1636,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002234_CHEBI_29985_GLUTAMIDOTRANS-RXN_SGD_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PRIBFAICARPISOM-RXN_BFO_0000066_reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829_null_HISTSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PRIBFAICARPISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_PRIBFAICARPISOM-RXN_location_lociGO_0005829>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1667,7 +1667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1690,7 +1690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1752,8 +1752,16 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://purl.obolibrary.org/obo/GO_0004635>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_HISTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1769,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1778,16 +1786,11 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ATPPHOSPHORIBOSYLTRANS-RXN_RO_0002234_CHEBI_58017_ATPPHOSPHORIBOSYLTRANS-RXN_SGD_HISTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004635>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.obolibrary.org/obo/CHEBI_57540>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_HISTOLDEHYD-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1798,16 +1801,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24333> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_57540>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_73200_ATPPHOSPHORIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_73200> ;
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1847,7 +1847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1866,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1878,7 +1878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1940,7 +1940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2011,7 +2011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2027,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2038,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2053,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2067,7 +2067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2115,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2130,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2143,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2182,7 +2182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2228,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,7 +2273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2284,7 +2284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2309,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2337,13 +2337,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24632> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57766_HISTAMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57766> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2354,24 +2365,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYSmallMolecule24522> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_RO_0002333_YBR248C-MONOMER_GLUTAMIDOTRANS-RXN_controller_SGD_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29888_HISTPRATPHYD-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2416,7 +2416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2433,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2467,7 +2467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2489,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2500,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2511,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2526,7 +2526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2546,7 +2546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2562,7 +2562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2574,7 +2574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2610,7 +2610,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HISTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTIDPHOS-RXN_SGD_HISTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2621,20 +2632,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002233_CHEBI_57980_HISTIDPHOS-RXN_SGD_HISTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2643,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2655,7 +2655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2700,7 +2700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2714,7 +2714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2733,7 +2733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2749,7 +2749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2778,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2814,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2829,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2844,7 +2844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2860,7 +2860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2876,7 +2876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2888,7 +2888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2899,28 +2899,13 @@
           <http://model.geneontology.org/YFR025C-MONOMER_HISTIDPHOS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005728> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "imidazole glycerol-phosphate dehydratase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYProtein24529> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HISTAMINOTRANS-RXN_BFO_0000050_HISTSYN-PWY/HISTSYN-PWY_SGD_HISTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2931,12 +2916,27 @@
           <http://model.geneontology.org/HISTSYN-PWY/HISTSYN-PWY>
 ] .
 
+<http://model.geneontology.org/YOR202W-MONOMER_IMIDPHOSDEHYD-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005728> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "imidazole glycerol-phosphate dehydratase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HISTSYN-PWYProtein24529> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/ev_w_id_HISTPRATPHYD-RXN_RO_0002233_CHEBI_73200_HISTPRATPHYD-RXN_SGD_HISTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2948,7 +2948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2971,7 +2971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2985,7 +2985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3012,7 +3012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3024,7 +3024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3044,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3058,7 +3058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3074,7 +3074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3089,7 +3089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3109,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3127,7 +3127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3144,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3157,7 +3157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3168,7 +3168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3186,7 +3186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,7 +3205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3222,7 +3222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3256,7 +3256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3270,7 +3270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3297,7 +3297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3308,7 +3308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3322,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3334,7 +3334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3364,7 +3364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3400,7 +3400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3422,7 +3422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3438,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3453,7 +3453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3478,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3491,7 +3491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3509,7 +3509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3525,7 +3525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3545,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3559,7 +3559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3575,7 +3575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3598,7 +3598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3614,7 +3614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3631,7 +3631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3650,7 +3650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3665,7 +3665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3689,7 +3689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HISTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3703,7 +3703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HISTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/HOMOCYS-CYS-CONVERT-HOMOCYS-CYS-CONVERT.ttl
+++ b/models/HOMOCYS-CYS-CONVERT-HOMOCYS-CYS-CONVERT.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,16 +102,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -119,7 +111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,8 +122,27 @@
           <http://model.geneontology.org/CHEBI_28938_CYSTATHIONINE-BETA-LYASE-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_CYSTAGLY-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-721_RO_0002234_CHEBI_58161_RXN-721_SGD_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -139,7 +150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,17 +161,6 @@
           <http://model.geneontology.org/CHEBI_16134_CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002333_YAL012W-MONOMER_CYSTAGLY-RXN_controller_SGD_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,12 +756,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_HOMOCYS-CYS-CONVERT>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,12 +786,12 @@
           <http://model.geneontology.org/CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_15377_CYSTAGLY-RXN_SGD_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_15361_CYSTATHIONINE-BETA-LYASE-RXN_SGD_HOMOCYS-CYS-CONVERT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -812,17 +812,6 @@
 <http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_HOMOCYS-CYS-CONVERT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -831,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,12 +831,23 @@
           <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002233_CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_HOMOCYS-CYS-CONVERT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_35235_CYSTAGLY-RXN_SGD_HOMOCYS-CYS-CONVERT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -875,7 +875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -892,7 +892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1095,7 +1095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "homocysteine and cysteine interconversion - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1143,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1163,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1174,21 +1174,6 @@
           <http://model.geneontology.org/CHEBI_35235_CYSTAGLY-RXN>
 ] .
 
-<http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
-        a       <http://identifiers.org/sgd/S000003891> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "cystathionine gamma-synthase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTProtein61185> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_58199_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1198,13 +1183,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTSmallMolecule61088> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YJR130C-MONOMER_RXN-721_controller>
+        a       <http://identifiers.org/sgd/S000003891> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "cystathionine gamma-synthase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=HOMOCYS-CYS-CONVERTProtein61185> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_30089_RXN-721>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30089> ;
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1272,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1455,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,7 +1469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1486,7 +1486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,7 +1533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1549,7 +1549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1624,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYS-CYS-CONVERT" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1655,7 +1655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYS-CYS-CONVERT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/HOMOCYSDEGR-PWY-1-HOMOCYSDEGR-PWY-1.ttl
+++ b/models/HOMOCYSDEGR-PWY-1-HOMOCYSDEGR-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-cysteine biosynthesis III (from L-homocysteine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,24 +203,13 @@
 <http://purl.obolibrary.org/obo/GO_0004123>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTAGLY-RXN_SGD_HOMOCYSDEGR-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOCYSDEGR-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTAGLY-RXN_SGD_HOMOCYSDEGR-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,6 +220,17 @@
           <http://model.geneontology.org/CHEBI_58161_CYSTAGLY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002233_CHEBI_58161_CYSTAGLY-RXN_SGD_HOMOCYSDEGR-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOCYSDEGR-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_33384_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33384> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -240,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOCYSDEGR-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/HOMOSER-THRESYN-PWY-HOMOSER-THRESYN-PWY.ttl
+++ b/models/HOMOSER-THRESYN-PWY-HOMOSER-THRESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSER-THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSER-THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/HOMOSERSYN-PWY-HOMOSERSYN-PWY.ttl
+++ b/models/HOMOSERSYN-PWY-HOMOSERSYN-PWY.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homoserine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,18 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +227,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,23 +267,23 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002411_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002333_YER052C-MONOMER_ASPARTATEKIN-RXN_controller_SGD_HOMOSERSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002411_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,24 +777,13 @@
           <http://model.geneontology.org/ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:HOMOSERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,6 +794,17 @@
           <http://model.geneontology.org/CHEBI_57783_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_13390_HOMOSERDEHYDROG-RXN_SGD_HOMOSERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:HOMOSERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000002565>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -993,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:HOMOSERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,16 +1181,13 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000003900>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002234_CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_HOMOSERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,6 +1197,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
+
+<http://identifiers.org/sgd/S000003900>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1232,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=HOMOSERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/ILEUSYN-PWY-1-ILEUSYN-PWY-1.ttl
+++ b/models/ILEUSYN-PWY-1-ILEUSYN-PWY-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -559,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -702,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -763,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -948,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -964,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1163,7 +1163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1301,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1385,7 +1385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1405,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1489,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-isoleucine biosynthesis I (from threonine) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1506,7 +1506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1522,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1565,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1616,7 +1616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,7 +1633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1733,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1747,7 +1747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1763,7 +1763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1791,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1822,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1838,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1856,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1884,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1895,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1910,7 +1910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,7 +1927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1950,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=ILEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:ILEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/IPPSYN-PWY-IPPSYN-PWY.ttl
+++ b/models/IPPSYN-PWY-IPPSYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -515,20 +515,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_null_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -541,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,12 +538,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002413_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_null_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ACETYL-COA-ACETYLTRANSFER-RXN_RO_0002234_CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN_SGD_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -965,7 +965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1311,7 +1311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1334,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1374,7 +1374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1388,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1400,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1434,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1480,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,12 +1508,23 @@
           <http://model.geneontology.org/CHEBI_58146_MEVALONATE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_IPPSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002233_CHEBI_57287_1.1.1.34-RXN_SGD_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,17 +1547,6 @@
           <http://model.geneontology.org/IPPSYN-PWY/IPPSYN-PWY>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002234_CHEBI_43074_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_SGD_IPPSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_128769>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1556,7 +1556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,7 +1573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1620,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1634,7 +1634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1669,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1685,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1710,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1858,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1935,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1961,7 +1961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +1978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,7 +1998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2051,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2069,7 +2069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2085,7 +2085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2101,7 +2101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2115,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2131,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2146,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2163,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2180,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2214,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2248,6 +2248,20 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002411_MEVALONATE-KINASE-RXN_SGD_IPPSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:IPPSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
 <http://model.geneontology.org/CHEBI_36464_MEVALONATE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36464> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2257,7 +2271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2265,26 +2279,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/reaction_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_1.1.1.34-RXN_RO_0002411_MEVALONATE-KINASE-RXN_SGD_IPPSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:IPPSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHOMEVALONATE-KINASE-RXN_RO_0002413_DIPHOSPHOMEVALONTE-DECARBOXYLASE-RXN_null_IPPSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2295,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2335,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2355,7 +2355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2368,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2380,7 +2380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2427,7 +2427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2440,7 +2440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2455,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2469,7 +2469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2485,7 +2485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2496,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2513,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2530,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2541,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2553,7 +2553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2570,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2590,7 +2590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2608,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2627,7 +2627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2638,7 +2638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2655,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2667,7 +2667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,25 +2676,6 @@
           <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_IPPSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
@@ -2706,7 +2687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2714,12 +2695,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_IPPSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002333_YML126C-MONOMER_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_controller_SGD_IPPSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2737,7 +2737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2750,7 +2750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=IPPSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:IPPSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/LEUSYN-PWY-1-LEUSYN-PWY-1.ttl
+++ b/models/LEUSYN-PWY-1-LEUSYN-PWY-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,43 +37,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1SmallMolecule49773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005634> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "alpha-isopropylmalate synthase, minor isozyme" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1Protein49809> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -81,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,13 +60,45 @@
           <http://model.geneontology.org/CHEBI_57945_RXN-13158>
 ] .
 
+<http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005634> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "alpha-isopropylmalate synthase, minor isozyme" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1Protein49809> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/CHEBI_15377_2-ISOPROPYLMALATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LEUSYN-PWY-1SmallMolecule49773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_17865_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -184,13 +184,13 @@
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_1178_2-ISOPROPYLMALATESYN-RXN> , <http://model.geneontology.org/CHEBI_57287_2-ISOPROPYLMALATESYN-RXN> , <http://model.geneontology.org/CHEBI_15378_2-ISOPROPYLMALATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller> , <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller> ;
+                <http://model.geneontology.org/YNL104C-MONOMER_2-ISOPROPYLMALATESYN-RXN_controller> , <http://model.geneontology.org/MONOMER3O-59_2-ISOPROPYLMALATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/RXN-13163> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -802,26 +802,26 @@
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 <http://model.geneontology.org/ev_w_id_RXN-13163_RO_0002333_YGL009C-MONOMER_RXN-13163_controller_SGD_LEUSYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN-13158_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/ev_w_id_2-ISOPROPYLMALATESYN-RXN_RO_0002411_RXN-13163_SGD_LEUSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -872,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -909,7 +909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,13 +1150,24 @@
 <http://identifiers.org/sgd/S000005634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_LEUSYN-PWY-1/LEUSYN-PWY-1_SGD_LEUSYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LEUSYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_LEUSYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,17 +1177,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YHR208W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
 ] .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000050_LEUSYN-PWY-1/LEUSYN-PWY-1_SGD_LEUSYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LEUSYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-leucine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1207,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1241,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1321,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1371,7 +1371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1398,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1433,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,7 +1450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1524,7 +1524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LEUSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LEUSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/LIPASYN-PWY-1-LIPASYN-PWY-1.ttl
+++ b/models/LIPASYN-PWY-1-LIPASYN-PWY-1.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,7 +76,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,6 +110,17 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_554b2f09-17a7-4a60-bb23-cbb62af7265b_3.1.4.11-RXN_SGD_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_17815_PHOSPHOLIPASE-C-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17815> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -119,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -299,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -341,11 +352,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN_SGD_LIPASYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_554b2f09-17a7-4a60-bb23-cbb62af7265b_3.1.4.11-RXN_SGD_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +364,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN>
+          <http://model.geneontology.org/554b2f09-17a7-4a60-bb23-cbb62af7265b_3.1.4.11-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004435>
@@ -364,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -379,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -398,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -466,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -568,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -585,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -694,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -717,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,24 +736,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002333_YKR031C-MONOMER_PHOSCHOL-RXN_controller_SGD_LIPASYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOLIPASE-C-RXN_RO_0002233_CHEBI_16110_PHOSPHOLIPASE-C-RXN_SGD_LIPASYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,6 +753,17 @@
           <http://model.geneontology.org/CHEBI_16110_PHOSPHOLIPASE-C-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002333_YKR031C-MONOMER_PHOSCHOL-RXN_controller_SGD_LIPASYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LIPASYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -761,7 +772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -802,6 +813,23 @@
 
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/554b2f09-17a7-4a60-bb23-cbb62af7265b_3.1.4.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000006189>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -818,7 +846,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/554b2f09-17a7-4a60-bb23-cbb62af7265b_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -828,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -845,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -865,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipids degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +1019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,17 +1069,6 @@
           <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN_SGD_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -1060,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,7 +1164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1195,17 +1212,6 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_LIPASYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LIPASYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1214,7 +1220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,22 +1231,16 @@
           <http://model.geneontology.org/reaction_PHOSPHOLIPASE-C-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/329f05ee-2ce4-4ed3-aa8e-0718b59bc1f2_3.1.4.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+<http://model.geneontology.org/ev_w_id_PHOSCHOL-RXN_RO_0002233_CHEBI_16110_PHOSCHOL-RXN_SGD_LIPASYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LIPASYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LIPASYN-PWY-1SmallMolecule26368> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1248,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LIPASYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/LYSDEGII-PWY-LYSDEGII-PWY.ttl
+++ b/models/LYSDEGII-PWY-LYSDEGII-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -119,7 +119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -418,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,7 +747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,7 +826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1258,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1291,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1465,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1522,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,7 +1575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,13 +1673,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSDEGII-PWYSmallMolecule26417> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_79192>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57540_KETAMID-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1690,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1698,15 +1701,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_79192>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_BFO_0000066_reaction_GLUTARATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829_null_LYSDEGII-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,7 +1779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1802,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1846,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1861,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1875,7 +1875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1894,7 +1894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1910,7 +1910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1922,7 +1922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1942,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1966,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1997,7 +1997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2034,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2059,7 +2059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2072,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2106,7 +2106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2122,7 +2122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2133,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2147,7 +2147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2158,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSDEGII-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSDEGII-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/LYSINE-AMINOAD-PWY-2-LYSINE-AMINOAD-PWY-2.ttl
+++ b/models/LYSINE-AMINOAD-PWY-2-LYSINE-AMINOAD-PWY-2.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -563,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -730,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -780,7 +780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -792,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -941,7 +941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,7 +1262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,13 +1304,24 @@
           <http://model.geneontology.org/LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002411_1.5.1.7-RXN_SGD_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_BFO_0000050_LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2_SGD_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,23 +1332,12 @@
           <http://model.geneontology.org/LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-127_RO_0002411_1.5.1.7-RXN_SGD_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_58672_RXN3O-9808_SGD_LYSINE-AMINOAD-PWY-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1377,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,7 +1421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,7 +1438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,7 +1455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-lysine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1544,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1555,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1573,7 +1573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1589,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1621,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1666,7 +1666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1707,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1719,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,7 +1739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1771,7 +1771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1851,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1863,7 +1863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1880,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1891,12 +1891,31 @@
           <http://model.geneontology.org/LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '2-oxoglutarate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>R</i>)-homocitrate + coenzyme A + H<SUP>+</SUP>' 'null' '(2<i>R</i>)-homocitrate &rarr; <i>cis</i>-homoaconitate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002413_RXN3O-1983_null_LYSINE-AMINOAD-PWY-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOCITRATE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-1983>
+] .
+
 <http://model.geneontology.org/ev_w_id_HOMOACONITATE-HYDRATASE-RXN_BFO_0000050_LYSINE-AMINOAD-PWY-2/LYSINE-AMINOAD-PWY-2_SGD_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1911,32 +1930,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73607> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '2-oxoglutarate + acetyl-CoA + H<sub>2</sub>O &rarr; (2<i>R</i>)-homocitrate + coenzyme A + H<SUP>+</SUP>' 'null' '(2<i>R</i>)-homocitrate &rarr; <i>cis</i>-homoaconitate + H<sub>2</sub>O' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCITRATE-SYNTHASE-RXN_RO_0002413_RXN3O-1983_null_LYSINE-AMINOAD-PWY-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCITRATE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-1983>
-] .
 
 <http://model.geneontology.org/YIL094C-MONOMER_RXN-7970_controller>
         a       <http://identifiers.org/sgd/S000001356> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1945,7 +1945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1958,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -1973,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1987,7 +1987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2006,7 +2006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2054,7 +2054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2077,7 +2077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2094,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2110,7 +2110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2121,7 +2121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2135,7 +2135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2152,7 +2152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2169,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2199,7 +2199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2215,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2226,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2252,7 +2252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2286,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,7 +2320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2339,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2364,7 +2364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2378,7 +2378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2408,7 +2408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2423,7 +2423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2436,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2448,7 +2448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2459,24 +2459,13 @@
           <http://model.geneontology.org/CHEBI_57499_2-AMINOADIPATE-AMINOTRANSFERASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002333_YIR034C-MONOMER_1.5.1.7-RXN_controller_SGD_LYSINE-AMINOAD-PWY-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002233_CHEBI_58672_RXN3O-9808_SGD_LYSINE-AMINOAD-PWY-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,12 +2476,23 @@
           <http://model.geneontology.org/CHEBI_58672_RXN3O-9808>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.7-RXN_RO_0002333_YIR034C-MONOMER_1.5.1.7-RXN_controller_SGD_LYSINE-AMINOAD-PWY-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9808_RO_0002333_YBR115C-MONOMER_RXN3O-9808_controller_SGD_LYSINE-AMINOAD-PWY-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2517,7 +2517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2537,7 +2537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2554,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2570,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2586,7 +2586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2597,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2612,24 +2612,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2SmallMolecule73515> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_LYSINE-AMINOAD-PWY-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:LYSINE-AMINOAD-PWY-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YBR115C-MONOMER_RXN3O-9808_controller>
         a       <http://identifiers.org/sgd/S000000319> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2638,13 +2627,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=LYSINE-AMINOAD-PWY-2Protein73565> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7970_RO_0002234_CHEBI_16526_RXN-7970_SGD_LYSINE-AMINOAD-PWY-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:LYSINE-AMINOAD-PWY-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_32551_1.5.1.7-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32551> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2655,7 +2655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2672,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2689,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2718,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2738,7 +2738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2758,7 +2758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2772,7 +2772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2793,7 +2793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2809,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2827,7 +2827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2844,7 +2844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2861,7 +2861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2878,7 +2878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2894,7 +2894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2909,7 +2909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2923,7 +2923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2940,7 +2940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2960,7 +2960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -2991,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3004,7 +3004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3018,7 +3018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3029,7 +3029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3041,7 +3041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3061,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3078,7 +3078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3107,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3124,7 +3124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3141,7 +3141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3158,7 +3158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3177,7 +3177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3197,7 +3197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3211,7 +3211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3227,7 +3227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3241,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3252,7 +3252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3263,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:LYSINE-AMINOAD-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -3275,7 +3275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=LYSINE-AMINOAD-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/NADSYN-PWY-NADSYN-PWY.ttl
+++ b/models/NADSYN-PWY-NADSYN-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -594,7 +594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -913,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -928,7 +928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1247,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1339,7 +1339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1508,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1522,7 +1522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,7 +1542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1561,7 +1561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1616,7 +1616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1658,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,7 +1677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1739,7 +1739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1775,7 +1775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1807,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1825,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1838,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1853,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1873,7 +1873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1889,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1900,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1914,7 +1914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1981,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2024,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2064,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD <i>de novo</i> biosynthesis II (from tryptophan) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2095,7 +2095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2140,7 +2140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,7 +2160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2180,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2200,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2234,7 +2234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2254,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2267,7 +2267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2299,7 +2299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2312,7 +2312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2324,7 +2324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2340,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2368,7 +2368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2398,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2429,7 +2429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2444,7 +2444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2463,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2475,7 +2475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2494,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2510,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2537,7 +2537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2554,7 +2554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2581,7 +2581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2595,7 +2595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,7 +2612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2641,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2661,7 +2661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2680,7 +2680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,7 +2700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2717,7 +2717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2734,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2751,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2765,7 +2765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2785,7 +2785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2798,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2840,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2853,7 +2853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2867,7 +2867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2881,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2892,7 +2892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2903,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2914,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2926,7 +2926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2946,7 +2946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2963,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2994,7 +2994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3025,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3042,7 +3042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3055,7 +3055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3067,7 +3067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3090,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3105,7 +3105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3121,7 +3121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3133,7 +3133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3153,7 +3153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3173,7 +3173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3189,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3200,7 +3200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3215,7 +3215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3231,7 +3231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3269,7 +3269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3280,7 +3280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3294,7 +3294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3310,7 +3310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3329,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3343,7 +3343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3362,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3387,7 +3387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3403,7 +3403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3422,7 +3422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3440,7 +3440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3460,7 +3460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3473,7 +3473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3485,7 +3485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3504,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3516,7 +3516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3532,7 +3532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3543,7 +3543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3556,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3570,7 +3570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3597,7 +3597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3608,7 +3608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3620,7 +3620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3643,7 +3643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3670,7 +3670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3687,7 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3701,7 +3701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3721,7 +3721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3751,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3765,7 +3765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3781,7 +3781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3792,7 +3792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NADSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NADSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/NONOXIPENT-PWY-NONOXIPENT-PWY.ttl
+++ b/models/NONOXIPENT-PWY-NONOXIPENT-PWY.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -105,41 +105,13 @@
 <http://purl.obolibrary.org/obo/GO_0004802>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002411_TRANSALDOL-RXN_SGD_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_TRANSALDOL-RXN_SGD_NONOXIPENT-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/TRANSALDOL-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57483_TRANSALDOL-RXN>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YPR074C-MONOMER_1TRANSKETO-RXN_controller_SGD_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -150,6 +122,34 @@
           <http://model.geneontology.org/YPR074C-MONOMER_1TRANSKETO-RXN_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_57483_TRANSALDOL-RXN_SGD_NONOXIPENT-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/TRANSALDOL-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57483_TRANSALDOL-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002411_TRANSALDOL-RXN_SGD_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16897>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -159,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -170,23 +170,12 @@
           <http://model.geneontology.org/YOR095C-MONOMER_RIB5PISOM-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57737_1TRANSKETO-RXN_SGD_NONOXIPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002333_YBR117C-MONOMER_1TRANSKETO-RXN_controller_SGD_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -211,13 +200,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=NONOXIPENT-PWYBiochemicalReaction34335> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_57737_1TRANSKETO-RXN_SGD_NONOXIPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -273,7 +273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,9 +477,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_null_NONOXIPENT-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -492,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,23 +511,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RIBULP3EPIM-RXN_BFO_0000066_reaction_RIBULP3EPIM-RXN_location_lociGO_0005829_null_NONOXIPENT-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:NONOXIPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2TRANSKETO-RXN_BFO_0000066_reaction_2TRANSKETO-RXN_location_lociGO_0005829_null_NONOXIPENT-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,16 +565,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002333_YLR354C-MONOMER_TRANSALDOL-RXN_controller_SGD_NONOXIPENT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,6 +582,9 @@
           <http://model.geneontology.org/YLR354C-MONOMER_TRANSALDOL-RXN_controller>
 ] .
 
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://identifiers.org/sgd/S000000321>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -594,7 +594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,7 +862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (non-oxidative branch) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1109,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1166,7 +1166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1384,7 +1384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1403,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1419,7 +1419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1470,7 +1470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1504,7 +1504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1531,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1620,7 +1620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:NONOXIPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1665,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=NONOXIPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/OXIDATIVEPENT-PWY-OXIDATIVEPENT-PWY.ttl
+++ b/models/OXIDATIVEPENT-PWY-OXIDATIVEPENT-PWY.ttl
@@ -13,7 +13,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway (oxidative branch) I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,8 +432,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_OXIDATIVEPENT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:OXIDATIVEPENT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -441,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,16 +460,8 @@
           <http://model.geneontology.org/CHEBI_15377_6PGLUCONOLACT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLU6PDEHYDROG-RXN_RO_0002234_CHEBI_15378_GLU6PDEHYDROG-RXN_SGD_OXIDATIVEPENT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:OXIDATIVEPENT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1109,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:OXIDATIVEPENT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1168,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=OXIDATIVEPENT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/P4-PWY-1-P4-PWY-1.ttl
+++ b/models/P4-PWY-1-P4-PWY-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,6 +70,9 @@
 <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://purl.obolibrary.org/obo/CHEBI_29991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_57716_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57716> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -79,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,8 +90,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_29991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002411_HOMOSERKIN-RXN_SGD_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -98,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,16 +120,22 @@
           <http://model.geneontology.org/reaction_ASPAMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002411_HOMOSERKIN-RXN_SGD_P4-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/04506362-df4d-4160-b134-d982d7a2aebd_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -130,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,9 +322,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/04506362-df4d-4160-b134-d982d7a2aebd_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/10319606-6493-42d4-b775-0298619a501c_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -315,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -376,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -384,11 +401,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22_SGD_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_04506362-df4d-4160-b134-d982d7a2aebd_RXN3O-22_SGD_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,7 +413,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22>
+          <http://model.geneontology.org/04506362-df4d-4160-b134-d982d7a2aebd_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -405,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,17 +471,6 @@
           <http://model.geneontology.org/YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22_SGD_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -474,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -509,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -650,11 +656,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/10319606-6493-42d4-b775-0298619a501c_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004795>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -667,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -704,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -781,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -827,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,7 +884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -922,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -944,7 +967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -975,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1022,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1071,7 +1094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1098,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1147,7 +1170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1220,7 +1243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1251,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1265,7 +1288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1295,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,7 +1332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1356,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1374,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1387,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1402,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1415,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1430,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1443,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1464,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1478,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1509,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1546,7 +1569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1588,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1604,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1615,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1627,7 +1650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,7 +1670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1703,7 +1726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1730,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1745,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1759,7 +1782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1779,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1856,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1869,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1880,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1895,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,11 +1928,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22_SGD_P4-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_10319606-6493-42d4-b775-0298619a501c_RXN3O-22_SGD_P4-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1917,7 +1940,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22>
+          <http://model.geneontology.org/10319606-6493-42d4-b775-0298619a501c_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_P4-PWY-1>
@@ -1925,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1937,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1956,7 +1979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1989,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2000,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2086,7 +2109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2106,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2136,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2156,7 +2179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2172,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2184,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2228,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2259,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2287,7 +2310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2321,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2335,7 +2358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2352,7 +2375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2375,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2391,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2405,7 +2428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2421,7 +2444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2432,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2444,7 +2467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2462,7 +2485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2475,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2486,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2501,7 +2524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2515,23 +2538,6 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_43474_THRESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2541,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2598,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2609,7 +2615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2621,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2644,7 +2650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2664,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2684,7 +2690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2718,7 +2724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2731,7 +2737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2748,7 +2754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2778,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,7 +2798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2808,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2819,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2832,7 +2838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2849,7 +2855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2863,7 +2869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2883,7 +2889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2896,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2908,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2925,7 +2931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2941,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2953,7 +2959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2981,7 +2987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2995,7 +3001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3011,7 +3017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3038,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3055,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3077,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3095,7 +3101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3115,13 +3121,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule23967> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_04506362-df4d-4160-b134-d982d7a2aebd_RXN3O-22_SGD_P4-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3131,7 +3148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3145,7 +3162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3156,7 +3173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3167,7 +3184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3182,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3199,7 +3216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3215,7 +3232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3227,7 +3244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3243,7 +3260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3256,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3274,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3288,7 +3305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3318,7 +3335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3335,7 +3352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine and methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3352,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3365,7 +3382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3377,7 +3394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3397,7 +3414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3417,7 +3434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3433,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3444,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3458,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3473,7 +3490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3493,7 +3510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3513,7 +3530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3526,7 +3543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3539,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3553,7 +3570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3564,17 +3581,6 @@
           <http://model.geneontology.org/CHEBI_57535_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_4c1c7c0b-1f00-47ed-b61c-e468bbe237ec_RXN3O-22_SGD_P4-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:P4-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004069>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3583,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3594,7 +3600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3612,7 +3618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3625,7 +3631,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:P4-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_10319606-6493-42d4-b775-0298619a501c_RXN3O-22_SGD_P4-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3637,7 +3654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3653,7 +3670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3668,7 +3685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3681,7 +3698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3698,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3714,7 +3731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3725,7 +3742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3737,7 +3754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3748,29 +3765,12 @@
           <http://model.geneontology.org/YKL106W-MONOMER_ASPAMINOTRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/17f1bb4e-01c2-4ff0-ace2-a12bd5c83a71_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=P4-PWY-1SmallMolecule24122> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_P4-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3781,7 +3781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3792,7 +3792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3804,7 +3804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3821,7 +3821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3837,7 +3837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3849,7 +3849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3866,7 +3866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3882,7 +3882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3896,7 +3896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3907,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3925,7 +3925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3942,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3956,7 +3956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3972,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3987,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -4000,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4015,7 +4015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4031,7 +4031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:P4-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4043,7 +4043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=P4-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PANTOSYN2-PWY-PANTOSYN2-PWY.ttl
+++ b/models/PANTOSYN2-PWY-PANTOSYN2-PWY.ttl
@@ -1,10 +1,21 @@
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_7aade4d3-98e5-47b4-b091-7a1ac4df636d_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2-DEHYDROPANTOATE-REDUCT-RXN_RO_0002233_CHEBI_58349_2-DEHYDROPANTOATE-REDUCT-RXN_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -102,11 +113,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_7aade4d3-98e5-47b4-b091-7a1ac4df636d_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -114,7 +125,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/7aade4d3-98e5-47b4-b091-7a1ac4df636d_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004595>
@@ -126,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -256,9 +267,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/1833d84d-9d04-4455-88bf-730c31a4cbac_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11851_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_15377_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
+                <http://model.geneontology.org/CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> , <http://model.geneontology.org/7aade4d3-98e5-47b4-b091-7a1ac4df636d_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-90_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -266,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,18 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -772,7 +772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,7 +788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,23 +828,6 @@
           <http://model.geneontology.org/CHEBI_16526_P-PANTOCYSDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -853,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,7 +914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,11 +1064,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/7aade4d3-98e5-47b4-b091-7a1ac4df636d_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule25018> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1093,7 +1093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,12 +1166,23 @@
 <http://purl.obolibrary.org/obo/GO_0004633>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_1833d84d-9d04-4455-88bf-730c31a4cbac_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_CHEBI_11561_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1188,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1244,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1258,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1295,7 +1306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,7 +1328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1344,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1379,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1418,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1482,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1494,7 +1505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1554,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1565,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1588,7 +1599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pantothenate and coenzyme A biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1638,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1649,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1660,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1675,7 +1686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1689,7 +1700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1722,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1739,7 +1750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,7 +1784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,23 +1795,23 @@
           <http://model.geneontology.org/CHEBI_456216_PANTOTHENATE-KIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_P-PANTOCYSDECARB-RXN_RO_0002333_MONOMER3O-317_P-PANTOCYSDECARB-RXN_controller_SGD_PANTOSYN2-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PANTOSYN2-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-PROPANAL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_3-PROPANAL-DEHYDROGENASE-RXN_SGD_PANTOSYN2-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1822,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1833,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1893,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1910,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1926,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1941,7 +1952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2004,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2015,7 +2026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2030,7 +2041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2043,7 +2054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2058,7 +2069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2094,7 +2105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2105,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2119,7 +2130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2136,7 +2147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,7 +2170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2179,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2196,7 +2207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2213,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2226,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2238,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2254,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2266,7 +2277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,7 +2294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2300,7 +2311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2337,7 +2348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2351,7 +2362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2369,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2389,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,7 +2413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2414,7 +2425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2431,7 +2442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2447,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2458,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2472,7 +2483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2485,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2502,7 +2513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,7 +2533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2530,23 +2541,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002234_303b2964-6e12-40ce-b030-b7a90a91748c_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PANTOSYN2-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_P-PANTOCYSLIG-RXN_RO_0002234_CHEBI_15378_P-PANTOCYSLIG-RXN_SGD_PANTOSYN2-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2558,7 +2558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2574,7 +2574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2586,7 +2586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2602,11 +2602,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/1833d84d-9d04-4455-88bf-730c31a4cbac_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/3-PROPANAL-DEHYDROGENASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004029> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2627,7 +2644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2643,7 +2660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2655,7 +2672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2671,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2706,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2729,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2756,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2773,7 +2790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2787,7 +2804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2803,7 +2820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2817,7 +2834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,7 +2859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,7 +2875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2873,7 +2890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2890,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2903,7 +2920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2914,7 +2931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2928,7 +2945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2944,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2959,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2969,11 +2986,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
+          <http://model.geneontology.org/ev_w_id_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_RO_0002233_1833d84d-9d04-4455-88bf-730c31a4cbac_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN_SGD_PANTOSYN2-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2981,7 +2998,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
+          <http://model.geneontology.org/1833d84d-9d04-4455-88bf-730c31a4cbac_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/date>
@@ -2996,7 +3013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3013,7 +3030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3033,7 +3050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3049,7 +3066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3067,7 +3084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3084,7 +3101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3103,7 +3120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3114,7 +3131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3126,7 +3143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3143,7 +3160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3159,7 +3176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3174,7 +3191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3188,7 +3205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3204,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3219,7 +3236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3232,7 +3249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3244,7 +3261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3260,7 +3277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3272,7 +3289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3292,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3305,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3316,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3330,7 +3347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,7 +3367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3361,23 +3378,6 @@
 <http://purl.obolibrary.org/obo/GO_0003864>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/7b9ff20c-e115-40cb-bc00-a7e68bbcfdcb_3-CH3-2-OXOBUTANOATE-OH-CH3-XFER-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PANTOSYN2-PWYSmallMolecule24983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation '(<i>R</i>)-pantothenate + ATP &rarr; (<i>R</i>)-4'-phosphopantothenate + ADP + H<SUP>+</SUP>' 'null' '(<i>R</i>)-4'-phosphopantothenate + L-cysteine + CTP &rarr; (R)-4'-phosphopantothenoyl-L-cysteine + CMP + diphosphate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -3386,7 +3386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3403,7 +3403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3423,7 +3423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3436,7 +3436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3451,7 +3451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3468,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3485,7 +3485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3498,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3516,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3530,7 +3530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3563,7 +3563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3576,7 +3576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3587,7 +3587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3602,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3619,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3636,7 +3636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3653,7 +3653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3669,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3687,7 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3702,7 +3702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3716,7 +3716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3732,7 +3732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3746,7 +3746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3758,7 +3758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3777,7 +3777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3792,7 +3792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3808,7 +3808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3820,7 +3820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3836,7 +3836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3848,7 +3848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3864,7 +3864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3879,7 +3879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3893,7 +3893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3912,7 +3912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3927,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3941,7 +3941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3964,7 +3964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3984,7 +3984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4000,7 +4000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4012,7 +4012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4031,7 +4031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4043,7 +4043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4059,7 +4059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4071,7 +4071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4091,7 +4091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4108,7 +4108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4121,7 +4121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4136,7 +4136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4152,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4167,7 +4167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4184,7 +4184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4197,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4208,7 +4208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4222,7 +4222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4239,7 +4239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4255,7 +4255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4269,7 +4269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4292,7 +4292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4309,7 +4309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4327,7 +4327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4354,7 +4354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4370,7 +4370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4384,7 +4384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PANTOSYN2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PANTOSYN2-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PENTOSE-P-PWY-PENTOSE-P-PWY.ttl
+++ b/models/PENTOSE-P-PWY-PENTOSE-P-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1068,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1107,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1181,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1345,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1384,7 +1384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1412,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1476,17 +1476,6 @@
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_TRANSALDOL-RXN_SGD_PENTOSE-P-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PENTOSE-P-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57955_GLU6PDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57955> ;
@@ -1497,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1505,13 +1494,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_TRANSALDOL-RXN_RO_0002233_CHEBI_59776_TRANSALDOL-RXN_SGD_PENTOSE-P-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PENTOSE-P-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1TRANSKETO-RXN_RO_0002234_CHEBI_78346_1TRANSKETO-RXN_SGD_PENTOSE-P-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1577,7 +1577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1605,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,7 +1619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1652,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1667,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1763,7 +1763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,7 +1828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1856,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1906,7 +1906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,7 +1919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1931,7 +1931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,7 +1948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,7 +1965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,7 +1985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2005,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2018,7 +2018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2032,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2046,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2057,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +2071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2116,7 +2116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2133,7 +2133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2149,7 +2149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2175,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2189,7 +2189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2206,7 +2206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2222,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2233,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2247,7 +2247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2265,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2282,7 +2282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2295,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2310,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2323,7 +2323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2335,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2397,7 +2397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2422,7 +2422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2436,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2467,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2481,7 +2481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2498,7 +2498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2514,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2529,7 +2529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2543,7 +2543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2559,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2597,7 +2597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2611,7 +2611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2630,7 +2630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2652,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pentose phosphate pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2685,7 +2685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2696,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2711,7 +2711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2727,7 +2727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2741,7 +2741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2774,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2789,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2803,7 +2803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2823,7 +2823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2840,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2853,7 +2853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PENTOSE-P-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PENTOSE-P-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PERIPLASMA-NAD-DEGRADATION-PERIPLASMA-NAD-DEGRADATION.ttl
+++ b/models/PERIPLASMA-NAD-DEGRADATION-PERIPLASMA-NAD-DEGRADATION.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "periplasmic NAD degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,13 +329,24 @@
           <http://model.geneontology.org/CHEBI_456215_NADPYROPHOSPHAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_PERIPLASMA-NAD-DEGRADATION>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMP-DEPHOSPHORYLATION-RXN_RO_0002233_CHEBI_15377_AMP-DEPHOSPHORYLATION-RXN_SGD_PERIPLASMA-NAD-DEGRADATION> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,18 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NADPYROPHOSPHAT-RXN_RO_0002234_CHEBI_15378_NADPYROPHOSPHAT-RXN_SGD_PERIPLASMA-NAD-DEGRADATION>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PERIPLASMA-NAD-DEGRADATION" ;
         <http://purl.org/pav/providedBy>

--- a/models/PHOS-PWY-PHOS-PWY.ttl
+++ b/models/PHOS-PWY-PHOS-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,26 +357,26 @@
           <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_29888>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_29888>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_57876_2.7.7.14-RXN_SGD_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,21 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,22 +427,19 @@
           <http://model.geneontology.org/PHOS-PWY/PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+<http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -467,11 +450,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/f1065b57-37c8-46ce-b5f6-e99952561f0f_2.1.1.17-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,7 +602,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> , <http://model.geneontology.org/42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2> ;
+                <http://model.geneontology.org/981ae858-001c-445a-aa8a-4cd4ecb28181_RXN4FS-2> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -610,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -637,7 +637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,18 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,11 +680,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_1faa2a62-e56f-43fa-bedf-3358acc86c35_PGPPHOSPHA-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +692,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN>
+          <http://model.geneontology.org/1faa2a62-e56f-43fa-bedf-3358acc86c35_PGPPHOSPHA-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_15378_PHOSPHASERSYN-RXN_SGD_PHOS-PWY>
@@ -711,18 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -836,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,12 +839,29 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN>
 ] .
 
+<http://model.geneontology.org/174b2c32-66c8-49fa-abd9-5ca50a8ffdd2_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -913,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,11 +921,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_05f76491-2ee8-4357-bec1-f4675a7bf4e6_RXN3O-349_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +933,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349>
+          <http://model.geneontology.org/05f76491-2ee8-4357-bec1-f4675a7bf4e6_RXN3O-349>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_295975>
@@ -950,6 +945,23 @@
 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CTP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38817> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -959,7 +971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -970,20 +982,20 @@
           <http://model.geneontology.org/PHOS-PWY/PHOS-PWY>
 ] .
 
-<http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_37563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/4d4f7953-5924-434a-8eb8-6f3f4c6e1819_2.7.8.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "CTP" ;
+                "a CDP-diacylglycerol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38817> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -993,7 +1005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1062,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,7 +1117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,11 +1161,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_34e87ae4-e7da-45a8-885c-e9d164a50a09_PHOSPHASERSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1173,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/34e87ae4-e7da-45a8-885c-e9d164a50a09_PHOSPHASERSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PHOS-PWY>
@@ -1169,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1226,7 +1238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1273,7 +1285,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/34e87ae4-e7da-45a8-885c-e9d164a50a09_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1283,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1293,11 +1305,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_8d841687-0f12-4512-86f3-8b446ddde064_CDPDIGLYSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1317,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/8d841687-0f12-4512-86f3-8b446ddde064_CDPDIGLYSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1314,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1351,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/8d841687-0f12-4512-86f3-8b446ddde064_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1347,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1361,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1399,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1424,11 +1436,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_54a71253-3b68-4317-abe7-628e469436e7_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1448,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/54a71253-3b68-4317-abe7-628e469436e7_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_ETHANOLAMINE-KINASE-RXN>
@@ -1448,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1463,7 +1475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,35 +1505,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1533,23 +1528,6 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -1559,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,7 +1556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1605,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,28 +1615,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39151> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1667,7 +1628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1678,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1692,7 +1653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1711,7 +1672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1748,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,14 +1723,14 @@
 <http://identifiers.org/sgd/S000003239>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_null_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PHOS-PWY" ;
+                "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1778,7 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,14 +1772,14 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002413_2.7.7.14-RXN_null_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
+                "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1830,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1844,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1859,7 +1820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1903,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1918,7 +1879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1932,7 +1893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1949,7 +1910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1980,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1993,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2007,7 +1968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2023,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +1996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2054,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2080,13 +2041,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_981ae858-001c-445a-aa8a-4cd4ecb28181_RXN4FS-2_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_64716_PGPPHOSPHA-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2111,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2123,7 +2095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2140,7 +2112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2156,11 +2128,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_9697b724-ff42-4c01-ad0c-135a57941d3b_2.1.1.71-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2140,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN>
+          <http://model.geneontology.org/9697b724-ff42-4c01-ad0c-135a57941d3b_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2177,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2210,7 +2182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2221,23 +2193,6 @@
           <http://model.geneontology.org/reaction_PHOSPHASERDECARB-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2246,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2266,7 +2221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2286,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,35 +2257,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_BFO_0000066_reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2347,7 +2285,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/f1065b57-37c8-46ce-b5f6-e99952561f0f_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2355,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2369,7 +2307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,7 +2323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2396,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2414,7 +2352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2431,7 +2369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2447,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2468,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2481,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2509,40 +2447,12 @@
 <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2554,7 +2464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2606,7 +2516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2617,11 +2527,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_f1065b57-37c8-46ce-b5f6-e99952561f0f_2.1.1.17-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2629,7 +2539,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/268b885f-58ed-4bd3-830b-277912927e37_2.1.1.17-RXN>
+          <http://model.geneontology.org/f1065b57-37c8-46ce-b5f6-e99952561f0f_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2638,7 +2548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2665,28 +2575,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/5ac096bf-6c51-4a20-8d70-4b8554656f7f_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2694,7 +2587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2711,7 +2604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2727,11 +2620,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.17-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2741,7 +2651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2752,22 +2662,22 @@
           <http://model.geneontology.org/2.7.7.15-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002333_YGR157W-MONOMER_2.1.1.17-RXN_controller_SGD_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.17-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller>
-] .
+<http://model.geneontology.org/9810a240-c2a6-4cb6-abb4-2a9cf782a1f3_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000828>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2779,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,7 +2702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2803,11 +2713,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_981ae858-001c-445a-aa8a-4cd4ecb28181_RXN4FS-2_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2815,8 +2725,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/42df60f6-08d4-489a-bdb9-6c26eb97c51b_RXN4FS-2>
+          <http://model.geneontology.org/981ae858-001c-445a-aa8a-4cd4ecb28181_RXN4FS-2>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2824,7 +2745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2835,23 +2756,12 @@
           <http://model.geneontology.org/CHEBI_64716_CARDIOLIPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_BFO_0000066_reaction_CDPDIGLYSYN-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2863,7 +2773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2879,7 +2789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2890,7 +2800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2902,7 +2812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2919,7 +2829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2939,11 +2849,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38887> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/05f76491-2ee8-4357-bec1-f4675a7bf4e6_RXN3O-349>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2959,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2972,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2983,7 +2910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2996,7 +2923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3013,7 +2940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3051,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3068,7 +2995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3076,24 +3003,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHASERSYN-RXN_null_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_295975_2.7.7.15-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3104,12 +3020,23 @@
           <http://model.geneontology.org/CHEBI_295975_2.7.7.15-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002413_PHOSPHASERSYN-RXN_null_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_BFO_0000066_reaction_2.7.7.15-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3127,7 +3054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3143,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3157,7 +3084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3177,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3194,7 +3121,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/05f76491-2ee8-4357-bec1-f4675a7bf4e6_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3202,7 +3129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3218,7 +3145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3241,7 +3168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3258,7 +3185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3286,18 +3213,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000003434>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.obolibrary.org/obo/CHEBI_58779>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000003434>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_4d4f7953-5924-434a-8eb8-6f3f4c6e1819_2.7.8.11-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_15378_2.7.7.14-RXN_SGD_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3308,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3320,7 +3258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3337,7 +3275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3355,7 +3293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3372,11 +3310,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38635> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/9697b724-ff42-4c01-ad0c-135a57941d3b_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39119> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3389,9 +3344,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/54a71253-3b68-4317-abe7-628e469436e7_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/9810a240-c2a6-4cb6-abb4-2a9cf782a1f3_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3399,7 +3354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3413,7 +3368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3429,7 +3384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3454,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3471,7 +3426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3485,7 +3440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3502,7 +3457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3516,6 +3471,9 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/ECO_0000313>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_295975_2.7.7.15-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3525,7 +3483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3533,8 +3491,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/981ae858-001c-445a-aa8a-4cd4ecb28181_RXN4FS-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_54a71253-3b68-4317-abe7-628e469436e7_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3542,7 +3525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3558,7 +3541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3569,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3583,7 +3566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3594,7 +3577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3606,7 +3589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3626,7 +3609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3640,7 +3623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3654,6 +3637,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_64716>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_1faa2a62-e56f-43fa-bedf-3358acc86c35_PGPPHOSPHA-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29888_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3663,7 +3657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3676,7 +3670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3690,7 +3684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3713,7 +3707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3730,7 +3724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3749,7 +3743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3769,7 +3763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3782,7 +3776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3793,7 +3787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3808,7 +3802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3822,7 +3816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3841,7 +3835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3860,7 +3854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3872,7 +3866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3891,7 +3885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3911,7 +3905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3924,7 +3918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3939,7 +3933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3956,7 +3950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,28 +3970,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38616> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38625> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4009,7 +3986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4028,7 +4005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4040,7 +4017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4059,7 +4036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4079,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4092,7 +4069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4106,7 +4083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4121,7 +4098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4138,7 +4115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4154,18 +4131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4183,7 +4149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4201,7 +4167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4214,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4226,7 +4192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4243,7 +4209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4259,7 +4225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4274,7 +4240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4287,7 +4253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4298,28 +4264,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_2.1.1.17-RXN_SGD_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.17-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_RXN-5781_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4328,6 +4277,23 @@
           <http://model.geneontology.org/RXN-5781> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_58779_RXN-5781>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_16038_2.1.1.17-RXN_SGD_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.17-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN>
 ] .
 
 <http://model.geneontology.org/2.7.7.14-RXN>
@@ -4349,7 +4315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4364,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4377,7 +4343,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_9810a240-c2a6-4cb6-abb4-2a9cf782a1f3_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4392,7 +4369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4406,23 +4383,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4433,18 +4399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4455,7 +4410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4467,7 +4422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4483,7 +4438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4495,7 +4450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4515,7 +4470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4531,7 +4486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4542,7 +4497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4553,7 +4508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4564,7 +4519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4576,7 +4531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4593,7 +4548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4609,7 +4564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4627,7 +4582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4642,7 +4597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4656,7 +4611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4676,7 +4631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4693,7 +4648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4709,7 +4664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4723,7 +4678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4741,7 +4696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4757,7 +4712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4768,7 +4723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4786,7 +4741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4801,7 +4756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4814,7 +4769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4826,7 +4781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4842,7 +4797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4857,7 +4812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4876,7 +4831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4895,7 +4850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4911,7 +4866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4922,18 +4877,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/8d841687-0f12-4512-86f3-8b446ddde064_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000066_reaction_RXN-5781_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4947,7 +4919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4964,7 +4936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4974,17 +4946,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16110_RXN4FS-2>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004123>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4998,7 +4959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5014,7 +4975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5025,7 +4986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5033,11 +4994,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_9810a240-c2a6-4cb6-abb4-2a9cf782a1f3_PHOSPHAGLYPSYN-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5045,7 +5006,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9fe9af38-c937-4c87-a726-ce92d247181c_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/9810a240-c2a6-4cb6-abb4-2a9cf782a1f3_PHOSPHAGLYPSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5054,7 +5015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5073,7 +5034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5090,7 +5051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5106,18 +5067,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/54a71253-3b68-4317-abe7-628e469436e7_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_456216_ETHANOLAMINE-KINASE-RXN_SGD_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5132,7 +5110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5145,7 +5123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5156,7 +5134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5164,23 +5142,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_17268>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARDIOLIPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -5191,11 +5152,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38662> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARDIOLIPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
+] .
+
+<http://model.geneontology.org/34e87ae4-e7da-45a8-885c-e9d164a50a09_PHOSPHASERSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -5208,7 +5203,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/4d4f7953-5924-434a-8eb8-6f3f4c6e1819_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5216,7 +5211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5237,7 +5232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5250,7 +5245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5259,23 +5254,29 @@
 <http://identifiers.org/sgd/S000003834>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/1faa2a62-e56f-43fa-bedf-3358acc86c35_PGPPHOSPHA-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39003> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5287,7 +5288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5307,7 +5308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidic acid and phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5324,7 +5325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5346,7 +5347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5362,7 +5363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5373,7 +5374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5387,7 +5388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5399,7 +5400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5415,7 +5416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5433,7 +5434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5450,7 +5451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5461,22 +5462,16 @@
           <http://model.geneontology.org/CHEBI_29888_2.7.7.15-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-5781> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_RXN-5781>
-] .
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_34e87ae4-e7da-45a8-885c-e9d164a50a09_PHOSPHASERSYN-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5484,7 +5479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5495,22 +5490,22 @@
           <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
 ] .
 
-<http://model.geneontology.org/588893fc-ba12-4c4f-b0d0-7b500ca57e8a_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-5781> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_RXN-5781>
+] .
 
 <http://model.geneontology.org/2.1.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -5521,9 +5516,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e4787e36-b8b0-45b0-8cc3-99be27584c92_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/9697b724-ff42-4c01-ad0c-135a57941d3b_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/174b2c32-66c8-49fa-abd9-5ca50a8ffdd2_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5531,7 +5526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5548,7 +5543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5567,7 +5562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5587,7 +5582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5604,7 +5599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5617,28 +5612,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PHOS-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CHOLINE-KINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5649,13 +5627,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule39044> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_295975_CHOLINE-KINASE-RXN_SGD_PHOS-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CHOLINE-KINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_295975_CHOLINE-KINASE-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/GO_0004142>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5665,7 +5660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5680,7 +5675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5691,13 +5686,24 @@
 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_9697b724-ff42-4c01-ad0c-135a57941d3b_2.1.1.71-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_174b2c32-66c8-49fa-abd9-5ca50a8ffdd2_2.1.1.71-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5705,7 +5711,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/05a449b4-0304-4d96-99a2-f2b0b673a45d_2.1.1.71-RXN>
+          <http://model.geneontology.org/174b2c32-66c8-49fa-abd9-5ca50a8ffdd2_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5714,7 +5720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5734,7 +5740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5748,7 +5754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5770,7 +5776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5790,7 +5796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5807,7 +5813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5815,23 +5821,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_e6f4e3fc-cee7-4ce0-aff7-22e688b4cfb3_CDPDIGLYSYN-RXN_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5846,7 +5841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5863,17 +5858,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_07c6b42d-c738-4dcf-9785-5720d7ef5519_RXN3O-349_SGD_PHOS-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YPR113W-MONOMER_2.7.8.11-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006317> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -5881,7 +5865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5889,26 +5873,37 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://purl.obolibrary.org/obo/GO_0004305>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_BFO_0000066_reaction_CHOLINE-KINASE-RXN_location_lociGO_0005829_null_PHOS-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004305>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_8d841687-0f12-4512-86f3-8b446ddde064_CDPDIGLYSYN-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PHOS-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5919,7 +5914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5931,7 +5926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5947,7 +5942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5962,7 +5957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5978,7 +5973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5990,7 +5985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6007,7 +6002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6023,7 +6018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6034,7 +6029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6048,7 +6043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6064,7 +6059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6076,7 +6071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6096,7 +6091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6109,7 +6104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6120,7 +6115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6135,7 +6130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6151,7 +6146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6162,34 +6157,6 @@
           <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOS-PWYSmallMolecule38686> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6199,7 +6166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6212,7 +6179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6224,7 +6191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6237,11 +6204,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN_SGD_PHOS-PWY> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_4d4f7953-5924-434a-8eb8-6f3f4c6e1819_2.7.8.11-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6249,8 +6216,30 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2c2b4117-2d1b-4b57-97d0-00b4fd12e1ca_2.7.8.11-RXN>
+          <http://model.geneontology.org/4d4f7953-5924-434a-8eb8-6f3f4c6e1819_2.7.8.11-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_f1065b57-37c8-46ce-b5f6-e99952561f0f_2.1.1.17-RXN_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_05f76491-2ee8-4357-bec1-f4675a7bf4e6_RXN3O-349_SGD_PHOS-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004307> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6271,7 +6260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6284,7 +6273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6309,7 +6298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6323,7 +6312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6342,7 +6331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6359,7 +6348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6375,7 +6364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6386,7 +6375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -6403,7 +6392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6423,7 +6412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6440,7 +6429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6451,17 +6440,6 @@
           <http://model.geneontology.org/YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOS-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6471,7 +6449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6479,13 +6457,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_BFO_0000050_PHOS-PWY/PHOS-PWY_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_174b2c32-66c8-49fa-abd9-5ca50a8ffdd2_2.1.1.71-RXN_SGD_PHOS-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOS-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PHOS-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6505,7 +6505,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/53f44c22-994f-47cf-bf1a-0713ca2eb664_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/1faa2a62-e56f-43fa-bedf-3358acc86c35_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6513,7 +6513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6530,7 +6530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6547,7 +6547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6563,7 +6563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOS-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOS-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PHOSLIPSYN2-PWY-1-PHOSLIPSYN2-PWY-1.ttl
+++ b/models/PHOSLIPSYN2-PWY-1-PHOSLIPSYN2-PWY-1.ttl
@@ -1,27 +1,10 @@
-<http://model.geneontology.org/92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,13 +60,24 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_7062b439-ee79-4173-bc37-357f05c7bdae_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_PHOSLIPSYN2-PWY-1/PHOSLIPSYN2-PWY-1_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -152,11 +146,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_04b1ba13-a810-480f-a55c-182831750cf6_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +158,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN>
+          <http://model.geneontology.org/04b1ba13-a810-480f-a55c-182831750cf6_2.1.1.17-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -173,7 +167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -222,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,24 +224,21 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/ECO_0000313>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_null_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15377>
+<http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24431>
+<http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN>
@@ -259,9 +250,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/9ee688ca-a146-4f15-be1f-b5008aa2a328_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/276a1d73-6355-46fb-92f1-ae094de7f0de_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -271,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,20 +270,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/80b78150-4c0c-44a0-b96d-104ff0ca6fa6_PHOSPHASERSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+                "a CDP-diacylglycerol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -302,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -429,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -440,20 +434,20 @@
           <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN>
+<http://model.geneontology.org/730457ee-e2df-4084-84f5-b03cd45f76bf_PGPPHOSPHA-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -462,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,11 +613,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_9ee688ca-a146-4f15-be1f-b5008aa2a328_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,11 +625,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/9ee688ca-a146-4f15-be1f-b5008aa2a328_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
+        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylserine decarboxylase, mitochondria" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27298> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -646,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,27 +663,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller>
-        a       <http://identifiers.org/sgd/S000005113> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylserine decarboxylase, mitochondria" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1Protein27298> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_PHOSLIPSYN2-PWY-1/PHOSLIPSYN2-PWY-1_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +694,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/80b78150-4c0c-44a0-b96d-104ff0ca6fa6_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -712,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,11 +719,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/7062b439-ee79-4173-bc37-357f05c7bdae_RXN3O-349>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -740,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,11 +780,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_7062b439-ee79-4173-bc37-357f05c7bdae_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +792,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349>
+          <http://model.geneontology.org/7062b439-ee79-4173-bc37-357f05c7bdae_RXN3O-349>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002234_CHEBI_43474_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1>
@@ -789,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -803,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -833,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,13 +879,24 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_31242432-3a0e-451a-8a5e-2931356f004d_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +918,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/04b1ba13-a810-480f-a55c-182831750cf6_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -904,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -918,7 +940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -952,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,17 +985,6 @@
           <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16038> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -983,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1059,11 +1070,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_537c8adb-09ff-4b8e-8fbd-65af3128bdfe_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1082,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN>
+          <http://model.geneontology.org/537c8adb-09ff-4b8e-8fbd-65af3128bdfe_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1080,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1093,11 +1104,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_276a1d73-6355-46fb-92f1-ae094de7f0de_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1116,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/276a1d73-6355-46fb-92f1-ae094de7f0de_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002411_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
@@ -1113,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1162,7 +1173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,7 +1212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1217,35 +1228,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1260,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1277,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1290,11 +1284,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_80b78150-4c0c-44a0-b96d-104ff0ca6fa6_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1296,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/80b78150-4c0c-44a0-b96d-104ff0ca6fa6_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1313,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,6 +1318,43 @@
           <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/537c8adb-09ff-4b8e-8fbd-65af3128bdfe_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/276a1d73-6355-46fb-92f1-ae094de7f0de_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15378>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1333,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,8 +1372,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15378>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_730457ee-e2df-4084-84f5-b03cd45f76bf_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1355,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1368,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1389,11 +1428,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_31242432-3a0e-451a-8a5e-2931356f004d_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,7 +1440,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN>
+          <http://model.geneontology.org/31242432-3a0e-451a-8a5e-2931356f004d_2.1.1.71-RXN>
 ] .
 
 <http://purl.org/dc/elements/1.1/source>
@@ -1415,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,6 +1464,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/31242432-3a0e-451a-8a5e-2931356f004d_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1437,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1471,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1483,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,23 +1550,23 @@
           <http://model.geneontology.org/CHEBI_64716_CARDIOLIPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_9ee688ca-a146-4f15-be1f-b5008aa2a328_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_537c8adb-09ff-4b8e-8fbd-65af3128bdfe_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1522,7 +1578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,13 +1589,24 @@
           <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_80b78150-4c0c-44a0-b96d-104ff0ca6fa6_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002333_YNL169C-MONOMER_PHOSPHASERDECARB-RXN_controller_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1563,11 +1630,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_730457ee-e2df-4084-84f5-b03cd45f76bf_PGPPHOSPHA-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,7 +1642,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN>
+          <http://model.geneontology.org/730457ee-e2df-4084-84f5-b03cd45f76bf_PGPPHOSPHA-RXN>
 ] .
 
 <http://model.geneontology.org/YGR170W-MONOMER_PHOSPHASERDECARB-RXN_controller>
@@ -1585,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1598,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1613,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1626,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1708,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/7062b439-ee79-4173-bc37-357f05c7bdae_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1649,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1668,7 +1735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,30 +1749,13 @@
 <http://purl.obolibrary.org/obo/GO_0004609>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1722,7 +1772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,12 +1783,23 @@
           <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_04b1ba13-a810-480f-a55c-182831750cf6_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1749,7 +1810,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1760,20 +1832,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1785,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1808,7 +1869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,24 +1900,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002333_YDL142C-MONOMER_CARDIOLIPSYN-RXN_controller_SGD_PHOSLIPSYN2-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1885,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1898,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1906,23 +1956,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.17-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -1933,13 +1966,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27168> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.17-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
@@ -1950,24 +2000,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27192> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_92808803-a36c-416a-8887-0875bc9d27dd_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1977,7 +2016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1996,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2012,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2023,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2052,7 +2091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2066,51 +2105,34 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_null_PHOSLIPSYN2-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002234_CHEBI_57856_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_57856_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2122,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,7 +2166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2178,7 +2200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,7 +2217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2215,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2228,7 +2250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2259,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2271,7 +2293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2291,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2304,28 +2326,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2333,7 +2338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2349,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2361,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2395,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2406,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2420,7 +2425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2437,7 +2442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2454,7 +2459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2470,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2487,7 +2492,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/9ee688ca-a146-4f15-be1f-b5008aa2a328_PHOSPHAGLYPSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27125> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2496,41 +2529,11 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_7777cc62-630f-47b0-9ecd-a3f45af0e3f2_2.1.1.17-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000003402>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_e5a7b416-09d7-40a9-aba8-600214525c9c_PHOSPHASERSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/RO_0002333>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/YJR073C-MONOMER_RXN3O-349_controller>
         a       <http://identifiers.org/sgd/S000003834> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2539,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2547,8 +2550,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/RO_0002333>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/04b1ba13-a810-480f-a55c-182831750cf6_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27199> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/2.1.1.71-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2559,9 +2576,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e46351b9-b1a9-4bfb-a746-bace90dc0620_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/537c8adb-09ff-4b8e-8fbd-65af3128bdfe_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/d3111c03-e3b8-4aa4-9676-a57234190c36_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/31242432-3a0e-451a-8a5e-2931356f004d_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2569,7 +2586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2583,7 +2600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2603,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2623,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2637,7 +2654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2647,6 +2664,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PHOSLIPSYN2-PWY-1/PHOSLIPSYN2-PWY-1>
 ] .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_276a1d73-6355-46fb-92f1-ae094de7f0de_PHOSPHAGLYPSYN-RXN_SGD_PHOSLIPSYN2-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PHOSLIPSYN2-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008962>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2660,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2674,7 +2702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,40 +2713,6 @@
           <http://model.geneontology.org/CHEBI_17754_CARDIOLIPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/43eca34c-a800-4aa3-a7e5-adc3c1e0f256_PHOSPHAGLYPSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27024> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CMP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27155> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2728,7 +2722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2741,29 +2735,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_bfa3f006-be14-4a71-b00c-7028bc8b6628_RXN3O-349_SGD_PHOSLIPSYN2-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CMP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PHOSLIPSYN2-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PHOSLIPSYN2-PWY-1SmallMolecule27155> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002333_YJR073C-MONOMER_2.1.1.71-RXN_controller_SGD_PHOSLIPSYN2-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2778,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2798,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2814,7 +2814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2834,7 +2834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2850,7 +2850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2867,7 +2867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2879,7 +2879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2896,7 +2896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2913,7 +2913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2929,7 +2929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2944,7 +2944,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/6ecaebea-746e-4437-a842-ca54099d6b50_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/730457ee-e2df-4084-84f5-b03cd45f76bf_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2952,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2965,7 +2965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2983,7 +2983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2996,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3021,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3034,7 +3034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PHOSLIPSYN2-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PLPSAL-PWY-PLPSAL-PWY.ttl
+++ b/models/PLPSAL-PWY-PLPSAL-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -439,7 +439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -519,7 +519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyridoxal 5'-phosphate salvage I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -641,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -897,7 +897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1084,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1176,7 +1176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1263,7 +1263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1308,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1327,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1367,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1412,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1466,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1489,7 +1489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,7 +1508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1545,7 +1545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,7 +1578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1645,7 +1645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1673,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,7 +1698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1715,7 +1715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1758,7 +1758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1778,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1792,7 +1792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1808,7 +1808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1860,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1902,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1916,7 +1916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1972,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1983,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2003,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2029,7 +2029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +2046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2079,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PLPSAL-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PLPSAL-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/POLYAMSYN-YEAST-PWY-POLYAMSYN-YEAST-PWY.ttl
+++ b/models/POLYAMSYN-YEAST-PWY-POLYAMSYN-YEAST-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -95,7 +95,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,23 +163,23 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SPERMIDINESYN-RXN_BFO_0000050_POLYAMSYN-YEAST-PWY/POLYAMSYN-YEAST-PWY_SGD_POLYAMSYN-YEAST-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002233_CHEBI_59789_SAMDECARB-RXN_SGD_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -392,13 +392,24 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_null_POLYAMSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SAMDECARB-RXN_RO_0002234_CHEBI_57443_SAMDECARB-RXN_SGD_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,24 +427,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYProtein27692> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002413_SPERMIDINESYN-RXN_null_POLYAMSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17509_SPERMINE-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17509> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -826,7 +826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1066,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1146,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of polyamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1217,7 +1217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1443,7 +1443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,30 +1457,13 @@
 <http://model.geneontology.org/reaction_SPERMIDINESYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/CHEBI_46911_ORNDECARBOX-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_46911> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "L-ornithine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYSmallMolecule27563> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ORNDECARBOX-RXN_RO_0002234_CHEBI_326268_ORNDECARBOX-RXN_SGD_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,13 +1474,30 @@
           <http://model.geneontology.org/CHEBI_326268_ORNDECARBOX-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_46911_ORNDECARBOX-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_46911> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "L-ornithine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=POLYAMSYN-YEAST-PWYSmallMolecule27563> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SPERMINE-SYNTHASE-RXN_RO_0002233_CHEBI_57443_SPERMINE-SYNTHASE-RXN_SGD_POLYAMSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1536,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1614,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:POLYAMSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/PROSYN-PWY-PROSYN-PWY.ttl
+++ b/models/PROSYN-PWY-PROSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -960,7 +960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -979,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,22 +1084,20 @@
           <http://model.geneontology.org/YOR323C-MONOMER_GLUTSEMIALDEHYDROG-RXN_controller>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002333_YDR300C-MONOMER_GLUTKIN-RXN_controller_SGD_PROSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLUTKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YDR300C-MONOMER_GLUTKIN-RXN_controller>
-] .
+<http://model.geneontology.org/YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000825> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "delta 1-pyrroline-5-carboxylate reductase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROSYN-PWYProtein29003> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_60039_PYRROLINECARBREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60039> ;
@@ -1110,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,20 +1116,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YER023W-MONOMER_PYRROLINECARBREDUCT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000825> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "delta 1-pyrroline-5-carboxylate reductase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROSYN-PWYProtein29003> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLUTKIN-RXN_RO_0002333_YDR300C-MONOMER_GLUTKIN-RXN_controller_SGD_PROSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLUTKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YDR300C-MONOMER_GLUTKIN-RXN_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_57783_GLUTSEMIALDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1237,7 +1237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1279,7 +1279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,7 +1398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1415,7 +1415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1432,7 +1432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1452,7 +1452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1484,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1501,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1520,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,7 +1540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PROUT-PWY-PROUT-PWY.ttl
+++ b/models/PROUT-PWY-PROUT-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,24 +32,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903_SGD_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903_SGD_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_dad85acd-7334-4147-9b94-cd8901132fc3_RXN-14903_SGD_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,7 +46,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903>
+          <http://model.geneontology.org/dad85acd-7334-4147-9b94-cd8901132fc3_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -66,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -105,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-proline degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -208,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,18 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PROUT-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_886f3918-a905-42db-a095-d01135e21610_RXN-14903_SGD_PROUT-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -607,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -620,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -631,11 +609,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_886f3918-a905-42db-a095-d01135e21610_RXN-14903_SGD_PROUT-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_c8649e85-f62f-462c-9aa0-270b25b2025e_RXN-14903_SGD_PROUT-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +621,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-14903> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/886f3918-a905-42db-a095-d01135e21610_RXN-14903>
+          <http://model.geneontology.org/c8649e85-f62f-462c-9aa0-270b25b2025e_RXN-14903>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -654,7 +632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,6 +694,17 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-proline<SUB>[in]</SUB> + an electron-transfer quinone<SUB>[membrane]</SUB> &rarr; (<i>S</i>)-1-pyrroline-5-carboxylate<SUB>[in]</SUB> + an electron-transfer quinol<SUB>[membrane]</SUB> + H<SUP>+</SUP><SUB>[in]</SUB>' 'null' '(<i>S</i>)-1-pyrroline-5-carboxylate + H<SUP>+</SUP> + H<sub>2</sub>O &harr; L-glutamate-5-semialdehyde' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -724,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,12 +741,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_CHEBI_17388_RXN-14903_SGD_PROUT-PWY>
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002234_dad85acd-7334-4147-9b94-cd8901132fc3_RXN-14903_SGD_PROUT-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -808,11 +797,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/c8649e85-f62f-462c-9aa0-270b25b2025e_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -820,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -854,7 +858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,11 +971,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29072> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/dad85acd-7334-4147-9b94-cd8901132fc3_RXN-14903>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29059> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -984,9 +1003,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-14903_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/886f3918-a905-42db-a095-d01135e21610_RXN-14903> , <http://model.geneontology.org/CHEBI_60039_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_60039_RXN-14903> , <http://model.geneontology.org/c8649e85-f62f-462c-9aa0-270b25b2025e_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903> , <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-14903> , <http://model.geneontology.org/CHEBI_17388_RXN-14903> , <http://model.geneontology.org/dad85acd-7334-4147-9b94-cd8901132fc3_RXN-14903> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR142W-MONOMER_RXN-14903_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -994,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1027,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,28 +1079,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_RXN-14116>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29072> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1089,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,20 +1102,33 @@
           <http://model.geneontology.org/CHEBI_58066_SPONTPRO-RXN>
 ] .
 
-<http://model.geneontology.org/886f3918-a905-42db-a095-d01135e21610_RXN-14903>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_15378_RXN-14116>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29035> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29072> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-14903_RO_0002233_c8649e85-f62f-462c-9aa0-270b25b2025e_RXN-14903_SGD_PROUT-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PROUT-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/SPONTPRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> ;
@@ -1132,7 +1147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1145,23 +1160,8 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PROUT-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/cbf52051-ec77-47b6-b764-c9444ece7b53_RXN-14903>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PROUT-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PROUT-PWYSmallMolecule29059> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PRPP-PWY-1-PRPP-PWY-1.ttl
+++ b/models/PRPP-PWY-1-PRPP-PWY-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -689,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -704,7 +704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -755,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -800,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -874,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -913,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -924,7 +924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +935,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_9a2c689e-2841-4523-abf0-8a2ffb72338c_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -950,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1101,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1152,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1260,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1276,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1330,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1341,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,7 +1406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1430,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1444,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1459,7 +1470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1530,7 +1541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1546,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1557,7 +1568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1605,7 +1616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1639,7 +1650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,7 +1683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,7 +1715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1732,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1751,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,7 +1778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1782,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1812,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1868,7 +1879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1888,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1929,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1943,7 +1954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1976,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2021,7 +2032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2033,7 +2044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2052,7 +2063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2088,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2127,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2142,7 +2153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2176,7 +2187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2192,7 +2203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2203,7 +2214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2226,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2239,7 +2250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2251,7 +2262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2267,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2282,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2296,7 +2307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2333,7 +2344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2387,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2404,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2418,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2445,7 +2456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2456,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2467,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2479,7 +2490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2500,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2513,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2524,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2558,7 +2569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2575,7 +2586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,7 +2603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2612,7 +2623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2626,7 +2637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2642,7 +2653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2657,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2670,7 +2681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2696,7 +2707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2711,7 +2722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2727,7 +2738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2739,7 +2750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2759,7 +2770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2776,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2804,7 +2815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2824,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2841,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2855,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2875,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2888,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2903,7 +2914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2916,7 +2927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2929,7 +2940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2943,7 +2954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2961,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2975,7 +2986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2989,29 +3000,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_58426>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_RO_0002411_GLYRIBONUCSYN-RXN_SGD_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3026,28 +3020,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39881> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3058,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3071,7 +3048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3083,7 +3060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3099,7 +3076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3121,7 +3098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3132,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3144,7 +3121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3164,7 +3141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3180,7 +3157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3191,7 +3168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3203,7 +3180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3219,7 +3196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3230,7 +3207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3245,7 +3222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3258,7 +3235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3269,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3281,7 +3258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3304,7 +3281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3317,7 +3294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3329,7 +3306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3345,7 +3322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3360,7 +3337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,7 +3357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3394,7 +3371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3411,7 +3388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3427,7 +3404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3442,7 +3419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3462,7 +3439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3478,7 +3455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3498,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3512,7 +3489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3528,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3539,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3550,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3562,7 +3539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3581,7 +3558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3592,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3607,7 +3584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3634,7 +3611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3647,7 +3624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3658,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3667,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3678,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3690,7 +3667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3707,7 +3684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3723,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3744,7 +3721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3758,7 +3735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,7 +3765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3802,7 +3779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3825,7 +3802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of histidine, purine, and pyrimidine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3838,7 +3815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3849,7 +3826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3859,7 +3836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3882,7 +3859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3896,7 +3873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3912,7 +3889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3924,7 +3901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3941,7 +3918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3957,7 +3934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3969,7 +3946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3991,7 +3968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4007,7 +3984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4022,7 +3999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4036,7 +4013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4055,7 +4032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4072,7 +4049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4091,7 +4068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4105,7 +4082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4113,11 +4090,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_9b75517d-db3f-4fc9-a331-7f88f8881929_GART-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4125,7 +4102,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN>
+          <http://model.geneontology.org/9b75517d-db3f-4fc9-a331-7f88f8881929_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58475_GLUTAMIDOTRANS-RXN>
@@ -4137,7 +4114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4154,7 +4131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4171,7 +4148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4184,7 +4161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4196,7 +4173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4218,7 +4195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4234,7 +4211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4245,7 +4222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4256,7 +4233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4267,7 +4244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4282,7 +4259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4299,7 +4276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4310,17 +4287,6 @@
           <http://model.geneontology.org/ADPREDUCT-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4330,11 +4296,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/9a2c689e-2841-4523-abf0-8a2ffb72338c_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4349,7 +4343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4362,7 +4356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4376,7 +4370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4399,7 +4393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4413,7 +4407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4429,7 +4423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4441,7 +4435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4460,7 +4454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4490,7 +4484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4503,7 +4497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4515,7 +4509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4531,7 +4525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4546,7 +4540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4560,7 +4554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4576,7 +4570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4591,7 +4585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4606,7 +4600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4619,7 +4613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4633,7 +4627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4649,7 +4643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4663,7 +4657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4682,7 +4676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4698,7 +4692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4716,7 +4710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4730,7 +4724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4750,7 +4744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4773,7 +4767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4790,7 +4784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4807,7 +4801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4823,7 +4817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4833,6 +4827,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_GLUTAMIDOTRANS-RXN_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a93085bf-5ee6-4384-889a-81ba4bd4f68f_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_IMPCYCLOHYDROLASE-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -4846,7 +4851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4860,7 +4865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4876,7 +4881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4887,7 +4892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4898,7 +4903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4909,7 +4914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4921,7 +4926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4937,7 +4942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4952,7 +4957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4972,7 +4977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4988,7 +4993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5003,7 +5008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5017,7 +5022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5033,7 +5038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5048,7 +5053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5066,7 +5071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5083,7 +5088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5099,7 +5104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5110,7 +5115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5122,7 +5127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5133,23 +5138,12 @@
           <http://model.geneontology.org/CHEBI_16526_OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_RO_0002413_GDPKIN-RXN_null_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5160,28 +5154,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_456216_DGDPKIN-RXN_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5189,7 +5177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5209,7 +5197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5222,7 +5210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5237,7 +5225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5253,7 +5241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5264,7 +5252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5276,7 +5264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5296,7 +5284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5312,7 +5300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5327,7 +5315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5341,7 +5329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5358,7 +5346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5377,7 +5365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5400,7 +5388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5413,7 +5401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5438,7 +5426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5451,7 +5439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5462,7 +5450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5477,7 +5465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5496,7 +5484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5509,7 +5497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5529,7 +5517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5545,7 +5533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5560,7 +5548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5573,7 +5561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5585,7 +5573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5601,7 +5589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5615,7 +5603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5637,7 +5625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5648,12 +5636,29 @@
           <http://model.geneontology.org/AICARTRANSFORM-RXN>
 ] .
 
+<http://model.geneontology.org/08e215dd-9e00-4267-9ba9-14d0d6aa318c_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_CHEBI_58457_GART-RXN_SGD_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5667,7 +5672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5687,7 +5692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5695,24 +5700,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_58564_AIRCARBOXY-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5732,7 +5726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5746,7 +5740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5763,7 +5757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5779,7 +5773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5791,7 +5785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5811,7 +5805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5825,7 +5819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5841,7 +5835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5852,7 +5846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5864,7 +5858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5880,7 +5874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5891,7 +5885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5903,7 +5897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5923,7 +5917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5936,7 +5930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5953,7 +5947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5970,7 +5964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5986,7 +5980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5997,7 +5991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6021,7 +6015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6040,7 +6034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6058,7 +6052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6072,7 +6066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6091,7 +6085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6108,7 +6102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6124,7 +6118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6139,7 +6133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6153,7 +6147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6169,7 +6163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6194,7 +6188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6207,7 +6201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6218,7 +6212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6230,7 +6224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6250,7 +6244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6264,7 +6258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6280,7 +6274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6294,7 +6288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6311,7 +6305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6330,7 +6324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6346,7 +6340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6361,7 +6355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6378,7 +6372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6392,7 +6386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6408,7 +6402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6421,7 +6415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6435,7 +6429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6468,7 +6462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6487,7 +6481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6503,7 +6497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6514,7 +6508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6526,7 +6520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6546,7 +6540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6563,9 +6557,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/08e215dd-9e00-4267-9ba9-14d0d6aa318c_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/9b75517d-db3f-4fc9-a331-7f88f8881929_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6573,7 +6567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6587,7 +6581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6603,7 +6597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6614,7 +6608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6629,7 +6623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6646,7 +6640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6659,7 +6653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6672,7 +6666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6686,7 +6680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6706,7 +6700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6720,7 +6714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6736,7 +6730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6747,7 +6741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6762,7 +6756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6775,7 +6769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6787,7 +6781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6801,12 +6795,29 @@
 <http://identifiers.org/sgd/S000001259>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/9b75517d-db3f-4fc9-a331-7f88f8881929_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-746_BFO_0000066_reaction_RXN0-746_location_lociGO_0005829_null_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6820,7 +6831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6837,7 +6848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6853,7 +6864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6866,7 +6877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6882,7 +6893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6898,7 +6909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6913,7 +6924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6927,7 +6938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6950,7 +6961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6964,7 +6975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6975,12 +6986,23 @@
           <http://model.geneontology.org/YJL130C-MONOMER_ASPCARBTRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_08e215dd-9e00-4267-9ba9-14d0d6aa318c_GART-RXN_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GLUTAMIDOTRANS-RXN_BFO_0000050_PRPP-PWY-1/PRPP-PWY-1_SGD_PRPP-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6991,7 +7013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7003,7 +7025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7020,7 +7042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7036,7 +7058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7050,7 +7072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7070,7 +7092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7084,7 +7106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7104,7 +7126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7127,7 +7149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7141,7 +7163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7171,7 +7193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7188,7 +7210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7204,7 +7226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7218,7 +7240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7229,7 +7251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7240,7 +7262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7258,7 +7280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7272,7 +7294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7290,7 +7312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7313,7 +7335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7340,7 +7362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7354,7 +7376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7370,7 +7392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7381,7 +7403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7406,7 +7428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7423,7 +7445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7439,7 +7461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7452,7 +7474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7466,7 +7488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7482,7 +7504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7497,7 +7519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7515,7 +7537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7545,7 +7567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7559,7 +7581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7575,7 +7597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7587,7 +7609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7607,7 +7629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7624,7 +7646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7638,7 +7660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7654,7 +7676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7666,7 +7688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7683,7 +7705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7699,7 +7721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7710,7 +7732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7722,7 +7744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7752,7 +7774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7772,7 +7794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7786,7 +7808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7809,7 +7831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7826,7 +7848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7839,7 +7861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7850,7 +7872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7861,7 +7883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7872,7 +7894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7886,7 +7908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7906,7 +7928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7919,7 +7941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7934,7 +7956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7947,7 +7969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7958,7 +7980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7969,7 +7991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -7981,7 +8003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8001,7 +8023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8021,7 +8043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8048,7 +8070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8061,7 +8083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8073,7 +8095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8089,7 +8111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8103,7 +8125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8114,7 +8136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8125,7 +8147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8140,7 +8162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8160,7 +8182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8173,7 +8195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8184,7 +8206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8198,7 +8220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8221,7 +8243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8234,7 +8256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8246,7 +8268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8262,7 +8284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8274,7 +8296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8290,7 +8312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8301,7 +8323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8316,7 +8338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8330,7 +8352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8353,7 +8375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8370,7 +8392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8386,7 +8408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8397,7 +8419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8409,7 +8431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8428,7 +8450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8439,7 +8461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8451,7 +8473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8474,7 +8496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8491,7 +8513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8504,7 +8526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8516,7 +8538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8542,7 +8564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8557,7 +8579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8570,7 +8592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8584,7 +8606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8604,7 +8626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8620,7 +8642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8640,7 +8662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8657,7 +8679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8670,7 +8692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8682,7 +8704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8705,7 +8727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8724,7 +8746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8744,7 +8766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8760,7 +8782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8775,7 +8797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8791,7 +8813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8810,7 +8832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8823,7 +8845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8836,7 +8858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8850,7 +8872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8868,7 +8890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8884,7 +8906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -8899,7 +8921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8919,7 +8941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8935,7 +8957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8955,7 +8977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8972,7 +8994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8992,7 +9014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9012,7 +9034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9022,11 +9044,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_9a2c689e-2841-4523-abf0-8a2ffb72338c_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9034,7 +9056,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/9a2c689e-2841-4523-abf0-8a2ffb72338c_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_HISTIDPHOS-RXN_RO_0002413_HISTOLDEHYD-RXN_null_PRPP-PWY-1>
@@ -9042,7 +9064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9054,7 +9076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9074,7 +9096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9091,7 +9113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9108,7 +9130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9124,7 +9146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9141,7 +9163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9159,7 +9181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9173,7 +9195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9192,7 +9214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9204,7 +9226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9220,7 +9242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9234,7 +9256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9249,7 +9271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9265,7 +9287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9285,7 +9307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9298,7 +9320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9310,7 +9332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9326,7 +9348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9341,7 +9363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9354,7 +9376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9365,7 +9387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9376,7 +9398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9390,7 +9412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9407,7 +9429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9428,7 +9450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9445,7 +9467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9462,7 +9484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9478,7 +9500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9493,7 +9515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9507,7 +9529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9527,7 +9549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9544,7 +9566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9563,7 +9585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9577,7 +9599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9593,7 +9615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9608,7 +9630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9625,7 +9647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9644,7 +9666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9658,7 +9680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9669,7 +9691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9682,7 +9704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9696,7 +9718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9716,7 +9738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9743,7 +9765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9756,7 +9778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9767,7 +9789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9780,7 +9802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9793,7 +9815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9804,7 +9826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9815,7 +9837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9830,7 +9852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9843,7 +9865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9855,7 +9877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9883,7 +9905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9896,7 +9918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9910,7 +9932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9921,24 +9943,13 @@
           <http://model.geneontology.org/GART-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_cbb04234-7050-4230-9436-0330a2ec999f_GART-RXN_SGD_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YHR216W-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9954,7 +9965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9965,7 +9976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9976,7 +9987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9987,7 +9998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -9999,7 +10010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10022,7 +10033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10036,7 +10047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10056,7 +10067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10070,7 +10081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10089,7 +10100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10100,7 +10111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10115,7 +10126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10129,7 +10140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10146,7 +10157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10166,7 +10177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10183,7 +10194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10200,7 +10211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10216,7 +10227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10231,7 +10242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10247,7 +10258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10267,7 +10278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10280,7 +10291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10291,7 +10302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10303,7 +10314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10321,7 +10332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10335,7 +10346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10351,7 +10362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10363,7 +10374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10381,7 +10392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10398,7 +10409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10412,7 +10423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10431,7 +10442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10443,7 +10454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10459,7 +10470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10470,7 +10481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10495,7 +10506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10522,7 +10533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10536,7 +10547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10556,7 +10567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10569,7 +10580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10584,7 +10595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10604,7 +10615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10624,7 +10635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10637,7 +10648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10652,7 +10663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10665,7 +10676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10683,7 +10694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10700,7 +10711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10716,7 +10727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10728,7 +10739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10747,7 +10758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10767,7 +10778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10781,7 +10792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10797,7 +10808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10812,9 +10823,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/870cf813-89cf-468d-ab08-b688a55f976a_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/9a2c689e-2841-4523-abf0-8a2ffb72338c_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/a93085bf-5ee6-4384-889a-81ba4bd4f68f_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -10822,7 +10833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10836,7 +10847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10853,7 +10864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10871,7 +10882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10889,7 +10900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10903,7 +10914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10919,7 +10930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10930,7 +10941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -10942,7 +10953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10962,7 +10973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10976,7 +10987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10995,7 +11006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11010,7 +11021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11024,7 +11035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11047,7 +11058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11064,7 +11075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11080,7 +11091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11091,7 +11102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11103,7 +11114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11123,24 +11134,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule39634> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11150,7 +11150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11173,7 +11173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11188,7 +11188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11201,7 +11201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11212,7 +11212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -11221,7 +11221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11236,7 +11236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11256,7 +11256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11270,7 +11270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11290,7 +11290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11303,7 +11303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11314,7 +11314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11326,7 +11326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11345,7 +11345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11357,7 +11357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11374,7 +11374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11390,7 +11390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11401,7 +11401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11418,7 +11418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11430,7 +11430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11447,7 +11447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11467,7 +11467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11484,7 +11484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11501,7 +11501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11514,7 +11514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11531,7 +11531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11543,7 +11543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11566,7 +11566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11581,7 +11581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11598,7 +11598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11612,7 +11612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11628,7 +11628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11643,7 +11643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11656,7 +11656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11669,7 +11669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11685,7 +11685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11702,7 +11702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11718,7 +11718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11731,7 +11731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11748,7 +11748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11761,7 +11761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11786,7 +11786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11800,7 +11800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11816,7 +11816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11827,7 +11827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11838,7 +11838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11850,7 +11850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11866,7 +11866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11881,7 +11881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11894,7 +11894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11906,7 +11906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11926,7 +11926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11940,7 +11940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11956,7 +11956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -11968,7 +11968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11984,7 +11984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -11999,7 +11999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12015,7 +12015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12030,7 +12030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12047,7 +12047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12063,7 +12063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12076,7 +12076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12092,7 +12092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12104,7 +12104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12134,7 +12134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12161,7 +12161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12178,7 +12178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12191,7 +12191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12206,7 +12206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12232,7 +12232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12245,7 +12245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12260,7 +12260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12277,7 +12277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12297,7 +12297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12310,7 +12310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12324,7 +12324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12344,7 +12344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12361,7 +12361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12377,7 +12377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12392,7 +12392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12409,7 +12409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12429,7 +12429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12447,7 +12447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12464,7 +12464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12477,7 +12477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12488,7 +12488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12500,7 +12500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12520,7 +12520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12534,7 +12534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12551,7 +12551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12571,7 +12571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12590,7 +12590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12607,7 +12607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12624,7 +12624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12644,7 +12644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12661,7 +12661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12679,7 +12679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12692,7 +12692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12717,7 +12717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12731,7 +12731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12748,7 +12748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12765,7 +12765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12781,7 +12781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12793,7 +12793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12809,7 +12809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12821,7 +12821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12837,7 +12837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12848,7 +12848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12859,7 +12859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12874,7 +12874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12891,7 +12891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12911,7 +12911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12924,7 +12924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12936,7 +12936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12952,7 +12952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12963,7 +12963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -12979,7 +12979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12993,7 +12993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13010,7 +13010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13026,7 +13026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13041,7 +13041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13058,7 +13058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13078,7 +13078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13094,7 +13094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13109,7 +13109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13125,7 +13125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13141,7 +13141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13164,7 +13164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13178,7 +13178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13194,7 +13194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13206,7 +13206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13222,7 +13222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13237,7 +13237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13251,7 +13251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13267,7 +13267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13279,7 +13279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13295,7 +13295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13306,7 +13306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13320,7 +13320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13340,7 +13340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13360,7 +13360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13380,7 +13380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13396,7 +13396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13412,7 +13412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13423,7 +13423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13438,7 +13438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13455,7 +13455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13468,7 +13468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13480,7 +13480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13496,7 +13496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13511,7 +13511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13524,7 +13524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13539,7 +13539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13555,7 +13555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13575,7 +13575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13592,7 +13592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13609,7 +13609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13623,7 +13623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13645,7 +13645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13657,7 +13657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13673,7 +13673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13684,7 +13684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13699,7 +13699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13713,7 +13713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13726,11 +13726,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a93085bf-5ee6-4384-889a-81ba4bd4f68f_AICARTRANSFORM-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13738,7 +13738,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/807c89ef-fddb-4022-9d60-7afdae4d8108_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/a93085bf-5ee6-4384-889a-81ba4bd4f68f_AICARTRANSFORM-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_IMPCYCLOHYDROLASE-RXN_RO_0002233_CHEBI_58053_IMPCYCLOHYDROLASE-RXN_SGD_PRPP-PWY-1>
@@ -13746,7 +13746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13757,7 +13757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13782,7 +13782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13795,7 +13795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13809,7 +13809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13825,7 +13825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13840,7 +13840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13854,7 +13854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13877,7 +13877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13890,7 +13890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13902,7 +13902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13918,7 +13918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -13930,7 +13930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13950,7 +13950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13967,7 +13967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13983,7 +13983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14006,7 +14006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14020,7 +14020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14037,7 +14037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14053,7 +14053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14068,7 +14068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14081,7 +14081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14092,7 +14092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14103,7 +14103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14115,7 +14115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14131,7 +14131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14146,7 +14146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14154,23 +14154,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN_SGD_PRPP-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PRPP-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_456216_DADPKIN-RXN_SGD_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14181,7 +14170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14192,7 +14181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -14202,7 +14191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14218,7 +14207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14246,7 +14235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14263,7 +14252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14279,7 +14268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14290,7 +14279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14308,7 +14297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14328,7 +14317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14343,7 +14332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14357,7 +14346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14373,7 +14362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14388,7 +14377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14401,7 +14390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14416,7 +14405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14433,7 +14422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14446,7 +14435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14460,7 +14449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14479,7 +14468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14491,7 +14480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14515,7 +14504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14532,7 +14521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14546,7 +14535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14562,7 +14551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14573,7 +14562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14584,7 +14573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14596,7 +14585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14613,7 +14602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14629,7 +14618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14644,7 +14633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14661,7 +14650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14691,7 +14680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14707,7 +14696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14722,7 +14711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14739,7 +14728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14754,7 +14743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14768,7 +14757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14796,7 +14785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14816,7 +14805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14833,7 +14822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14846,7 +14835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14871,7 +14860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14888,7 +14877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14905,7 +14894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14921,7 +14910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14953,7 +14942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14966,7 +14955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -14978,7 +14967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14998,7 +14987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15011,7 +15000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15025,7 +15014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15041,7 +15030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15056,7 +15045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15070,7 +15059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15086,7 +15075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15101,7 +15090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15114,7 +15103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15129,7 +15118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15146,7 +15135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15174,7 +15163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15191,7 +15180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15211,7 +15200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15225,7 +15214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15242,7 +15231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15258,7 +15247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15269,7 +15258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15294,7 +15283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15314,7 +15303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15328,7 +15317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15348,7 +15337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15364,7 +15353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15375,7 +15364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15383,11 +15372,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN_SGD_PRPP-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_08e215dd-9e00-4267-9ba9-14d0d6aa318c_GART-RXN_SGD_PRPP-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15395,7 +15384,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN>
+          <http://model.geneontology.org/08e215dd-9e00-4267-9ba9-14d0d6aa318c_GART-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_137981_AIRS-RXN>
@@ -15407,7 +15396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15423,7 +15412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15443,7 +15432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15460,7 +15449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15487,7 +15476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15501,7 +15490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15521,7 +15510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15535,7 +15524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15555,7 +15544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15569,7 +15558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15588,7 +15577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15600,7 +15589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15616,7 +15605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15631,7 +15620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15644,7 +15633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15656,7 +15645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15686,7 +15675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15699,7 +15688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15714,7 +15703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15731,7 +15720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15745,7 +15734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15765,7 +15754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15792,7 +15781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15806,7 +15795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15823,7 +15812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15840,7 +15829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15856,28 +15845,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/6c981c45-8a9a-4a4f-a36b-0cc81cfc3998_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40483> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58426_GART-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58426> ;
@@ -15888,7 +15860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15902,7 +15874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15919,7 +15891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15939,7 +15911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15959,7 +15931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -15972,7 +15944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -15984,7 +15956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16001,7 +15973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16021,7 +15993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16037,7 +16009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16049,7 +16021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16060,12 +16032,29 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/a93085bf-5ee6-4384-889a-81ba4bd4f68f_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PRPP-PWY-1SmallMolecule40505> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_BFO_0000066_reaction_CARBPSYN-RXN_location_lociGO_0005829_null_PRPP-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16077,7 +16066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16093,7 +16082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16105,7 +16094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16123,7 +16112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16142,7 +16131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16157,7 +16146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16174,7 +16163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16191,7 +16180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16207,7 +16196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16219,7 +16208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16238,7 +16227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16252,7 +16241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16267,7 +16256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16281,7 +16270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16298,7 +16287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16317,7 +16306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16329,7 +16318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16347,7 +16336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16360,7 +16349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16373,7 +16362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16386,7 +16375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16399,7 +16388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -16416,7 +16405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16430,7 +16419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16441,6 +16430,17 @@
           <http://model.geneontology.org/PRPP-PWY-1/PRPP-PWY-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_9b75517d-db3f-4fc9-a331-7f88f8881929_GART-RXN_SGD_PRPP-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PRPP-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YEL021W-MONOMER_OROTPDECARB-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000747> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -16448,7 +16448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16464,7 +16464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16481,7 +16481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16497,7 +16497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16508,7 +16508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16522,7 +16522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16538,7 +16538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16550,7 +16550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16566,7 +16566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16577,7 +16577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16588,7 +16588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16600,7 +16600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16616,7 +16616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16628,7 +16628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16647,7 +16647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16658,7 +16658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16669,7 +16669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16680,7 +16680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16694,7 +16694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16710,7 +16710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16728,7 +16728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16742,7 +16742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16760,7 +16760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16780,7 +16780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16796,7 +16796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16811,7 +16811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16830,7 +16830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16846,7 +16846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -16859,7 +16859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16872,7 +16872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16884,7 +16884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16900,7 +16900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16912,7 +16912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16928,7 +16928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16939,7 +16939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16950,7 +16950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -16962,7 +16962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -16982,7 +16982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -16998,7 +16998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17014,7 +17014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17029,7 +17029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17043,7 +17043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17059,7 +17059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17074,7 +17074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17091,7 +17091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17110,7 +17110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17128,7 +17128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17141,7 +17141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17152,7 +17152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17165,7 +17165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17178,7 +17178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17190,7 +17190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17211,7 +17211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17224,7 +17224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17236,7 +17236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17256,7 +17256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17275,7 +17275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17287,7 +17287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17306,7 +17306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17321,7 +17321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17335,7 +17335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17352,7 +17352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17371,7 +17371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17382,7 +17382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17393,7 +17393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17404,7 +17404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17415,7 +17415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17443,7 +17443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17457,7 +17457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17473,7 +17473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17484,7 +17484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17499,7 +17499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17513,7 +17513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17536,7 +17536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17549,7 +17549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17560,7 +17560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17572,7 +17572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17590,7 +17590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17606,7 +17606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17626,7 +17626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17646,7 +17646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -17660,7 +17660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17677,7 +17677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17693,7 +17693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -17707,7 +17707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -17726,7 +17726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PRPP-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PRPP-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-1801-1-PWY-1801-1.ttl
+++ b/models/PWY-1801-1-PWY-1801-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,7 +119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,23 +130,23 @@
           <http://model.geneontology.org/CHEBI_57540_1.2.1.2-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-2961_RO_0002234_CHEBI_57925_RXN-2961_SGD_PWY-1801-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_57688_RXN-2962_SGD_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "formaldehyde oxidation II (glutathione-dependent) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,6 +832,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_RXN-2962_location_lociGO_0005829>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0018738> ;
@@ -852,24 +863,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1BiochemicalReaction62268> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_15378_RXN-2962_SGD_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_S-FORMYLGLUTATHIONE-HYDROLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1027,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,7 +1077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,30 +1137,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_13390_RXN-2962>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD(P)<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1SmallMolecule62190> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-2962_RO_0002234_CHEBI_13392_RXN-2962_SGD_PWY-1801-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,6 +1154,34 @@
           <http://model.geneontology.org/CHEBI_13392_RXN-2962>
 ] .
 
+<http://model.geneontology.org/CHEBI_13390_RXN-2962>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD(P)<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-1801-1SmallMolecule62190> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000066_reaction_RXN-2961_location_lociGO_0005829_null_PWY-1801-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-1801-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_RXN-2961_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
@@ -1180,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,17 +1202,6 @@
           <http://model.geneontology.org/PWY-1801-1/PWY-1801-1>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-2961_BFO_0000066_reaction_RXN-2961_location_lociGO_0005829_null_PWY-1801-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-1801-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58758_RXN-2961>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58758> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1227,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1295,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1318,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-1801-1" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1372,7 +1372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,7 +1474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-1801-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-2201-PWY-2201.ttl
+++ b/models/PWY-2201-PWY-2201.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,23 +49,6 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -74,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,33 +100,39 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN>
+<http://model.geneontology.org/5844de13-9252-40b7-b4cc-264dd3c0f032_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/f41c029f-b2a5-48d4-8496-ca35b95ecc7e_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -151,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -170,7 +159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,24 +187,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,18 +212,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN_SGD_PWY-2201>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_5844de13-9252-40b7-b4cc-264dd3c0f032_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -253,11 +231,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_7059fb58-63ba-4c11-ba56-36dd595c1f97_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,7 +243,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/7059fb58-63ba-4c11-ba56-36dd595c1f97_FORMYLTHFDEFORMYL-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY-2201>
@@ -273,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,16 +291,13 @@
           <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,6 +307,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
 ] .
+
+<http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -344,28 +322,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -375,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,23 +347,6 @@
           <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -411,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -457,28 +401,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67378> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -487,11 +414,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/6910d97e-bc96-4d3d-8deb-8201da13fcff_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/cd3331a9-8d19-47f0-a8d6-c365d7dbf828_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -499,7 +460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -558,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,15 +604,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-5061_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061> , <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> ;
+                <http://model.geneontology.org/b3c0708b-7adb-4ca9-8efe-0a1555e41fda_RXN-5061> , <http://model.geneontology.org/Reduced-ferredoxins_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-5061> , <http://model.geneontology.org/d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061> , <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-5061> , <http://model.geneontology.org/60730349-2c72-49cc-a0e1-e8e27f9b0426_RXN-5061> , <http://model.geneontology.org/Apo-Ferredoxins_RXN-5061> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/HOMOCYSMETB12-RXN> , <http://model.geneontology.org/2.1.1.19-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -664,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -688,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate transformations I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -733,40 +694,12 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,8 +742,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004487>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
         a       <http://identifiers.org/sgd/S000003436> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -819,24 +760,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201Protein67687> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -846,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,38 +787,24 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004487>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/SGD_S000002426_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002426> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_456216_FORMATETHFLIG-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -912,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -926,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,23 +853,12 @@
           <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_CHEBI_57844_HOMOCYSMETB12-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -975,28 +880,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1007,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,14 +967,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_d6f98c12-4a59-45d5-a9e5-cf4d6468f75f_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/d6f98c12-4a59-45d5-a9e5-cf4d6468f75f_GLYOHMETRANS-RXN>
+] .
+
+<http://model.geneontology.org/d6f98c12-4a59-45d5-a9e5-cf4d6468f75f_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1094,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,39 +1009,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_6b5a3f23-39a8-4937-91d3-7f23010d5516_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN>
-] .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1021,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/6b5a3f23-39a8-4937-91d3-7f23010d5516_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_SGD_S000001876_CPLX3O-213_component_SGD_PWY-2201>
@@ -1152,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1164,23 +1041,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN_SGD_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.19-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN>
-] .
-
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1190,9 +1050,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/d91ff81d-82c0-4e67-b74d-89b3f1516b0a_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/6b5a3f23-39a8-4937-91d3-7f23010d5516_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1202,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1215,18 +1075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1258,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1268,11 +1117,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_74d6a35b-8eec-4e7c-b767-cd15ef49f8af_2.1.1.19-RXN_SGD_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.19-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/74d6a35b-8eec-4e7c-b767-cd15ef49f8af_2.1.1.19-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1288,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1300,12 +1166,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_17434>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_246b28cb-7d09-48c9-a63c-9d2a0555885d_1.5.1.20-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000066_reaction_1.5.1.20-RXN_location_lociGO_0005829_null_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1313,11 +1190,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_0aa000c7-4044-4200-b2d1-0f5f328f4ac3_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1202,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/0aa000c7-4044-4200-b2d1-0f5f328f4ac3_HOMOCYSMETB12-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -1337,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1354,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1392,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1408,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1425,11 +1302,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_246b28cb-7d09-48c9-a63c-9d2a0555885d_1.5.1.20-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,8 +1314,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN>
+          <http://model.geneontology.org/246b28cb-7d09-48c9-a63c-9d2a0555885d_1.5.1.20-RXN>
 ] .
+
+<http://model.geneontology.org/f3a3a25d-23b3-4b15-bb46-8eb950edc306_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1446,7 +1340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1462,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1473,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1485,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,9 +1402,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/f3a3a25d-23b3-4b15-bb46-8eb950edc306_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/5844de13-9252-40b7-b4cc-264dd3c0f032_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1518,7 +1412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1526,13 +1420,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_ef0c50eb-7ace-47b6-a6d9-6d81a2bd31bc_GCVMULTI-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,29 +1448,12 @@
           <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
-<http://model.geneontology.org/90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1580,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1619,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1637,7 +1525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1653,29 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1692,7 +1558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,6 +1569,34 @@
           <http://model.geneontology.org/1.5.1.15-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_cd3331a9-8d19-47f0-a8d6-c365d7dbf828_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/6b5a3f23-39a8-4937-91d3-7f23010d5516_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1711,7 +1605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1722,6 +1616,17 @@
           <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_7059fb58-63ba-4c11-ba56-36dd595c1f97_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1730,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,11 +1648,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_60730349-2c72-49cc-a0e1-e8e27f9b0426_RXN-5061_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1755,8 +1660,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061>
+          <http://model.geneontology.org/60730349-2c72-49cc-a0e1-e8e27f9b0426_RXN-5061>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_44fdd365-1f50-45ee-b788-a6f8df296219_GCVMULTI-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1764,7 +1680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1819,11 +1735,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_c1f99af4-cd09-4443-aaa5-c9b2f73d9420_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,7 +1747,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/c1f99af4-cd09-4443-aaa5-c9b2f73d9420_5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1842,7 +1758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1853,17 +1769,6 @@
           <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004477> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1873,15 +1778,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/f41c029f-b2a5-48d4-8496-ca35b95ecc7e_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/6910d97e-bc96-4d3d-8deb-8201da13fcff_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,13 +1794,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_16526_GCVMULTI-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_6910d97e-bc96-4d3d-8deb-8201da13fcff_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,7 +1819,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/6910d97e-bc96-4d3d-8deb-8201da13fcff_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_15378_1.5.1.20-RXN_SGD_PWY-2201>
@@ -1911,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1923,7 +1839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,12 +1850,40 @@
           <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
+<http://model.geneontology.org/831860e8-4507-4e39-9adb-61c12bccb87b_2.1.1.19-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_f41c029f-b2a5-48d4-8496-ca35b95ecc7e_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1947,17 +1891,6 @@
 
 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1967,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -1979,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,24 +1931,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN>
+<http://model.geneontology.org/d91ff81d-82c0-4e67-b74d-89b3f1516b0a_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -2024,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2038,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2058,7 +1980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2072,7 +1994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2092,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2142,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2154,7 +2076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2167,11 +2089,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_777aef34-c334-400e-a162-6ae74271dd64_1.5.1.15-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,7 +2101,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN>
+          <http://model.geneontology.org/777aef34-c334-400e-a162-6ae74271dd64_1.5.1.15-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000051>
@@ -2193,7 +2115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2209,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2220,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2252,7 +2174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,23 +2184,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2292,7 +2197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2312,7 +2217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2323,30 +2228,24 @@
           <http://model.geneontology.org/SGD_S000004801_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_d01575a5-cf01-4922-a292-f96237f553f9_1.5.1.15-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_f3a3a25d-23b3-4b15-bb46-8eb950edc306_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,36 +2253,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/f3a3a25d-23b3-4b15-bb46-8eb950edc306_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
-
-<http://model.geneontology.org/c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2393,7 +2264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2407,17 +2278,6 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0030272> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2427,21 +2287,38 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/c1f99af4-cd09-4443-aaa5-c9b2f73d9420_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_30616_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
+                <http://model.geneontology.org/cd3331a9-8d19-47f0-a8d6-c365d7dbf828_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_43474_5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201BiochemicalReaction67382> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/c1f99af4-cd09-4443-aaa5-c9b2f73d9420_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17437> ;
@@ -2452,11 +2329,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67541> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/777aef34-c334-400e-a162-6ae74271dd64_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2469,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2477,23 +2371,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000066_reaction_FORMATETHFLIG-RXN_location_lociGO_0005829_null_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2508,7 +2391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2525,7 +2408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2543,7 +2426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,33 +2434,33 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/c2a76776-a790-4090-95f2-c569ad2d467e_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_CHEBI_15378_2.1.1.19-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2587,7 +2470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,6 +2484,17 @@
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_d6f98c12-4a59-45d5-a9e5-cf4d6468f75f_GLYOHMETRANS-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2609,11 +2503,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_5ab0553d-7754-4fec-8bca-bf1e2c5e5f9b_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,23 +2515,23 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN>
+          <http://model.geneontology.org/5ab0553d-7754-4fec-8bca-bf1e2c5e5f9b_FORMYLTHFDEFORMYL-RXN>
 ] .
 
-<http://model.geneontology.org/233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/b3c0708b-7adb-4ca9-8efe-0a1555e41fda_RXN-5061>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2646,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2656,7 +2550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2673,7 +2567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2693,9 +2587,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/c2a76776-a790-4090-95f2-c569ad2d467e_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/d6f98c12-4a59-45d5-a9e5-cf4d6468f75f_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2705,7 +2599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2722,7 +2616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2736,7 +2630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,15 +2650,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_HOMOCYSMETB12-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN> ;
+                <http://model.geneontology.org/63e5e6c0-c233-478c-8067-790feae23cc0_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN> ;
+                <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN> , <http://model.geneontology.org/0aa000c7-4044-4200-b2d1-0f5f328f4ac3_HOMOCYSMETB12-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2778,7 +2672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2789,36 +2683,19 @@
           <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN_SGD_PWY-2201>
+<http://purl.obolibrary.org/obo/GO_0004489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_777aef34-c334-400e-a162-6ae74271dd64_1.5.1.15-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004489>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/9f323317-1377-4183-a6fe-26cb8ca999b2_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2826,7 +2703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2845,18 +2722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2870,7 +2736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2884,7 +2750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2901,7 +2767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2912,29 +2778,23 @@
           <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
-<http://model.geneontology.org/d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c2a76776-a790-4090-95f2-c569ad2d467e_GLYOHMETRANS-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -2949,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2963,7 +2823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +2843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2991,23 +2851,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000066_reaction_GCVMULTI-RXN_location_lociGO_0005829_null_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3019,7 +2868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3039,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3052,7 +2901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3064,7 +2913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3075,12 +2924,12 @@
           <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_d31e9200-9565-4a23-a71e-67f73fe0f3af_RXN-5061_SGD_PWY-2201>
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_74d6a35b-8eec-4e7c-b767-cd15ef49f8af_2.1.1.19-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3089,29 +2938,12 @@
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3122,7 +2954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3138,7 +2970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3155,7 +2987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3175,9 +3007,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/895d6629-1ad1-4901-ba60-0eba498166d2_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/777aef34-c334-400e-a162-6ae74271dd64_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/d01575a5-cf01-4922-a292-f96237f553f9_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3185,7 +3017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3199,7 +3031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3216,7 +3048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3227,16 +3059,22 @@
           <http://model.geneontology.org/http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_2c7caa39-11c7-49ff-81c0-8b24c8ec2655_HOMOCYSMETB12-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/44fdd365-1f50-45ee-b788-a6f8df296219_GCVMULTI-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3244,7 +3082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3263,7 +3101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3276,7 +3114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3290,7 +3128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3306,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3317,7 +3155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3328,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3336,11 +3174,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_5844de13-9252-40b7-b4cc-264dd3c0f032_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3348,7 +3186,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e83416de-f149-4686-bf96-daa298cd8801_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/5844de13-9252-40b7-b4cc-264dd3c0f032_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -3358,7 +3196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3371,7 +3209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3385,11 +3223,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c2a76776-a790-4090-95f2-c569ad2d467e_GLYOHMETRANS-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3397,7 +3235,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/417a62eb-a60f-477f-8c26-74f9d2817f6c_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/c2a76776-a790-4090-95f2-c569ad2d467e_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_CHEBI_456216_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
@@ -3405,7 +3243,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_f3a3a25d-23b3-4b15-bb46-8eb950edc306_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3413,11 +3262,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_d91ff81d-82c0-4e67-b74d-89b3f1516b0a_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3425,7 +3274,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/717a874f-67d4-46c8-ac27-7a91bb364165_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/d91ff81d-82c0-4e67-b74d-89b3f1516b0a_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY-2201>
@@ -3433,7 +3282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3444,7 +3293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3459,7 +3308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3469,11 +3318,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_831860e8-4507-4e39-9adb-61c12bccb87b_2.1.1.19-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3481,7 +3330,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.19-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN>
+          <http://model.geneontology.org/831860e8-4507-4e39-9adb-61c12bccb87b_2.1.1.19-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3490,7 +3339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3513,7 +3362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3524,11 +3373,50 @@
           <http://model.geneontology.org/CHEBI_58199_HOMOCYSMETB12-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_b3c0708b-7adb-4ca9-8efe-0a1555e41fda_RXN-5061_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000005944>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/74d6a35b-8eec-4e7c-b767-cd15ef49f8af_2.1.1.19-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002233_831860e8-4507-4e39-9adb-61c12bccb87b_2.1.1.19-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3539,7 +3427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3552,7 +3440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3563,7 +3451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3575,7 +3463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3595,7 +3483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3608,11 +3496,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_131545db-d16d-4453-9d4f-81a86fd5177a_1.5.1.20-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3620,7 +3508,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN>
+          <http://model.geneontology.org/131545db-d16d-4453-9d4f-81a86fd5177a_1.5.1.20-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3632,7 +3520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3643,12 +3531,23 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_131545db-d16d-4453-9d4f-81a86fd5177a_1.5.1.20-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002333_YPL023C-MONOMER_1.5.1.20-RXN_controller_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3656,11 +3555,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_ef0c50eb-7ace-47b6-a6d9-6d81a2bd31bc_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3668,8 +3567,36 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN>
+          <http://model.geneontology.org/ef0c50eb-7ace-47b6-a6d9-6d81a2bd31bc_GCVMULTI-RXN>
 ] .
+
+<http://model.geneontology.org/ef0c50eb-7ace-47b6-a6d9-6d81a2bd31bc_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002234_0aa000c7-4044-4200-b2d1-0f5f328f4ac3_HOMOCYSMETB12-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3686,7 +3613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3702,7 +3629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3717,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3731,7 +3658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3747,7 +3674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3760,7 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3773,18 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002234_956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3796,7 +3712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3813,7 +3729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3829,7 +3745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3840,7 +3756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3848,11 +3764,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_d01575a5-cf01-4922-a292-f96237f553f9_1.5.1.15-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3860,22 +3776,22 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN>
+          <http://model.geneontology.org/d01575a5-cf01-4922-a292-f96237f553f9_1.5.1.15-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_17437>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002234_8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_FORMYLTHFDEFORMYL-RXN_RO_0002233_5ab0553d-7754-4fec-8bca-bf1e2c5e5f9b_FORMYLTHFDEFORMYL-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_17437>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3885,7 +3801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3901,7 +3817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -3919,7 +3835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3936,7 +3852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3947,33 +3863,44 @@
           <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
+<http://model.geneontology.org/0aa000c7-4044-4200-b2d1-0f5f328f4ac3_HOMOCYSMETB12-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_57945_1.5.1.20-RXN_SGD_PWY-2201>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/3d9c7a4c-e37e-412b-b932-042c21a32115_5-FORMYL-THF-CYCLO-LIGASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (6<i>S</i>)-5-formyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_6910d97e-bc96-4d3d-8deb-8201da13fcff_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67387> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3981,7 +3908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3997,7 +3924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4012,7 +3939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4028,7 +3955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4039,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4050,7 +3977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4065,7 +3992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4082,7 +4009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4102,9 +4029,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/44fdd365-1f50-45ee-b788-a6f8df296219_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/1656f2f4-68c9-42dc-b79d-aa5073c63f57_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/ef0c50eb-7ace-47b6-a6d9-6d81a2bd31bc_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4112,7 +4039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4126,7 +4053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4146,15 +4073,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/90cbc433-0909-4b72-80d8-394c86ce671c_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/831860e8-4507-4e39-9adb-61c12bccb87b_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17434_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> , <http://model.geneontology.org/8a72ba7d-6ee2-418b-afd8-5eb9f6e9c5d8_2.1.1.19-RXN> ;
+                <http://model.geneontology.org/74d6a35b-8eec-4e7c-b767-cd15ef49f8af_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.19-RXN> , <http://model.geneontology.org/CHEBI_17437_2.1.1.19-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
                 <http://model.geneontology.org/GCVMULTI-RXN> , <http://model.geneontology.org/FORMATETHFLIG-RXN> , <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4169,7 +4096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4182,7 +4109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4194,7 +4121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4208,30 +4135,13 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_CHEBI_43474_FORMATETHFLIG-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4247,7 +4157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4262,7 +4172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4279,7 +4189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4293,7 +4203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4310,7 +4220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4326,7 +4236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4337,11 +4247,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_63e5e6c0-c233-478c-8067-790feae23cc0_HOMOCYSMETB12-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4349,15 +4259,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/HOMOCYSMETB12-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/286b50a9-1260-4794-ad13-6a0462d10289_HOMOCYSMETB12-RXN>
+          <http://model.geneontology.org/63e5e6c0-c233-478c-8067-790feae23cc0_HOMOCYSMETB12-RXN>
 ] .
+
+<http://model.geneontology.org/246b28cb-7d09-48c9-a63c-9d2a0555885d_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002333_YER183C-MONOMER_5-FORMYL-THF-CYCLO-LIGASE-RXN_controller_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4369,7 +4296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4380,6 +4307,17 @@
           <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOCYSMETB12-RXN_RO_0002233_63e5e6c0-c233-478c-8067-790feae23cc0_HOMOCYSMETB12-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57844_HOMOCYSMETB12-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57844> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4389,7 +4327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4405,11 +4343,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002234_cd3331a9-8d19-47f0-a8d6-c365d7dbf828_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4417,7 +4355,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/388f41c9-123a-482c-ae03-339633130a25_5-FORMYL-THF-CYCLO-LIGASE-RXN>
+          <http://model.geneontology.org/cd3331a9-8d19-47f0-a8d6-c365d7dbf828_5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4426,7 +4364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4442,20 +4380,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5ed6d032-e5d6-4f01-9c87-d43f1bbaf7c0_GLYOHMETRANS-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_5-FORMYL-THF-CYCLO-LIGASE-RXN_RO_0002233_c1f99af4-cd09-4443-aaa5-c9b2f73d9420_5-FORMYL-THF-CYCLO-LIGASE-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/131545db-d16d-4453-9d4f-81a86fd5177a_1.5.1.20-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/1.5.1.20-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4466,9 +4421,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/c82b67dd-8187-420a-8ab9-9645a0aa95bd_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/131545db-d16d-4453-9d4f-81a86fd5177a_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/246b28cb-7d09-48c9-a63c-9d2a0555885d_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -4476,7 +4431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4489,7 +4444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4501,7 +4456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4512,6 +4467,26 @@
           <http://model.geneontology.org/PWY-2201/PWY-2201>
 ] .
 
+<http://model.geneontology.org/d01575a5-cf01-4922-a292-f96237f553f9_1.5.1.15-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003436> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -4519,7 +4494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4534,7 +4509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4542,44 +4517,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/reaction_2.1.1.19-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008864> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY-2201/PWY-2201> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/7c575b6e-6d36-4bb0-b7c3-724ce1d2f323_FORMYLTHFDEFORMYL-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/956a9c1d-44f9-424c-adce-6162ffaf6a50_FORMYLTHFDEFORMYL-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201BiochemicalReaction67739> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -4590,7 +4537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4598,12 +4545,54 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
+<http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008864> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY-2201/PWY-2201> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_FORMYLTHFDEFORMYL-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/CHEBI_15377_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/5ab0553d-7754-4fec-8bca-bf1e2c5e5f9b_FORMYLTHFDEFORMYL-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/7059fb58-63ba-4c11-ba56-36dd595c1f97_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15378_FORMYLTHFDEFORMYL-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMYLTHFDEFORMYL-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201BiochemicalReaction67739> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/5ab0553d-7754-4fec-8bca-bf1e2c5e5f9b_FORMYLTHFDEFORMYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_BFO_0000050_PWY-2201/PWY-2201_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4615,7 +4604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4631,7 +4620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4642,7 +4631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4662,36 +4651,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/6b604762-65fe-41e0-95f5-719575aec09f_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67408> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002233_b3c0708b-7adb-4ca9-8efe-0a1555e41fda_RXN-5061_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4699,7 +4671,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-5061> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a3cb31e6-ab51-431b-be1d-21d5139811ed_RXN-5061>
+          <http://model.geneontology.org/b3c0708b-7adb-4ca9-8efe-0a1555e41fda_RXN-5061>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-5061>
@@ -4711,7 +4683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4724,11 +4696,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/60730349-2c72-49cc-a0e1-e8e27f9b0426_RXN-5061>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4738,11 +4727,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4750,7 +4742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4761,38 +4753,16 @@
           <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/reaction_5-FORMYL-THF-CYCLO-LIGASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN_SGD_PWY-2201>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_d91ff81d-82c0-4e67-b74d-89b3f1516b0a_FORMATETHFLIG-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFDEFORMYL-RXN_null_PWY-2201> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -4803,7 +4773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4812,12 +4782,31 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a tetrahydrofolate + ATP + formate &harr; a 10-formyltetrahydrofolate + ADP + phosphate' 'null' 'a 10-formyltetrahydrofolate + H<sub>2</sub>O &rarr; a tetrahydrofolate + formate + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002413_FORMYLTHFDEFORMYL-RXN_null_PWY-2201> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/FORMYLTHFDEFORMYL-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_2.1.1.19-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4828,33 +4817,33 @@
           <http://model.geneontology.org/2.1.1.19-RXN>
 ] .
 
+<http://model.geneontology.org/63e5e6c0-c233-478c-8067-790feae23cc0_HOMOCYSMETB12-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67345> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.19-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY-2201>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/28add9d7-69a4-4f79-b306-bc948c1b276b_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67744> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4862,7 +4851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4878,7 +4867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4889,7 +4878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4900,7 +4889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4915,7 +4904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4932,7 +4921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4948,18 +4937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-2201" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_632d6797-3910-48f0-aa39-7bdad67d30bb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -4971,7 +4949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4982,13 +4960,30 @@
           <http://model.geneontology.org/5-FORMYL-THF-CYCLO-LIGASE-RXN>
 ] .
 
+<http://model.geneontology.org/7059fb58-63ba-4c11-ba56-36dd595c1f97_FORMYLTHFDEFORMYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67515> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_CHEBI_57540_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5007,7 +5002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5023,7 +5018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -5034,7 +5029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -5045,11 +5040,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_f41c029f-b2a5-48d4-8496-ca35b95ecc7e_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5057,7 +5052,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c47007ce-c771-4196-86e7-f638b2dd6c58_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/f41c029f-b2a5-48d4-8496-ca35b95ecc7e_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller>
@@ -5069,7 +5064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5089,7 +5084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5103,7 +5098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5119,7 +5114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2201" ;
         <http://purl.org/pav/providedBy>
@@ -5134,7 +5129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5144,11 +5139,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN_SGD_PWY-2201> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_44fdd365-1f50-45ee-b788-a6f8df296219_GCVMULTI-RXN_SGD_PWY-2201> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5156,25 +5151,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/233e4e0a-b583-4e66-9bec-1e879fcd8563_GCVMULTI-RXN>
+          <http://model.geneontology.org/44fdd365-1f50-45ee-b788-a6f8df296219_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/36b8dc43-6e87-4495-8734-d3a882827f88_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67360> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_33384> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -5185,10 +5163,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-2201SmallMolecule67709> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_6b5a3f23-39a8-4937-91d3-7f23010d5516_FORMATETHFLIG-RXN_SGD_PWY-2201>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-5061_RO_0002234_60730349-2c72-49cc-a0e1-e8e27f9b0426_RXN-5061_SGD_PWY-2201>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2201" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-2201" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .

--- a/models/PWY-2301-PWY-2301.ttl
+++ b/models/PWY-2301-PWY-2301.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>myo</i>-inositol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -723,7 +723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-2301" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-2301" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-3322-PWY-3322.ttl
+++ b/models/PWY-3322-PWY-3322.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -173,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutamate degradation IX - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-3322" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-3322" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-46-PWY-46.ttl
+++ b/models/PWY-46-PWY-46.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "putrescine biosynthesis III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-46" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-46" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-5041-PWY-5041.ttl
+++ b/models/PWY-5041-PWY-5041.ttl
@@ -1,16 +1,16 @@
-<http://purl.obolibrary.org/obo/GO_0004478>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_6bdc7880-0a28-4d7c-bbd7-08deebafb1a1_RXN-7605_SGD_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0004478>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58207> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -21,13 +21,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30317> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -38,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,6 +60,23 @@
           <http://model.geneontology.org/CHEBI_29888_S-ADENMETSYN-RXN>
 ] .
 
+<http://model.geneontology.org/6bdc7880-0a28-4d7c-bbd7-08deebafb1a1_RXN-7605>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a methylated methyl donor" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30392> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_RXN-7605>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -58,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,14 +332,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#note>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -321,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,23 +357,15 @@
           <http://model.geneontology.org/RXN-7605>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605_SGD_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://www.w3.org/2004/02/skos/core#note>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_BFO_0000066_reaction_S-ADENMETSYN-RXN_location_lociGO_0005829_null_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -460,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -534,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -580,15 +597,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7605_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_RXN-7605> , <http://model.geneontology.org/95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605> ;
+                <http://model.geneontology.org/f26cf89b-c723-414a-840c-2030d8b3541f_RXN-7605> , <http://model.geneontology.org/CHEBI_59789_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
+                <http://model.geneontology.org/6bdc7880-0a28-4d7c-bbd7-08deebafb1a1_RXN-7605> , <http://model.geneontology.org/CHEBI_57856_RXN-7605> , <http://model.geneontology.org/CHEBI_15378_RXN-7605> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/ADENOSYLHOMOCYSTEINASE-RXN> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,7 +707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -781,11 +798,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605_SGD_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_f26cf89b-c723-414a-840c-2030d8b3541f_RXN-7605_SGD_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,8 +810,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605>
+          <http://model.geneontology.org/f26cf89b-c723-414a-840c-2030d8b3541f_RXN-7605>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_f26cf89b-c723-414a-840c-2030d8b3541f_RXN-7605_SGD_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -805,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,23 +844,23 @@
           <http://model.geneontology.org/MONOMER3O-1014_S-ADENMETSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_43474_S-ADENMETSYN-RXN_SGD_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002233_CHEBI_30616_S-ADENMETSYN-RXN_SGD_PWY-5041>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -871,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -901,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,17 +943,6 @@
 <http://identifiers.org/sgd/S000002910>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002333_YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller_SGD_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_ADENOSYLHOMOCYSTEINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -935,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,12 +960,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002333_YER043C-MONOMER_ADENOSYLHOMOCYSTEINASE-RXN_controller_SGD_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ADENOSYLHOMOCYSTEINASE-RXN_RO_0002233_CHEBI_57856_ADENOSYLHOMOCYSTEINASE-RXN_SGD_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,23 +1002,6 @@
           <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a demethylated methyl donor" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30372> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -999,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>S</i>-adenosyl-L-methionine cycle II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1049,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1062,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1070,29 +1081,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a methylated methyl donor" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30392> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000050_PWY-5041/PWY-5041_SGD_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,7 +1130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1153,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1194,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1229,7 +1223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1284,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1331,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1368,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1426,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1459,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,9 +1489,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_null_PWY-5041>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5041" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1507,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1518,17 +1523,6 @@
           <http://model.geneontology.org/CHEBI_58199_ADENOSYLHOMOCYSTEINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_BFO_0000066_reaction_HOMOCYSMET-RXN_location_lociGO_0005829_null_PWY-5041>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5041" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://identifiers.org/sgd/S000004170>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1538,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1564,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1581,7 +1575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1597,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1613,11 +1607,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605_SGD_PWY-5041> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002234_6bdc7880-0a28-4d7c-bbd7-08deebafb1a1_RXN-7605_SGD_PWY-5041> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,29 +1619,35 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7605> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c32e648c-fd53-4633-85f8-3960a9523773_RXN-7605>
+          <http://model.geneontology.org/6bdc7880-0a28-4d7c-bbd7-08deebafb1a1_RXN-7605>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-7605_RO_0002233_95b7de90-9e68-45c8-a8ff-f68bc349f8b6_RXN-7605_SGD_PWY-5041>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/f26cf89b-c723-414a-840c-2030d8b3541f_RXN-7605>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a demethylated methyl donor" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5041" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5041SmallMolecule30372> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002333_YER091C-MONOMER_HOMOCYSMET-RXN_controller_SGD_PWY-5041>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5041" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5041" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5080-1-PWY-5080-1.ttl
+++ b/models/PWY-5080-1-PWY-5080-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -28,18 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814_SGD_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,35 +56,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 3-hydroxyacyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9812_BFO_0000066_reaction_RXN3O-9812_location_lociGO_0005829_null_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +158,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57783_RXN3O-9812> , <http://model.geneontology.org/CHEBI_15489_RXN3O-9812> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> , <http://model.geneontology.org/16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812> ;
+                <http://model.geneontology.org/CHEBI_58349_RXN3O-9812> , <http://model.geneontology.org/4822777e-aead-4ef4-bfa0-029d4c8992d8_RXN3O-9812> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-79_RXN3O-9812_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -194,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -218,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,11 +219,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_14e0a409-e19c-4220-84e0-0d1c58c1e3ea_RXN3O-9813_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,7 +231,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813>
+          <http://model.geneontology.org/14e0a409-e19c-4220-84e0-0d1c58c1e3ea_RXN3O-9813>
 ] .
 
 <http://model.geneontology.org/CHEBI_58349_RXN3O-9812>
@@ -271,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,12 +271,23 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_dc9ec985-684d-4156-880d-641143a4feff_RXN3O-9813_SGD_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002333_MONOMER3O-85_RXN3O-9813_controller_SGD_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -330,12 +313,23 @@
 <http://identifiers.org/sgd/S000000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_5f952822-326c-4095-805a-56a70d920c58_RXN3O-9814_SGD_PWY-5080-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -350,13 +344,24 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_4822777e-aead-4ef4-bfa0-029d4c8992d8_RXN3O-9812_SGD_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002233_CHEBI_15489_RXN3O-9812_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -501,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -518,6 +523,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_14e0a409-e19c-4220-84e0-0d1c58c1e3ea_RXN3O-9813_SGD_PWY-5080-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5080-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9813>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -527,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,23 +654,6 @@
           <http://model.geneontology.org/YCR034W-MONOMER_RXN3O-9811_controller>
 ] .
 
-<http://model.geneontology.org/ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -664,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,9 +674,6 @@
           <http://model.geneontology.org/CHEBI_15378_RXN3O-9812>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_15489>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_16526_RXN3O-9811>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -687,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,13 +691,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/CHEBI_15489>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9811_RO_0002233_CHEBI_33184_RXN3O-9811_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,23 +750,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812_SGD_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000050_PWY-5080-1/PWY-5080-1_SGD_PWY-5080-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -793,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -822,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -836,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,22 +835,11 @@
           <http://model.geneontology.org/CHEBI_58349_RXN3O-9814>
 ] .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813_SGD_PWY-5080-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -870,7 +847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -993,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,28 +990,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1046,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1061,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1075,7 +1035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,22 +1054,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/5f952822-326c-4095-805a-56a70d920c58_RXN3O-9814>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002234_4822777e-aead-4ef4-bfa0-029d4c8992d8_RXN3O-9812_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,7 +1094,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9812> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812>
+          <http://model.geneontology.org/4822777e-aead-4ef4-bfa0-029d4c8992d8_RXN3O-9812>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1126,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1161,23 +1138,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/16da5e07-0fd6-402b-a18c-98eaee4158e7_RXN3O-9812>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 3-hydroxyacyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/RXN3O-9814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0102758> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1187,7 +1147,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9814_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> ;
+                <http://model.geneontology.org/5f952822-326c-4095-805a-56a70d920c58_RXN3O-9814> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9814> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9814> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9814> , <http://model.geneontology.org/CHEBI_33184_RXN3O-9814> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1195,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1208,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1219,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1231,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,7 +1208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,11 +1221,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002234_dc9ec985-684d-4156-880d-641143a4feff_RXN3O-9813_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1233,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9813> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813>
+          <http://model.geneontology.org/dc9ec985-684d-4156-880d-641143a4feff_RXN3O-9813>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
@@ -1288,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1301,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1333,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,17 +1304,6 @@
 <http://model.geneontology.org/reaction_RXN3O-9811_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9813_RO_0002233_86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813_SGD_PWY-5080-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5080-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1363,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1377,11 +1326,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814_SGD_PWY-5080-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_5f952822-326c-4095-805a-56a70d920c58_RXN3O-9814_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1389,7 +1338,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9814> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/af7013dd-0906-4d84-91ae-20201bee8853_RXN3O-9814>
+          <http://model.geneontology.org/5f952822-326c-4095-805a-56a70d920c58_RXN3O-9814>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9813_BFO_0000066_reaction_RXN3O-9813_location_lociGO_0005829_null_PWY-5080-1>
@@ -1397,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1411,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1423,7 +1372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1440,7 +1389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,13 +1400,30 @@
           <http://model.geneontology.org/CHEBI_16526_RXN3O-9811>
 ] .
 
+<http://model.geneontology.org/4822777e-aead-4ef4-bfa0-029d4c8992d8_RXN3O-9812>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 3-hydroxyacyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9814_RO_0002233_CHEBI_15378_RXN3O-9814_SGD_PWY-5080-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,18 +1439,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/dc9ec985-684d-4156-880d-641143a4feff_RXN3O-9813>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75474> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9812_RO_0002413_RXN3O-9813_null_PWY-5080-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
@@ -1510,9 +1493,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9813_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/86e8c535-9751-41fe-95e6-46b29562e1f5_RXN3O-9813> ;
+                <http://model.geneontology.org/14e0a409-e19c-4220-84e0-0d1c58c1e3ea_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ae841fba-3d2a-4c70-980e-bde4e6f08b2e_RXN3O-9813> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9813> , <http://model.geneontology.org/dc9ec985-684d-4156-880d-641143a4feff_RXN3O-9813> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-85_RXN3O-9813_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1520,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1537,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "very long chain fatty acid biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1553,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,11 +1555,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5080-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/14e0a409-e19c-4220-84e0-0d1c58c1e3ea_RXN3O-9813>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 3-hydroxyacyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5080-1SmallMolecule75543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1584,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5080-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5084-PWY-5084.ttl
+++ b/models/PWY-5084-PWY-5084.ttl
@@ -1,12 +1,12 @@
 <http://identifiers.org/sgd/S000002555>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_029caa0a-d4eb-4269-99e1-038d67c4af54_RXN0-1147_SGD_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -14,11 +14,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_029caa0a-d4eb-4269-99e1-038d67c4af54_RXN0-1147_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147>
+          <http://model.geneontology.org/029caa0a-d4eb-4269-99e1-038d67c4af54_RXN0-1147>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,6 +100,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_57292>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/6428995e-6386-4fd7-be6e-dcdee7cc7a4f_RXN-7716>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -109,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,9 +146,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2OXOGLUTDECARB-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/3077cb2f-96a7-44ee-8990-dba3c6408412_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_15378_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16810_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN> ;
+                <http://model.geneontology.org/49f0663a-b782-4093-b098-c25a5bfd7e96_2OXOGLUTDECARB-RXN> , <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -139,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +169,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_ea136246-74d5-418b-83ff-875e98e6f3cb_RXN-7716_SGD_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +191,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_f497659c-2c99-4ff3-acf7-c0663f426745_RXN0-1147_SGD_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -178,30 +217,27 @@
 <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_6428995e-6386-4fd7-be6e-dcdee7cc7a4f_RXN-7716_SGD_PWY-5084>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_CHEBI_57292_RXN0-1147_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147_SGD_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller>
         a       <http://identifiers.org/sgd/S000001876> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -210,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,24 +254,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_null_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7716> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
-] .
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16526_2OXOGLUTDECARB-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -246,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,34 +291,31 @@
           <http://model.geneontology.org/CHEBI_57292_RXN0-1147>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002233_58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147_SGD_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716_SGD_PWY-5084>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_null_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7716> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_CHEBI_57945_RXN-7716_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,12 +338,29 @@
           <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller>
 ] .
 
+<http://model.geneontology.org/f497659c-2c99-4ff3-acf7-c0663f426745_RXN0-1147>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-7716_BFO_0000066_reaction_RXN-7716_location_lociGO_0005829_null_PWY-5084>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -354,6 +388,23 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/029caa0a-d4eb-4269-99e1-038d67c4af54_RXN0-1147>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/PWY-5084>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -364,30 +415,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "2-oxoglutarate decarboxylation to succinyl-CoA - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004149>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -403,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -434,9 +468,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57292_RXN0-1147> , <http://model.geneontology.org/58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147> ;
+                <http://model.geneontology.org/029caa0a-d4eb-4269-99e1-038d67c4af54_RXN0-1147> , <http://model.geneontology.org/CHEBI_57292_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN0-1147> , <http://model.geneontology.org/f497659c-2c99-4ff3-acf7-c0663f426745_RXN0-1147> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-16_RXN0-1147_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -444,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -492,11 +526,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_6428995e-6386-4fd7-be6e-dcdee7cc7a4f_RXN-7716_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +538,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716>
+          <http://model.geneontology.org/6428995e-6386-4fd7-be6e-dcdee7cc7a4f_RXN-7716>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_CHEBI_57540_RXN-7716_SGD_PWY-5084>
@@ -512,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -540,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -551,28 +585,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -585,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,22 +613,16 @@
           <http://model.geneontology.org/reaction_RXN0-1147_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/58dfbeb7-e287-4ed5-b5d9-5056fb57765f_RXN0-1147>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_3077cb2f-96a7-44ee-8990-dba3c6408412_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -619,7 +630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,11 +643,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_49f0663a-b782-4093-b098-c25a5bfd7e96_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +655,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/49f0663a-b782-4093-b098-c25a5bfd7e96_2OXOGLUTDECARB-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829>
@@ -661,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -690,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,28 +768,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57540_RXN-7716>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -786,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,12 +791,29 @@
           <http://model.geneontology.org/PWY-5084/PWY-5084>
 ] .
 
+<http://model.geneontology.org/CHEBI_57540_RXN-7716>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_CHEBI_16810_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -871,9 +882,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7716_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716> ;
+                <http://model.geneontology.org/CHEBI_57540_RXN-7716> , <http://model.geneontology.org/ea136246-74d5-418b-83ff-875e98e6f3cb_RXN-7716> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716> , <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
+                <http://model.geneontology.org/CHEBI_57945_RXN-7716> , <http://model.geneontology.org/6428995e-6386-4fd7-be6e-dcdee7cc7a4f_RXN-7716> , <http://model.geneontology.org/CHEBI_15378_RXN-7716> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN-7716_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -881,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -901,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -914,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -923,16 +934,33 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ea136246-74d5-418b-83ff-875e98e6f3cb_RXN-7716>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_f497659c-2c99-4ff3-acf7-c0663f426745_RXN0-1147_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +968,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1147> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147>
+          <http://model.geneontology.org/f497659c-2c99-4ff3-acf7-c0663f426745_RXN0-1147>
 ] .
 
 <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
@@ -948,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -958,7 +986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -996,7 +1024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1013,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1021,22 +1049,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_PWY-5084> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
-] .
+<http://model.geneontology.org/3077cb2f-96a7-44ee-8990-dba3c6408412_2OXOGLUTDECARB-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16973> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1046,7 +1074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1083,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,24 +1119,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5084" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-12_2OXOGLUTDECARB-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001387_CPLX3O-12_component>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002233_3077cb2f-96a7-44ee-8990-dba3c6408412_2OXOGLUTDECARB-RXN_SGD_PWY-5084> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,25 +1150,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2OXOGLUTDECARB-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6502a9d9-9579-480d-902b-7d96a143a8f7_2OXOGLUTDECARB-RXN>
+          <http://model.geneontology.org/3077cb2f-96a7-44ee-8990-dba3c6408412_2OXOGLUTDECARB-RXN>
 ] .
-
-<http://model.geneontology.org/34ba6d6e-0d27-4d24-bd2f-6b3e0bd0a41a_RXN0-1147>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1147,26 +1164,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716>
+<http://model.geneontology.org/49f0663a-b782-4093-b098-c25a5bfd7e96_2OXOGLUTDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule16950> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1182,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,11 +1212,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716_SGD_PWY-5084> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002233_ea136246-74d5-418b-83ff-875e98e6f3cb_RXN-7716_SGD_PWY-5084> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1224,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7716> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/73c9ecd9-5d64-46ba-9f39-eddb08125c80_RXN-7716>
+          <http://model.geneontology.org/ea136246-74d5-418b-83ff-875e98e6f3cb_RXN-7716>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-12_2OXOGLUTDECARB-RXN_controller_BFO_0000051_SGD_S000001387_CPLX3O-12_component_SGD_PWY-5084>
@@ -1215,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,46 +1255,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/e4a8e963-70c0-4160-9105-04c2ebea3cd2_2OXOGLUTDECARB-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [2-oxoglutarate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-succinyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5084SmallMolecule17047> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000001876>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN-7716_RO_0002234_67297050-9231-4a13-89f5-8da3fee97c10_RXN-7716_SGD_PWY-5084>
+<http://model.geneontology.org/ev_w_id_2OXOGLUTDECARB-RXN_RO_0002234_49f0663a-b782-4093-b098-c25a5bfd7e96_2OXOGLUTDECARB-RXN_SGD_PWY-5084>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000001876>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN0-1147_RO_0002234_CHEBI_57287_RXN0-1147_SGD_PWY-5084>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5084" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5084" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-5123-PWY-5123.ttl
+++ b/models/PWY-5123-PWY-5123.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "<i>trans, trans</i>-farnesyl diphosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -370,7 +370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -938,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5123" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5177-PWY-5177.ttl
+++ b/models/PWY-5177-PWY-5177.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -251,7 +251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutaryl-CoA degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -350,25 +350,25 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002413_GLUTACONYL-COA-DECARBOXYLASE-RXN_null_PWY-5177>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002233_CHEBI_15378_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY-5177>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002413_GLUTACONYL-COA-DECARBOXYLASE-RXN_null_PWY-5177>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,41 +528,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5177SmallMolecule43639> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000066_reaction_RXN-11662_location_lociGO_0005829_null_PWY-5177>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5177" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57286_RXN-11662>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57286> ;
@@ -573,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -581,13 +553,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_ACETYL-COA-ACETYLTRANSFER-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN-11662_BFO_0000066_reaction_RXN-11662_location_lociGO_0005829_null_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLUTACONYL-COA-DECARBOXYLASE-RXN_RO_0002233_CHEBI_15378_GLUTACONYL-COA-DECARBOXYLASE-RXN_SGD_PWY-5177>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5177" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTARYL-COA-DEHYDROG-RXN_RO_0002234_CHEBI_57353_GLUTARYL-COA-DEHYDROG-RXN_SGD_PWY-5177> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -774,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -802,7 +802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -867,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -998,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1160,7 +1160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1216,7 +1216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1294,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1373,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1387,7 +1387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5177" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1556,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5177" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5194-1-PWY-5194-1.ttl
+++ b/models/PWY-5194-1-PWY-5194-1.ttl
@@ -9,7 +9,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -922,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -1041,25 +1041,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/CHEBI_58827_RXN-13403>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58827> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "precorrin-2" ;
+                "ferrochelatase / precorrin-2 dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41712> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1Protein41778> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/DIMETHUROPORDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0043115> ;
@@ -1080,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1093,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,26 +1147,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/MONOMER3O-106_SIROHEME-FERROCHELAT-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+<http://model.geneontology.org/CHEBI_58827_RXN-13403>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58827> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "ferrochelatase / precorrin-2 dehydrogenase" ;
+                "precorrin-2" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1Protein41778> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5194-1SmallMolecule41712> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_58827_DIMETHUROPORDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58827> ;
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,7 +1196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5194-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5194-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5340-PWY-5340.ttl
+++ b/models/PWY-5340-PWY-5340.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate activation (for sulfonation) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -780,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +841,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5340" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5340" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5344-PWY-5344.ttl
+++ b/models/PWY-5344-PWY-5344.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -22,7 +22,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -464,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5344" ;
         <http://purl.org/pav/providedBy>
@@ -793,7 +793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5344" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-homocysteine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5651-PWY-5651.ttl
+++ b/models/PWY-5651-PWY-5651.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,16 +463,13 @@
           <http://model.geneontology.org/CHEBI_15377_3-HYDROXY-KYNURENINASE-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN_SGD_PWY-5651> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,6 +479,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_KYNURENINE-3-MONOOXYGENASE-RXN>
 ] .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -529,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan degradation to 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -821,16 +821,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5651SmallMolecule74027> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/RXN-8665>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0033754> ;
@@ -851,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,12 +856,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_RXN-8665_BFO_0000066_reaction_RXN-8665_location_lociGO_0005829_null_PWY-5651>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -923,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -957,7 +957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1044,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1063,7 +1063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1111,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1395,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1418,7 +1418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1458,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1474,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1499,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,7 +1516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1619,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1642,7 +1642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1673,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1685,7 +1685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,7 +1707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1735,7 +1735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1758,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1774,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1794,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,7 +1834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1895,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -1924,7 +1924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1959,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1974,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1988,7 +1988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5651" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5651" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5651" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5653-PWY-5653.ttl
+++ b/models/PWY-5653-PWY-5653.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD biosynthesis from 2-amino-3-carboxymuconate semialdehyde - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,7 +870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1028,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1039,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1062,7 +1062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1216,7 +1216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1291,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1331,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1403,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1430,7 +1430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1483,7 +1483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1541,7 +1541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1558,7 +1558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1606,7 +1606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1701,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1718,7 +1718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5653" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1786,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5653" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5653" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5669-PWY-5669.ttl
+++ b/models/PWY-5669-PWY-5669.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,30 +37,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_15378_PHOSPHASERDECARB-RXN_SGD_PWY-5669>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002234_CHEBI_60377_PHOSPHASERSYN-RXN_SGD_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylethanolamine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -119,29 +119,12 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PWY-5669>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -173,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,17 +224,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN_SGD_PWY-5669>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5669" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -261,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -277,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +264,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/2104ed49-ba74-4039-be84-dd654a3b2852_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -302,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -332,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -510,11 +482,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN_SGD_PWY-5669> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_2104ed49-ba74-4039-be84-dd654a3b2852_PHOSPHASERSYN-RXN_SGD_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +494,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5d8756ce-28f9-4a1f-8aa4-01393e9c0aad_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/2104ed49-ba74-4039-be84-dd654a3b2852_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -533,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -557,6 +529,17 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_2104ed49-ba74-4039-be84-dd654a3b2852_PHOSPHASERSYN-RXN_SGD_PWY-5669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5669" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -569,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -583,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -606,7 +589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -638,13 +621,30 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/2104ed49-ba74-4039-be84-dd654a3b2852_PHOSPHASERSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5669SmallMolecule21674> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_CHEBI_33384_PHOSPHASERSYN-RXN_SGD_PWY-5669> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -822,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5669" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5669" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5670-1-PWY-5670-1.ttl
+++ b/models/PWY-5670-1-PWY-5670-1.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "epoxysqualene biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,24 +50,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57310>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN3O-9816_SGD_PWY-5670-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5670-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002234_CHEBI_15441_RXN3O-9816_SGD_PWY-5670-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,33 +67,27 @@
           <http://model.geneontology.org/CHEBI_15441_RXN3O-9816>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002233_CHEBI_15440_RXN3O-9816_SGD_PWY-5670-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5670-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-12263_BFO_0000066_reaction_RXN-12263_location_lociGO_0005829_null_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY-5670-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-12263> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57310_RXN-12263>
-] .
 
 <http://model.geneontology.org/CHEBI_57310_RXN66-281>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57310> ;
@@ -115,13 +98,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5670-1SmallMolecule74444> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY-5670-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-12263> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57310_RXN-12263>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,7 +265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,6 +285,9 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_29888_RXN-12263>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -294,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,15 +336,12 @@
           <http://model.geneontology.org/CHEBI_57310_RXN66-281>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24331>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9816_RO_0002333_YGR175C-MONOMER_RXN3O-9816_controller_SGD_PWY-5670-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -465,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -873,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -918,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,14 +937,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17499_RXN3O-9816>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24331> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1050,7 +1050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1097,7 +1097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1141,7 @@
 ] .
 
 <http://model.geneontology.org/CHEBI_15339_RXN3O-9816>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5670-1" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1236,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5670-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5686-1-PWY-5686-1.ttl
+++ b/models/PWY-5686-1-PWY-5686-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -552,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -606,7 +606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -690,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -807,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1058,7 +1058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1260,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1280,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,7 +1313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1358,7 +1358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1466,7 +1466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1598,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1669,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,7 +1730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1745,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1835,7 +1835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1851,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1862,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1874,7 +1874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1892,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1909,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -1937,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1977,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1994,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UMP biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +2008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2036,7 +2036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2070,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2122,7 +2122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2142,7 +2142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2158,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2170,7 +2170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2190,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2215,7 +2215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2235,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2264,7 +2264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,7 +2281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2310,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2327,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,7 +2347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2365,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2379,7 +2379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2395,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2406,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2431,7 +2431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2444,7 +2444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2455,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2470,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2483,7 +2483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2493,7 +2493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2510,7 +2510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2532,7 +2532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2551,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>
@@ -2566,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2583,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2597,7 +2597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2614,7 +2614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2633,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5686-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5686-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5694-PWY-5694.ttl
+++ b/models/PWY-5694-PWY-5694.ttl
@@ -8,7 +8,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -21,7 +21,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -273,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -406,7 +406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -577,7 +577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -677,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to glyoxylate I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -871,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -900,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,7 +975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5694" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,7 +1025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5694" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5697-PWY-5697.ttl
+++ b/models/PWY-5697-PWY-5697.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -39,7 +39,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "allantoin degradation to ureidoglycolate I (urea producing) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -182,7 +182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -262,7 +262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5697" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5697" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5703-PWY-5703.ttl
+++ b/models/PWY-5703-PWY-5703.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,13 +71,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ALLOPHANATE-HYDROLASE-RXN_RO_0002233_CHEBI_15832_ALLOPHANATE-HYDROLASE-RXN_SGD_PWY-5703> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,9 +90,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15832_ALLOPHANATE-HYDROLASE-RXN>
 ] .
-
-<http://model.geneontology.org/reaction_ALLOPHANATE-HYDROLASE-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -635,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "urea degradation I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5703" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -992,7 +992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5703" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5703" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-5760-1-PWY-5760-1.ttl
+++ b/models/PWY-5760-1-PWY-5760-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "&beta;-alanine biosynthesis IV - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -349,7 +349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,7 +561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,7 +669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5760-1" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5760-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-5971-1-PWY-5971-1.ttl
+++ b/models/PWY-5971-1-PWY-5971-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -166,18 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9538_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,13 +191,24 @@
           <http://model.geneontology.org/reaction_RXN-9518_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002233_Tetradec-2-enoyl-ACPs_RXN-9538_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9536_RO_0002234_CHEBI_57783_RXN-9536_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -333,7 +333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -741,7 +741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,7 +792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -853,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -909,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1032,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1091,28 +1091,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33050> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ACP_RXN-9520>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (3<i>R</i>)-3-hydroxyhexanoyl-[acp]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33252> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -1122,7 +1105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,12 +1116,29 @@
           <http://model.geneontology.org/Tetradec-2-enoyl-ACPs_RXN-9537>
 ] .
 
+<http://model.geneontology.org/ACP_RXN-9520>
+        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (3<i>R</i>)-3-hydroxyhexanoyl-[acp]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33252> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 <http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9527_SGD_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1395,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,7 +1560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,7 +1580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1617,7 +1617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1637,7 +1637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,7 +1713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1738,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1749,7 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1816,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1830,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1850,7 +1850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1867,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1898,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1914,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -1926,7 +1926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1943,7 +1943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,7 +1962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2007,7 +2007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2057,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2082,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2094,7 +2094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,7 +2113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2140,7 +2140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2151,7 +2151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2184,53 +2184,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_58349_RXN-9526>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32976> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9530> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
-] .
-
-<http://purl.org/pav/providedBy>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9655_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2241,12 +2201,52 @@
           <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
 ] .
 
+<http://model.geneontology.org/CHEBI_58349_RXN-9526>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32976> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/pav/providedBy>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9530_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9530> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-9526_RO_0002233_CHEBI_15378_RXN-9526_SGD_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2255,35 +2255,16 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_CHEBI_15378_RXN-9523_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000066_reaction_RXN-9516_location_lociGO_0005829_null_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
+                "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000066_reaction_RXN-9536_location_lociGO_0005829_null_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9536> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9536_location_lociGO_0005829>
-] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2291,7 +2272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,25 +2283,44 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-9524>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9536_BFO_0000066_reaction_RXN-9536_location_lociGO_0005829_null_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9536> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9536_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_null_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9516_BFO_0000066_reaction_RXN-9516_location_lociGO_0005829_null_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9523_RO_0002233_CHEBI_15378_RXN-9523_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5971-1" ;
+                "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2329,18 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2352,7 +2341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2363,13 +2352,24 @@
           <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002234_CHEBI_57783_RXN-9532_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,7 +2388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2408,7 +2408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2436,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2461,7 +2461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2477,7 +2477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2489,7 +2489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2507,7 +2507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2523,7 +2523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2540,7 +2540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2563,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2576,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2587,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2599,7 +2599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2616,7 +2616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2632,32 +2632,32 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN-9534_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_RXN-9524_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/reaction_RXN-9534_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_15378_RXN-9626_SGD_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2668,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2680,7 +2680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2700,7 +2700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2728,7 +2728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2747,7 +2747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2767,7 +2767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2784,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2815,7 +2815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2835,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2848,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2859,7 +2859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2870,7 +2870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2883,7 +2883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2900,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2913,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -2925,7 +2925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2955,7 +2955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2969,7 +2969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2988,7 +2988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3021,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3050,7 +3050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3067,7 +3067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3083,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3097,7 +3097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3109,7 +3109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3125,7 +3125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3137,7 +3137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3154,7 +3154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3170,20 +3170,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9528_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3196,7 +3185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3204,12 +3193,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9528_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000066_reaction_4.2.1.59-RXN_location_lociGO_0005829_null_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3224,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3237,7 +3237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3249,7 +3249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3303,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3317,7 +3317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3334,7 +3334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3350,7 +3350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3365,7 +3365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3397,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3414,7 +3414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3431,7 +3431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3475,7 +3475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3491,7 +3491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3502,7 +3502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3513,7 +3513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3525,7 +3525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3542,7 +3542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3561,7 +3561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3572,7 +3572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3583,7 +3583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3595,7 +3595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3612,7 +3612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3628,7 +3628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3642,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3671,7 +3671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3684,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3699,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3712,7 +3712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3726,7 +3726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3742,7 +3742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3757,7 +3757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3771,7 +3771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3791,7 +3791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3805,7 +3805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3822,7 +3822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3842,7 +3842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3859,7 +3859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3872,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3884,7 +3884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3901,7 +3901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3921,7 +3921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3934,7 +3934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3945,7 +3945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -3957,7 +3957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3976,7 +3976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3996,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4009,7 +4009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4024,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4037,7 +4037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4049,7 +4049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4066,7 +4066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4082,7 +4082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4095,7 +4095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4111,7 +4111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4141,7 +4141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4155,7 +4155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4171,7 +4171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4182,7 +4182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4197,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4211,7 +4211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4228,7 +4228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4244,7 +4244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4257,7 +4257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4270,7 +4270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4281,7 +4281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4295,7 +4295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4310,7 +4310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4326,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4337,7 +4337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4349,7 +4349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4382,7 +4382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4395,7 +4395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4407,7 +4407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4430,7 +4430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4443,7 +4443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4455,7 +4455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4475,7 +4475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4488,7 +4488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4503,7 +4503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4516,7 +4516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4530,7 +4530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4549,7 +4549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4565,7 +4565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4576,7 +4576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4588,7 +4588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4607,7 +4607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4623,7 +4623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4637,7 +4637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4654,7 +4654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4665,13 +4665,24 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN-9533_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000066_reaction_RXN-9535_location_lociGO_0005829_null_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_RO_0002333_YKL182W-MONOMER_4.2.1.59-RXN_controller_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4682,17 +4693,6 @@
           <http://model.geneontology.org/YKL182W-MONOMER_4.2.1.59-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_BFO_0000066_reaction_RXN-9535_location_lociGO_0005829_null_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -4701,7 +4701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4731,7 +4731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4745,7 +4745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4761,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4776,7 +4776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4790,7 +4790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4807,7 +4807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4827,7 +4827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4840,7 +4840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4852,7 +4852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4871,7 +4871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4887,7 +4887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4898,7 +4898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4909,7 +4909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4920,7 +4920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -4935,7 +4935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4952,7 +4952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4966,7 +4966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4996,7 +4996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5009,7 +5009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5023,7 +5023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5041,7 +5041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5055,7 +5055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5071,7 +5071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5086,7 +5086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5100,7 +5100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5116,7 +5116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5128,7 +5128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5145,7 +5145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5161,7 +5161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5176,7 +5176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5192,7 +5192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5207,7 +5207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5224,7 +5224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5240,7 +5240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5251,7 +5251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5266,7 +5266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5283,7 +5283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5300,7 +5300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5330,7 +5330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5346,7 +5346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5369,7 +5369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5386,7 +5386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5403,7 +5403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5423,7 +5423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5436,7 +5436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5447,7 +5447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5462,7 +5462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5475,7 +5475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5487,7 +5487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5503,7 +5503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5515,7 +5515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5535,7 +5535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5551,7 +5551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5576,7 +5576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5589,7 +5589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5603,7 +5603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5623,7 +5623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5637,7 +5637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5653,7 +5653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5665,7 +5665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5686,7 +5686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5703,7 +5703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5716,7 +5716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5727,7 +5727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5740,7 +5740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5754,7 +5754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5771,7 +5771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5787,7 +5787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5802,7 +5802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5818,7 +5818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5835,7 +5835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5851,7 +5851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5862,7 +5862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5873,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5885,7 +5885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5902,7 +5902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5918,7 +5918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5929,7 +5929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5941,7 +5941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5958,7 +5958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5974,7 +5974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -5986,7 +5986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6003,7 +6003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6026,7 +6026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6039,7 +6039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6054,7 +6054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6071,7 +6071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6085,7 +6085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6104,7 +6104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6120,7 +6120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6131,7 +6131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6146,7 +6146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6162,7 +6162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6179,7 +6179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6193,13 +6193,24 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002333_YKL182W-MONOMER_RXN-9655_controller_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9538_RO_0002333_YKL182W-MONOMER_RXN-9538_controller_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6210,17 +6221,6 @@
           <http://model.geneontology.org/YKL182W-MONOMER_RXN-9538_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9655_RO_0002333_YKL182W-MONOMER_RXN-9655_controller_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/Tetradec-2-enoyl-ACPs_RXN-9537>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6230,7 +6230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6247,7 +6247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6260,7 +6260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6272,7 +6272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6288,7 +6288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6305,7 +6305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6316,7 +6316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6327,7 +6327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6338,7 +6338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6349,7 +6349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6361,7 +6361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6381,7 +6381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6408,7 +6408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6425,7 +6425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "myristate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6439,7 +6439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6456,7 +6456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6474,7 +6474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6490,7 +6490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6502,7 +6502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6519,7 +6519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6539,7 +6539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6552,7 +6552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6567,7 +6567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6581,7 +6581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6598,7 +6598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6614,7 +6614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6632,7 +6632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6662,7 +6662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6676,7 +6676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6692,7 +6692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6703,7 +6703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6715,7 +6715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6724,25 +6724,6 @@
           <http://model.geneontology.org/RXN-9520> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/Hex-2-enoyl-ACPs_RXN-9520>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_null_PWY-5971-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-9538> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN-9538_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/ACP_RXN-9524>
@@ -6754,7 +6735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6762,12 +6743,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-9538_BFO_0000066_reaction_RXN-9538_location_lociGO_0005829_null_PWY-5971-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-9538> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN-9538_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-8214_RO_0002234_ACP_RXN3O-8214_SGD_PWY-5971-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6788,7 +6788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6802,7 +6802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6819,7 +6819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6835,7 +6835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6846,7 +6846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6857,7 +6857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6869,7 +6869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6885,7 +6885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6908,7 +6908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6923,7 +6923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6940,7 +6940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6953,7 +6953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -6966,7 +6966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6980,7 +6980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6991,23 +6991,6 @@
           <http://model.geneontology.org/PWY-5971-1/PWY-5971-1>
 ] .
 
-<http://model.geneontology.org/ACP_RXN-9536>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (3<i>R</i>)-3-hydroxytetradecanoyl-[acp]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33026> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN-9626>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7017,13 +7000,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1SmallMolecule32956> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ACP_RXN-9536>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (3<i>R</i>)-3-hydroxytetradecanoyl-[acp]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-5971-1Protein33026> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/Dodec-2-enoyl-ACPs_RXN-9533>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
@@ -7034,7 +7034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7047,7 +7047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7058,7 +7058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7083,7 +7083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7094,12 +7094,12 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002411_RXN-9655_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7110,18 +7110,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002411_RXN-9655_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002333_YPL231W-MONOMER_RXN-9535_controller_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7132,7 +7132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7147,7 +7147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7155,12 +7155,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7175,7 +7175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7183,13 +7183,35 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-9528_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_null_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9528_RO_0002234_3-oxo-decanoyl-ACPs_RXN-9528_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7200,35 +7222,13 @@
           <http://model.geneontology.org/3-oxo-decanoyl-ACPs_RXN-9528>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_BFO_0000066_reaction_RXN-9527_location_lociGO_0005829_null_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-9535_RO_0002233_CHEBI_15378_RXN-9535_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9626_RO_0002234_CHEBI_30807_RXN-9626_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7248,7 +7248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7261,7 +7261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7272,7 +7272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7284,7 +7284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7301,7 +7301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7317,7 +7317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7328,7 +7328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7340,7 +7340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7351,13 +7351,24 @@
           <http://model.geneontology.org/3-oxo-hexanoyl-ACPs_RXN-9518>
 ] .
 
+<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9532_RO_0002233_CHEBI_58349_RXN-9532_SGD_PWY-5971-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7368,17 +7379,6 @@
           <http://model.geneontology.org/CHEBI_58349_RXN-9532>
 ] .
 
-<http://model.geneontology.org/ev_w_id_4.2.1.59-RXN_BFO_0000050_PWY-5971-1/PWY-5971-1_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ACP_RXN-9518>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7388,7 +7388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7403,7 +7403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7416,7 +7416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7431,7 +7431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7447,7 +7447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7464,7 +7464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7484,7 +7484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7498,7 +7498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7515,7 +7515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7531,7 +7531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7546,7 +7546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7560,7 +7560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7577,7 +7577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7594,7 +7594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7605,6 +7605,17 @@
           <http://model.geneontology.org/ACP_RXN-9531>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_CHEBI_16526_RXN-9527_SGD_PWY-5971-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-5971-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57287_RXN-9626>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57287> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7614,7 +7625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7622,23 +7633,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-9527_RO_0002234_CHEBI_16526_RXN-9527_SGD_PWY-5971-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-5971-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-9521_RO_0002233_CHEBI_15378_RXN-9521_SGD_PWY-5971-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7652,7 +7652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7664,7 +7664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7684,7 +7684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7711,7 +7711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7725,7 +7725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7742,7 +7742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7762,7 +7762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7779,7 +7779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7798,7 +7798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7816,7 +7816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7833,7 +7833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7850,7 +7850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7870,7 +7870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7886,7 +7886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-5971-1" ;
         <http://purl.org/pav/providedBy>
@@ -7899,7 +7899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-5971-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6074-1-PWY-6074-1.ttl
+++ b/models/PWY-6074-1-PWY-6074-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -29,24 +29,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_17813>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318_SGD_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002333_YGR060W-MONOMER_RXN3O-9823_controller_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +71,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,7 +298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -357,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -446,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -491,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -570,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -587,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,11 +743,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_5554e059-205b-4a62-b5a2-62e09a53a2a6_RXN3O-9825_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,7 +755,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825>
+          <http://model.geneontology.org/5554e059-205b-4a62-b5a2-62e09a53a2a6_RXN3O-9825>
 ] .
 
 <http://model.geneontology.org/CHEBI_136486_RXN66-314>
@@ -778,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -890,7 +879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1044,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1097,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1122,24 +1111,13 @@
 <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_13392_RXN3O-9822_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,11 +1137,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75051> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/128b254b-c296-47c7-b684-a0eb6a0f0a9c_RXN66-318>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1172,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1193,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1260,7 +1255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,11 +1274,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/9c53807c-f638-413c-9ad0-1c3249440f77_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1291,7 +1303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1329,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1340,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1379,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1424,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1469,7 +1481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1508,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1525,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1542,7 +1554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1559,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1577,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1591,7 +1603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1650,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1661,7 +1673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1676,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1689,7 +1701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1706,7 +1718,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_1949_RXN3O-9824> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN3O-9824> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9824> , <http://model.geneontology.org/d72be128-a78a-42d1-b907-999470e701a5_RXN3O-9824> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1714,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1728,7 +1740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,23 +1771,6 @@
 <http://identifiers.org/sgd/S000005224>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9823>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1785,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1815,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1827,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1847,7 +1842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,11 +1862,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74870> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/5554e059-205b-4a62-b5a2-62e09a53a2a6_RXN3O-9825>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1884,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1897,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1912,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1927,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1941,7 +1953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1952,12 +1964,40 @@
           <http://model.geneontology.org/PWY-6074-1/PWY-6074-1>
 ] .
 
+<http://model.geneontology.org/d72be128-a78a-42d1-b907-999470e701a5_RXN3O-9824>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002233_CHEBI_15379_RXN3O-9823_SGD_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_128b254b-c296-47c7-b684-a0eb6a0f0a9c_RXN66-318_SGD_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +2009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1985,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -1996,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2007,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2021,7 +2061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2058,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2078,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,7 +2132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2112,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2129,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2146,7 +2186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2178,7 +2218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2192,7 +2232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2208,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2220,7 +2260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2236,7 +2276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2250,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2261,11 +2301,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_e912dd2c-f196-4f56-b265-14d61026f5d5_RXN3O-9826_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,7 +2313,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826>
+          <http://model.geneontology.org/e912dd2c-f196-4f56-b265-14d61026f5d5_RXN3O-9826>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2282,7 +2322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,12 +2336,29 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/e912dd2c-f196-4f56-b265-14d61026f5d5_RXN3O-9826>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002233_CHEBI_87289_RXN3O-9822_SGD_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2329,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2343,7 +2400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2351,11 +2408,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_128b254b-c296-47c7-b684-a0eb6a0f0a9c_RXN66-318_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2363,7 +2420,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318>
+          <http://model.geneontology.org/128b254b-c296-47c7-b684-a0eb6a0f0a9c_RXN66-318>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2372,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,7 +2445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2401,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2414,7 +2471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2422,11 +2479,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_d72be128-a78a-42d1-b907-999470e701a5_RXN3O-9824_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,8 +2491,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9824> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824>
+          <http://model.geneontology.org/d72be128-a78a-42d1-b907-999470e701a5_RXN3O-9824>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_5554e059-205b-4a62-b5a2-62e09a53a2a6_RXN3O-9825_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58349_RXN66-306>
         a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2446,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2460,7 +2528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2480,7 +2548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2497,9 +2565,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9825_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9825> , <http://model.geneontology.org/9c53807c-f638-413c-9ad0-1c3249440f77_RXN3O-9825> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN3O-9825> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9825> , <http://model.geneontology.org/5554e059-205b-4a62-b5a2-62e09a53a2a6_RXN3O-9825> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9825_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2507,7 +2575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2521,7 +2589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2540,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2560,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2576,7 +2644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2593,7 +2661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2620,7 +2688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2634,7 +2702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2650,7 +2718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2665,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2678,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2693,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2708,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2727,20 +2795,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002234_3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825_SGD_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2753,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2772,7 +2829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2802,7 +2859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2818,7 +2875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2829,23 +2886,12 @@
           <http://model.geneontology.org/reaction_RXN3O-9824_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825_SGD_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002413_RXN3O-9825_null_PWY-6074-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2857,7 +2903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,7 +2923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2897,7 +2943,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318> , <http://model.geneontology.org/CHEBI_13390_RXN66-318> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN66-318> , <http://model.geneontology.org/128b254b-c296-47c7-b684-a0eb6a0f0a9c_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2907,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2920,7 +2966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -2932,7 +2978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2943,17 +2989,6 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9825>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826_SGD_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9821>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2963,7 +2998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2990,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3003,7 +3038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3014,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3026,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3045,7 +3080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3061,7 +3096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3073,7 +3108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3090,7 +3125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3110,7 +3145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3124,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3144,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3157,7 +3192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3172,7 +3207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3189,7 +3224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,7 +3240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3214,30 +3249,13 @@
 <http://geneontology.org/lego/modelstate>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/3b4b9e1b-03b0-4ecf-8f97-36f46a910f0c_RXN3O-9825>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9823_RO_0002234_CHEBI_15377_RXN3O-9823_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3253,7 +3271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3264,7 +3282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3275,7 +3293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3288,7 +3306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3302,7 +3320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3322,7 +3340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "zymosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3335,7 +3353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3346,7 +3364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3357,7 +3375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3369,7 +3387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3386,7 +3404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3419,30 +3437,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1BiochemicalReaction75177> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74861> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3453,7 +3454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3464,19 +3465,19 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9824_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002413_RXN66-306_null_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3486,7 +3487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3502,7 +3503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3520,28 +3521,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule75037> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3554,9 +3538,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9826_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/536ba925-b9c1-4237-a7fd-14054b761f32_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> ;
+                <http://model.geneontology.org/CHEBI_13392_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15379_RXN3O-9826> , <http://model.geneontology.org/e912dd2c-f196-4f56-b265-14d61026f5d5_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> , <http://model.geneontology.org/48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826> ;
+                <http://model.geneontology.org/959fbd07-1481-4b53-89fe-b41c67f5020b_RXN3O-9826> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9826> , <http://model.geneontology.org/CHEBI_13390_RXN3O-9826> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN3O-9826_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3564,7 +3548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3580,7 +3564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3592,7 +3576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3609,7 +3593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3623,17 +3607,6 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824_SGD_PWY-6074-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_13390_RXN3O-9825>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_13390> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3643,7 +3616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3651,12 +3624,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9826> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-6074-1/PWY-6074-1>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN66-313_RO_0002234_CHEBI_136486_RXN66-313_SGD_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3669,7 +3659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3677,29 +3667,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9826> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-6074-1/PWY-6074-1>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002234_CHEBI_52386_RXN66-318_SGD_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3710,7 +3683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3725,7 +3698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3740,7 +3713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3754,7 +3727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3770,7 +3743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3785,7 +3758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3799,7 +3772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3815,7 +3788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3826,7 +3799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3838,7 +3811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3855,7 +3828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3872,7 +3845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3888,7 +3861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3899,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -3911,7 +3884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3942,7 +3915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3952,11 +3925,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_9c53807c-f638-413c-9ad0-1c3249440f77_RXN3O-9825_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3964,7 +3937,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9825> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/768062b7-ea9d-4de5-9989-124a92ee25b8_RXN3O-9825>
+          <http://model.geneontology.org/9c53807c-f638-413c-9ad0-1c3249440f77_RXN3O-9825>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9822>
@@ -3976,7 +3949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3989,7 +3962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4014,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4024,28 +3997,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY-6074-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN66-319> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_18252_RXN66-319>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9822_RO_0002234_CHEBI_13390_RXN3O-9822_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4056,22 +4012,22 @@
           <http://model.geneontology.org/CHEBI_13390_RXN3O-9822>
 ] .
 
-<http://model.geneontology.org/d42afac7-1553-4418-9864-c60dc42235e9_RXN66-318>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_18252_RXN66-319_SGD_PWY-6074-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN66-319> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_18252_RXN66-319>
+] .
 
 <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004090> ;
@@ -4080,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4095,7 +4051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4103,13 +4059,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9825_RO_0002233_9c53807c-f638-413c-9ad0-1c3249440f77_RXN3O-9825_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-9820_RO_0002233_CHEBI_16521_RXN3O-9820_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4129,7 +4096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4149,7 +4116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4160,20 +4127,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_87289>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002969> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-3 sterol dehydrogenase" ;
+<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1Protein75174> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_13392_RXN3O-9822>
         a       <http://purl.obolibrary.org/obo/CHEBI_13392> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4184,7 +4147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4192,23 +4155,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-314_BFO_0000050_PWY-6074-1/PWY-6074-1_SGD_PWY-6074-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002969> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "C-3 sterol dehydrogenase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6074-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1Protein75174> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-9824_BFO_0000066_reaction_RXN3O-9824_location_lociGO_0005829_null_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4223,7 +4190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4243,7 +4210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4253,11 +4220,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826_SGD_PWY-6074-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_959fbd07-1481-4b53-89fe-b41c67f5020b_RXN3O-9826_SGD_PWY-6074-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4265,7 +4232,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9826> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/48051dd1-fc90-4ddb-a9e1-43f15d9523ca_RXN3O-9826>
+          <http://model.geneontology.org/959fbd07-1481-4b53-89fe-b41c67f5020b_RXN3O-9826>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002233_CHEBI_58349_RXN66-314_SGD_PWY-6074-1>
@@ -4273,7 +4240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4285,7 +4252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4305,7 +4272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4325,7 +4292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4339,7 +4306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4356,7 +4323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4373,7 +4340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4406,7 +4373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4422,7 +4389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4439,7 +4406,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4450,23 +4417,6 @@
           <http://model.geneontology.org/RXN3O-9825>
 ] .
 
-<http://model.geneontology.org/be5f5e08-d3be-4ac5-8464-4fbcef239cdf_RXN3O-9824>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_1949>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4475,7 +4425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4487,7 +4437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4503,7 +4453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4514,7 +4464,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9824_RO_0002234_d72be128-a78a-42d1-b907-999470e701a5_RXN3O-9824_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4525,7 +4486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4536,7 +4497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4548,7 +4509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4568,7 +4529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4584,7 +4545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4604,7 +4565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4620,7 +4581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4640,7 +4601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4657,7 +4618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4674,7 +4635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4687,7 +4648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4702,7 +4663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4718,7 +4679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4729,7 +4690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4741,7 +4702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4752,12 +4713,40 @@
           <http://model.geneontology.org/CHEBI_15379_RXN3O-9824>
 ] .
 
+<http://model.geneontology.org/959fbd07-1481-4b53-89fe-b41c67f5020b_RXN3O-9826>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6074-1SmallMolecule74891> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-319_RO_0002233_CHEBI_58349_RXN66-319_SGD_PWY-6074-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002234_959fbd07-1481-4b53-89fe-b41c67f5020b_RXN3O-9826_SGD_PWY-6074-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4768,7 +4757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4780,7 +4769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4797,7 +4786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4813,9 +4802,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6074-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9826_RO_0002233_e912dd2c-f196-4f56-b265-14d61026f5d5_RXN3O-9826_SGD_PWY-6074-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4824,7 +4824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -4836,7 +4836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4856,7 +4856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4873,7 +4873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4893,7 +4893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4922,7 +4922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4936,7 +4936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4956,7 +4956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4970,7 +4970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4987,7 +4987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5007,7 +5007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5024,7 +5024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5044,7 +5044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5064,7 +5064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5081,7 +5081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5095,7 +5095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5111,7 +5111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -5122,7 +5122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>
@@ -5134,7 +5134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5154,7 +5154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5171,7 +5171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5194,7 +5194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5207,7 +5207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6074-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6074-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6075-1-PWY-6075-1.ttl
+++ b/models/PWY-6075-1-PWY-6075-1.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -161,7 +161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -547,7 +547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -660,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -751,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -822,7 +822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -834,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -922,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,7 +1131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1211,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1281,7 +1281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1450,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1462,7 +1462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1490,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1506,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1521,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1535,7 +1535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1585,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1616,7 +1616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1675,7 +1675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1691,7 +1691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1720,7 +1720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1734,7 +1734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1771,7 +1771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1794,7 +1794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1810,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1822,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,7 +1839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1862,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1886,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1898,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1917,7 +1917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1933,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1947,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1958,7 +1958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>
@@ -1992,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2006,7 +2006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2026,7 +2026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2066,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2083,7 +2083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2096,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6075-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6075-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6122-1-PWY-6122-1.ttl
+++ b/models/PWY-6122-1-PWY-6122-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,7 +249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -481,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_299985a7-0ec8-41ff-a43c-adcb4db794a7_GART-RXN_SGD_PWY-6122-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -798,17 +809,17 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -816,7 +827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -853,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -884,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -897,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -909,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,7 +954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -963,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -978,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,7 +1021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1070,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1083,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1117,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1137,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1156,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1167,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1279,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1304,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1319,7 +1330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1375,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1383,11 +1394,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN_SGD_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_299985a7-0ec8-41ff-a43c-adcb4db794a7_GART-RXN_SGD_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1406,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN>
+          <http://model.geneontology.org/299985a7-0ec8-41ff-a43c-adcb4db794a7_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002333_YGL234W-MONOMER_GLYRIBONUCSYN-RXN_controller_SGD_PWY-6122-1>
@@ -1403,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1415,7 +1426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1439,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1453,7 +1464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1464,12 +1475,23 @@
           <http://model.geneontology.org/CHEBI_30616_GLYRIBONUCSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_c7706e3f-b968-4548-96be-b5f8ed6e3e53_GART-RXN_SGD_PWY-6122-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6122-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_BFO_0000066_reaction_FGAMSYN-RXN_location_lociGO_0005829_null_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1484,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1498,7 +1520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1514,18 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN_SGD_PWY-6122-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1536,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1550,7 +1561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1559,12 +1570,29 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/c7706e3f-b968-4548-96be-b5f8ed6e3e53_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_CHEBI_15378_GART-RXN_SGD_PWY-6122-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1578,7 +1606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1612,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1657,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1670,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1688,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1708,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1722,7 +1750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,30 +1764,13 @@
 <http://purl.obolibrary.org/obo/GO_0004044>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71740> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN_SGD_PWY-6122-1> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_c7706e3f-b968-4548-96be-b5f8ed6e3e53_GART-RXN_SGD_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1767,7 +1778,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN>
+          <http://model.geneontology.org/c7706e3f-b968-4548-96be-b5f8ed6e3e53_GART-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_PRPPAMIDOTRANS-RXN_BFO_0000066_reaction_PRPPAMIDOTRANS-RXN_location_lociGO_0005829_null_PWY-6122-1>
@@ -1775,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1790,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,30 +1831,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1BiochemicalReaction71907> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_GLYRIBONUCSYN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -1857,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1871,7 +1865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1898,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1909,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1920,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +1926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,9 +1949,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4dbb1461-8474-412c-85e5-1c74cf485ef2_GART-RXN> , <http://model.geneontology.org/CHEBI_58457_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/299985a7-0ec8-41ff-a43c-adcb4db794a7_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN> , <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/c7706e3f-b968-4548-96be-b5f8ed6e3e53_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1965,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1992,7 +1986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2005,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2017,7 +2011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2033,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2047,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2063,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2075,7 +2069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,6 +2080,23 @@
           <http://model.geneontology.org/CHEBI_30616_AIRS-RXN>
 ] .
 
+<http://model.geneontology.org/299985a7-0ec8-41ff-a43c-adcb4db794a7_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6122-1SmallMolecule71718> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_43474_FGAMSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2095,7 +2106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2115,7 +2126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2132,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,7 +2157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2176,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2192,7 +2203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "5-aminoimidazole ribonucleotide biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2225,7 +2236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2248,24 +2259,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_c2cf1a18-d9d3-46dd-827c-7a00eef10953_GART-RXN_SGD_PWY-6122-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6122-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_58457_GLYRIBONUCSYN-RXN_SGD_PWY-6122-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2315,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2357,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2374,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2391,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2404,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6122-1" ;
         <http://purl.org/pav/providedBy>
@@ -2419,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6122-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6123-1-PWY-6123-1.ttl
+++ b/models/PWY-6123-1-PWY-6123-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,20 +65,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -87,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -104,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -119,9 +108,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/5c11a33d-9b11-4b2a-90ee-66de7e206f9a_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/0b8edfe1-b06e-485c-b408-ad3341ee1508_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -129,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -188,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -238,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,23 +268,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -304,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -387,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,29 +443,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_0b8edfe1-b06e-485c-b408-ad3341ee1508_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72829> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002234_CHEBI_43474_SAICARSYN-RXN_SGD_PWY-6123-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -508,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -522,7 +488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,6 +524,23 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_58564>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/0b8edfe1-b06e-485c-b408-ad3341ee1508_AICARTRANSFORM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72829> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_137981>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -576,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -616,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -850,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -885,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,11 +945,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72707> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/5c11a33d-9b11-4b2a-90ee-66de7e206f9a_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6123-1SmallMolecule72807> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -996,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1033,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1069,7 +1069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,7 +1176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,11 +1263,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_0b8edfe1-b06e-485c-b408-ad3341ee1508_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/0b8edfe1-b06e-485c-b408-ad3341ee1508_AICARTRANSFORM-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000000070>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1301,7 +1301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1331,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,24 +1342,13 @@
           <http://model.geneontology.org/AICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_1722b619-4a74-4755-be7a-7de767cbdc1a_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6123-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002234_CHEBI_137981_AIRCARBOXY-RXN_SGD_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1376,7 +1365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1392,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1392,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6123-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_5c11a33d-9b11-4b2a-90ee-66de7e206f9a_AICARTRANSFORM-RXN_SGD_PWY-6123-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1503,7 +1503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1593,7 +1593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1609,7 +1609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1653,7 +1653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1716,7 +1716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1745,7 +1745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,11 +1761,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_5c11a33d-9b11-4b2a-90ee-66de7e206f9a_AICARTRANSFORM-RXN_SGD_PWY-6123-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,7 +1773,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e9f8330f-5e25-4a44-bb9f-7e1c0f183c13_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/5c11a33d-9b11-4b2a-90ee-66de7e206f9a_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0043727>
@@ -1784,7 +1784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1795,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1810,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inosine-5'-phosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1852,7 +1852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1868,7 +1868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1880,7 +1880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1924,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1937,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>
@@ -1965,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6123-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6123-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6125-PWY-6125.ttl
+++ b/models/PWY-6125-PWY-6125.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -222,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -253,23 +253,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_58595>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
         a       <http://identifiers.org/sgd/S000003563> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000050_PWY-6125/PWY-6125_SGD_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -898,7 +898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -932,7 +932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,7 +949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1057,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1117,7 +1117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1138,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1303,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1312,16 +1323,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-746_RO_0002233_CHEBI_15740_RXN0-746_SGD_PWY-6125> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,16 +1340,8 @@
           <http://model.geneontology.org/CHEBI_15740_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1349,7 +1349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1414,7 +1414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1434,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1480,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1503,7 +1503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1511,23 +1511,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1542,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1605,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1638,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1661,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1693,7 +1693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1707,7 +1707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1741,7 +1741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1757,7 +1757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1788,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1835,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1851,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1862,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1873,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,7 +1902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1919,7 +1919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -1971,7 +1971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2022,7 +2022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2038,28 +2038,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-746>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2070,7 +2053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2078,12 +2061,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002234_CHEBI_15378_GMP-SYN-GLUT-RXN_SGD_PWY-6125> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GMP-SYN-GLUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_GMP-SYN-GLUT-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003412_CPLX3O-270_component_SGD_PWY-6125>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2137,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,7 +2150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2164,7 +2164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2181,7 +2181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2200,7 +2200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2216,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2227,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,18 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY-6125>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2280,7 +2269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2311,13 +2300,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6125SmallMolecule29197> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_RO_0002233_CHEBI_58359_GMP-SYN-GLUT-RXN_SGD_PWY-6125>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2328,7 +2328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2363,7 +2363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2376,7 +2376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2391,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2404,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2416,7 +2416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2438,7 +2438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2458,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2472,7 +2472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2492,7 +2492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2509,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2522,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2564,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2577,7 +2577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2589,7 +2589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2606,7 +2606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2622,7 +2622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2642,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2656,7 +2656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2668,7 +2668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,7 +2685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2705,7 +2705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2721,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2733,7 +2733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2763,7 +2763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2776,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2787,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2802,7 +2802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2816,7 +2816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2832,7 +2832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2844,7 +2844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2861,7 +2861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2877,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2888,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2899,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2924,7 +2924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2943,7 +2943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2960,7 +2960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -2987,7 +2987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3001,7 +3001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3020,7 +3020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3039,7 +3039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3050,7 +3050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3065,7 +3065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of guanosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3078,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
         <http://purl.org/pav/providedBy>
@@ -3091,7 +3091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3104,9 +3104,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6125" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PWY-6125>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-6125" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3116,7 +3127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3127,17 +3138,6 @@
           <http://model.geneontology.org/CHEBI_61429_RXN0-746>
 ] .
 
-<http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002413_GMP-SYN-GLUT-RXN_null_PWY-6125>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-6125" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3147,7 +3147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6125" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6126-1-PWY-6126-1.ttl
+++ b/models/PWY-6126-1-PWY-6126-1.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of adenosine nucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,18 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -153,7 +142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,13 +153,24 @@
           <http://model.geneontology.org/ADENYL-KIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_15378_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,7 +384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,6 +431,28 @@
 <http://purl.obolibrary.org/obo/GO_0004550>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_null_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/PWY-6126-1/PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -438,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -446,34 +468,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_AMPSYN-RXN_RO_0002413_ADENYL-KIN-RXN_null_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002234_Red-Thioredoxin_ADPREDUCT-RXN_SGD_PWY-6126-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -665,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -962,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1027,7 +1027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,45 +1038,8 @@
           <http://model.geneontology.org/DADPKIN-RXN>
 ] .
 
-<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15377_RXN0-745>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30045> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/reaction_AMPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_61404> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1087,13 +1050,50 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30031> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15377_RXN0-745>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6126-1SmallMolecule30045> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000872> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004019> ;
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1280,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1304,7 +1304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1360,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1371,7 +1371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1420,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,17 +1471,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1490,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,6 +1490,17 @@
           <http://model.geneontology.org/reaction_ADENYLOSUCCINATE-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY-6126-1/PWY-6126-1_SGD_PWY-6126-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57667_DADPKIN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57667> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1510,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1532,24 +1532,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY-6126-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6126-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-6126-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,9 +1554,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ADPREDUCT-RXN_RO_0002233_CHEBI_57667_ADPREDUCT-RXN_SGD_PWY-6126-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1628,7 +1628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1645,7 +1645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1659,7 +1659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,7 +1721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1732,7 +1732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1743,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1755,7 +1755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1803,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1815,7 +1815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,7 +1834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1851,7 +1851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1899,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1915,7 +1915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1930,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1957,7 +1957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2015,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2100,7 +2100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2112,7 +2112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2152,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2165,7 +2165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2201,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2218,7 +2218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2232,7 +2232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2249,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2269,7 +2269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2286,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2302,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2314,7 +2314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2331,7 +2331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2351,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2395,7 +2395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2409,7 +2409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2420,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2432,7 +2432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2470,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>
@@ -2481,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6126-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6126-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6132-PWY-6132.ttl
+++ b/models/PWY-6132-PWY-6132.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6132" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "lanosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6132" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6147-PWY-6147.ttl
+++ b/models/PWY-6147-PWY-6147.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -691,7 +691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "6-hydroxymethyl-dihydropterin diphosphate biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -951,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -977,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1181,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1298,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1407,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1456,7 +1456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1624,7 +1624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1668,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1694,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1711,7 +1711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6147" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1818,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6147" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6482-1-PWY-6482-1.ttl
+++ b/models/PWY-6482-1-PWY-6482-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,11 +36,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_b31a3355-929f-4105-9e97-0c9cb19cfcd1_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN>
+          <http://model.geneontology.org/b31a3355-929f-4105-9e97-0c9cb19cfcd1_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,13 +74,24 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_b31a3355-929f-4105-9e97-0c9cb19cfcd1_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_15378_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,12 +217,29 @@
           <http://model.geneontology.org/PWY-6482-1/PWY-6482-1>
 ] .
 
+<http://model.geneontology.org/6a6346c1-4deb-47ff-9061-5532231f19a3_RXN-11371>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an L-histidine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43400> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_CHEBI_15378_RXN-11374_SGD_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +291,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11371_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_RXN-11371> , <http://model.geneontology.org/2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371> ;
+                <http://model.geneontology.org/CHEBI_59789_RXN-11371> , <http://model.geneontology.org/6a6346c1-4deb-47ff-9061-5532231f19a3_RXN-11371> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17509_RXN-11371> , <http://model.geneontology.org/CHEBI_15378_RXN-11371> , <http://model.geneontology.org/CHEBI_58031_RXN-11371> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -273,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -286,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -328,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,28 +427,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -434,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,23 +515,12 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002333_MONOMER-15582_RXN-11373_controller_SGD_PWY-6482-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -548,36 +548,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_4fecd64d-3b6f-40ae-ab95-5dcd7d9b58ea_RXN-11374_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,16 +568,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11374> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374>
+          <http://model.geneontology.org/4fecd64d-3b6f-40ae-ab95-5dcd7d9b58ea_RXN-11374>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_6a6346c1-4deb-47ff-9061-5532231f19a3_RXN-11371_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -602,11 +585,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11371> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371>
+          <http://model.geneontology.org/6a6346c1-4deb-47ff-9061-5532231f19a3_RXN-11371>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/4fecd64d-3b6f-40ae-ab95-5dcd7d9b58ea_RXN-11374>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_59789_RXN-11374>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_59789_RXN-11374> , <http://model.geneontology.org/CHEBI_57784_RXN-11374> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> , <http://model.geneontology.org/9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374> ;
+                <http://model.geneontology.org/4fecd64d-3b6f-40ae-ab95-5dcd7d9b58ea_RXN-11374> , <http://model.geneontology.org/CHEBI_15378_RXN-11374> , <http://model.geneontology.org/CHEBI_57856_RXN-11374> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER-15582_RXN-11374_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -681,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -776,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,23 +787,12 @@
           <http://model.geneontology.org/MONOMER-15582_RXN-11370_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373_SGD_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,13 +818,30 @@
           <http://model.geneontology.org/CHEBI_58031_RXN-11371>
 ] .
 
+<http://model.geneontology.org/b56aa4ae-7b72-448e-a190-319b12c65fd5_RXN-11373>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2-[(3S)-3-carboxy-3-(dimethylammonio)propyl]-L-histidine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43314> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002234_CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,6 +852,17 @@
           <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_b56aa4ae-7b72-448e-a190-319b12c65fd5_RXN-11373_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -855,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,46 +883,12 @@
           <http://model.geneontology.org/CHEBI_57856_RXN-11373>
 ] .
 
-<http://model.geneontology.org/2d26898e-070f-47b1-9763-13755bb4e24d_RXN-11371>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an L-histidine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43400> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphthine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -920,7 +903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -937,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -951,7 +934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -996,6 +979,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_3f82eaaf-aebe-41cb-8569-c8198cc1e916_RXN-11373_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1005,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1032,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1044,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,7 +1060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1082,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1105,7 +1099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1155,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1167,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1235,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1285,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1368,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1388,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1401,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1412,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1421,24 +1415,13 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002233_b56aa4ae-7b72-448e-a190-319b12c65fd5_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1429,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373>
+          <http://model.geneontology.org/b56aa4ae-7b72-448e-a190-319b12c65fd5_RXN-11373>
 ] .
 
 <http://model.geneontology.org/CPLX-8046_RXN-11371_controller>
@@ -1458,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,7 +1458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1489,7 +1472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1531,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,7 +1562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1613,7 +1596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1654,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1674,7 +1657,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30616_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_28938_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/b31a3355-929f-4105-9e97-0c9cb19cfcd1_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_456215_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_29888_DIPHTINE--AMMONIA-LIGASE-RXN> , <http://model.geneontology.org/CHEBI_15378_DIPHTINE--AMMONIA-LIGASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1682,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,7 +1679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1713,7 +1696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1724,12 +1707,23 @@
           <http://model.geneontology.org/CHEBI_16692_DIPHTINE--AMMONIA-LIGASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_6a6346c1-4deb-47ff-9061-5532231f19a3_RXN-11371_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_CHEBI_57856_RXN-11373_SGD_PWY-6482-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1740,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1748,11 +1742,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373_SGD_PWY-6482-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11373_RO_0002234_3f82eaaf-aebe-41cb-8569-c8198cc1e916_RXN-11373_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1760,7 +1754,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11373> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373>
+          <http://model.geneontology.org/3f82eaaf-aebe-41cb-8569-c8198cc1e916_RXN-11373>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1769,7 +1763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1809,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diphthamide biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1834,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1849,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1862,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -1877,7 +1871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1888,24 +1882,13 @@
           <http://model.geneontology.org/CHEBI_57856_RXN-11374>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002233_CHEBI_59789_RXN-11371_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1916,24 +1899,61 @@
           <http://model.geneontology.org/CHEBI_59789_RXN-11371>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_null_PWY-6482-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
-] .
+<http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/b31a3355-929f-4105-9e97-0c9cb19cfcd1_DIPHTINE--AMMONIA-LIGASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphthine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/3f82eaaf-aebe-41cb-8569-c8198cc1e916_RXN-11373>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphthine-[translation elongation factor 2]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_59789_RXN-11373>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1944,7 +1964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1952,44 +1972,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11371_RO_0002234_CHEBI_17509_RXN-11371_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphthine-[translation elongation factor 2]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6482-1SmallMolecule43322> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000066_reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829_null_PWY-6482-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIPHTINE--AMMONIA-LIGASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_DIPHTINE--AMMONIA-LIGASE-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/RXN-11373>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -2000,9 +2000,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11373_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/da5ff4f3-309e-47a9-bb8f-22c45c510f5e_RXN-11373> , <http://model.geneontology.org/CHEBI_59789_RXN-11373> ;
+                <http://model.geneontology.org/CHEBI_59789_RXN-11373> , <http://model.geneontology.org/b56aa4ae-7b72-448e-a190-319b12c65fd5_RXN-11373> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> , <http://model.geneontology.org/03b6ed69-0733-4873-8b4e-ae12af201db1_RXN-11373> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN-11373> , <http://model.geneontology.org/CHEBI_57856_RXN-11373> , <http://model.geneontology.org/3f82eaaf-aebe-41cb-8569-c8198cc1e916_RXN-11373> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER-15582_RXN-11373_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2018,12 +2018,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_9000ac8d-20f8-4977-89af-4cb7199f5c63_RXN-11374_SGD_PWY-6482-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_BFO_0000050_PWY-6482-1/PWY-6482-1_SGD_PWY-6482-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2051,7 +2051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2067,7 +2067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
@@ -2082,7 +2082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2096,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2113,7 +2113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2133,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2141,13 +2141,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-11374_RO_0002234_4fecd64d-3b6f-40ae-ab95-5dcd7d9b58ea_RXN-11374_SGD_PWY-6482-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6482-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-11370_RO_0002234_CHEBI_57856_RXN-11370_SGD_PWY-6482-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2163,20 +2174,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6482-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIPHTINE--AMMONIA-LIGASE-RXN_RO_0002233_95a8f49c-9917-4291-8e31-665c5dd79c10_DIPHTINE--AMMONIA-LIGASE-RXN_SGD_PWY-6482-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6482-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2202,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6482-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-6543-PWY-6543.ttl
+++ b/models/PWY-6543-PWY-6543.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6543" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -661,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6543" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-6614-PWY-6614.ttl
+++ b/models/PWY-6614-PWY-6614.ttl
@@ -9,7 +9,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrahydrofolate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,23 +204,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17836_H2PTEROATESYNTH-RXN>
 ] .
-
-<http://model.geneontology.org/ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -237,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -248,15 +231,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0008150>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002233_CHEBI_17836_H2PTEROATESYNTH-RXN_SGD_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -271,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,16 +259,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0008150>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -296,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,11 +281,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c84be546-5734-45ed-aa5b-0f41f2a3e7ce_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +293,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/c84be546-5734-45ed-aa5b-0f41f2a3e7ce_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0008841>
@@ -335,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -415,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,16 +440,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/GO_0004156>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002411_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,6 +457,9 @@
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004156>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -497,7 +469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -562,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -614,15 +586,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/c84be546-5734-45ed-aa5b-0f41f2a3e7ce_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/d1853b4a-debf-40a5-81cc-627a40494005_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -696,23 +668,6 @@
           <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY-6614> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
@@ -724,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,8 +687,36 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY-6614> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
+] .
+
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY-6614/PWY-6614_SGD_PWY-6614>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -741,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,23 +735,12 @@
           <http://model.geneontology.org/CHEBI_29985_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY-6614/PWY-6614_SGD_PWY-6614>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-6614" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -790,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -815,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -902,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -918,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -933,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -950,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -974,11 +946,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d1853b4a-debf-40a5-81cc-627a40494005_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +958,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ca994287-dcfb-4c6c-aad3-a749d81b22d4_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/d1853b4a-debf-40a5-81cc-627a40494005_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -997,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1009,30 +981,13 @@
 <http://model.geneontology.org/reaction_DIHYDROFOLATESYNTH-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_17839_DIHYDROFOLATESYNTH-RXN_SGD_PWY-6614> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1043,23 +998,23 @@
           <http://model.geneontology.org/CHEBI_17839_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY-6614>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c84be546-5734-45ed-aa5b-0f41f2a3e7ce_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_33caca7a-4ad1-478d-bd69-363c45d0160a_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_456216_DIHYDROFOLATESYNTH-RXN_SGD_PWY-6614>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1087,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1099,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,6 +1068,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d1853b4a-debf-40a5-81cc-627a40494005_DIHYDROFOLATEREDUCT-RXN_SGD_PWY-6614>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-6614" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -1121,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1139,6 +1105,23 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/c84be546-5734-45ed-aa5b-0f41f2a3e7ce_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64261> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1151,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1185,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1216,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1236,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,11 +1235,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/d1853b4a-debf-40a5-81cc-627a40494005_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-6614SmallMolecule64284> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1266,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-6614" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-6614" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-7176-PWY-7176.ttl
+++ b/models/PWY-7176-PWY-7176.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -116,28 +116,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PWY-7176> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CTPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PWY-7176>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-7176" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -147,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,17 +152,6 @@
           <http://model.geneontology.org/reaction_RXN-12002_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_UDPKIN-RXN_BFO_0000066_reaction_UDPKIN-RXN_location_lociGO_0005829_null_PWY-7176>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-7176" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_29985_CTPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29985> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -178,13 +161,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7176SmallMolecule70646> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_46398_CTPSYN-RXN_SGD_PWY-7176> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CTPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_46398_CTPSYN-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_58359_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58359> ;
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UTP and CTP <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -284,7 +284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -450,11 +450,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_456216_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -465,16 +468,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7176SmallMolecule70518> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_57865_RXN-12002>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57865> ;
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -735,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -840,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1067,7 +1067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1127,7 +1127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1144,7 +1144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7176" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7176" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY-7219-PWY-7219.ttl
+++ b/models/PWY-7219-PWY-7219.ttl
@@ -8,7 +8,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,30 +317,13 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "adenylo-succinate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72348> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -351,13 +334,30 @@
           <http://model.geneontology.org/CHEBI_43474_ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57567> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "adenylo-succinate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-7219SmallMolecule72348> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY-7219> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -467,7 +467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -545,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -714,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7219" ;
         <http://purl.org/pav/providedBy>
@@ -1066,7 +1066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1083,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1167,7 +1167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7219" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-7220-1-PWY-7220-1.ttl
+++ b/models/PWY-7220-1-PWY-7220-1.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,9 +381,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_61404>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://identifiers.org/sgd/S000003412>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_30616_RXN0-745>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -393,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,12 +398,15 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://identifiers.org/sgd/S000003412>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_PWY-7220-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -523,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -889,7 +889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -917,7 +917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "adenosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1007,7 +1007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1146,7 +1146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1209,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1226,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1287,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1302,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1321,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7220-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7220-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-7221-PWY-7221.ttl
+++ b/models/PWY-7221-PWY-7221.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -419,7 +419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -546,7 +546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -806,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -826,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -840,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -950,7 +950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -970,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1090,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1167,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1214,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1265,7 +1265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1356,7 +1356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1434,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1501,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1545,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1637,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1666,7 +1666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1699,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1752,7 +1752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1766,7 +1766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1830,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1844,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1861,7 +1861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7221" ;
         <http://purl.org/pav/providedBy>
@@ -1893,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7221" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-7222-1-PWY-7222-1.ttl
+++ b/models/PWY-7222-1-PWY-7222-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -76,7 +76,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,26 +829,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-7222-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000051> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
-] .
 
 <http://model.geneontology.org/PWY-7222-1>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -859,13 +842,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "guanosine deoxyribonucleotides <i>de novo</i> biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CPLX3O-270_GDPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY-7222-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000051> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/SGD_S000001328_CPLX3O-270_component>
+] .
 
 <http://model.geneontology.org/CHEBI_58595_GDPREDUCT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58595> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -890,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1043,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1101,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1113,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1193,7 +1193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1223,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,7 +1240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-7222-1" ;
         <http://purl.org/pav/providedBy>
@@ -1338,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-7222-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-781-PWY-781.ttl
+++ b/models/PWY-781-PWY-781.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,7 +176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -357,7 +357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sulfate assimilation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -849,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -962,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1002,7 +1002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1050,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1176,7 +1176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,7 +1219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1301,7 +1301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1343,7 +1343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1425,7 +1425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1462,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1488,7 +1488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1547,7 +1547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1561,7 +1561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1615,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1632,7 +1632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1664,7 +1664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1678,7 +1678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1712,7 +1712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1742,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>
@@ -1779,7 +1779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1810,7 +1810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-781" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-781" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-821-1-PWY-821-1.ttl
+++ b/models/PWY-821-1-PWY-821-1.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,8 +75,30 @@
 <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a0477e6d-33f9-4d6e-8e4f-ea2678c866f3_RXN3O-22_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_29991>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57716_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57716> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -87,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,28 +126,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31038> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -137,7 +142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,16 +153,22 @@
           <http://model.geneontology.org/reaction_ADENYLYLSULFKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002233_CHEBI_58349_SULFITE-REDUCT-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/CHEBI_30616_SULFATE-ADENYLYLTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31023> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -165,7 +176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -184,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,12 +250,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_9566f59f-7ee9-480a-861a-d6d8f236b438_RXN3O-22_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002234_CHEBI_57287_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -305,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -404,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -566,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -614,9 +636,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/a0477e6d-33f9-4d6e-8e4f-ea2678c866f3_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/9566f59f-7ee9-480a-861a-d6d8f236b438_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -624,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -678,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -888,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -903,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -917,7 +939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -969,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1063,7 +1085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1121,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1132,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1158,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1231,7 +1253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1252,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1266,7 +1288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1297,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1309,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1326,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1369,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1405,11 +1427,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_9566f59f-7ee9-480a-861a-d6d8f236b438_RXN3O-22_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1439,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22>
+          <http://model.geneontology.org/9566f59f-7ee9-480a-861a-d6d8f236b438_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1428,7 +1450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1475,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,7 +1554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1582,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1595,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1610,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1623,7 +1645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1638,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1659,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1673,7 +1695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1709,7 +1731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1728,18 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1751,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,12 +1773,23 @@
           <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002333_YGL184C-MONOMER_CYSTATHIONINE-BETA-LYASE-RXN_controller_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002233_CHEBI_58349_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_SGD_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1803,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1819,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1834,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1848,7 +1870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1865,7 +1887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1881,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1896,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1913,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1928,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1945,7 +1967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1961,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -1982,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1996,7 +2018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2013,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2038,7 +2060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,7 +2077,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2088,7 +2110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2103,7 +2125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2116,7 +2138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2130,7 +2152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2147,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,7 +2186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2184,24 +2206,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule31230> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/1.8.4.8-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004604> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2222,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2235,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2295,7 +2306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2328,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2339,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2354,7 +2365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2395,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2409,7 +2420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2423,13 +2434,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_null_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002233_CHEBI_29991_ASPARTATEKIN-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2440,17 +2462,6 @@
           <http://model.geneontology.org/CHEBI_29991_ASPARTATEKIN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_RO_0002413_ACETYLHOMOSER-CYS-RXN_null_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YER052C-MONOMER_ASPARTATEKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000854> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2458,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2471,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2483,7 +2494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2497,17 +2508,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57844>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_30089_ACETYLHOMOSER-CYS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30089> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2517,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2525,22 +2525,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002234_CHEBI_15377_CYSTATHIONINE-BETA-SYNTHASE-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YKL001C-MONOMER_ADENYLYLSULFKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001484> ;
@@ -2549,7 +2543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2576,7 +2570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2592,7 +2586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2608,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2623,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2640,7 +2634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2653,7 +2647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2665,7 +2659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,7 +2679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2698,7 +2692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2709,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2724,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2740,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2751,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2763,7 +2757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2779,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2793,29 +2787,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002234_CHEBI_58243_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2827,7 +2813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2847,7 +2833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2861,7 +2847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2872,8 +2858,16 @@
           <http://model.geneontology.org/CHEBI_57288_HOMOSERINE-O-ACETYLTRANSFERASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002233_CHEBI_57476_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_CYSTATHIONINE-BETA-SYNTHASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -2897,7 +2891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2914,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2927,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2939,7 +2933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2956,7 +2950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2975,7 +2969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2986,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -2998,7 +2992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3015,7 +3009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3031,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3049,7 +3043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3062,7 +3056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3079,7 +3073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3094,7 +3088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3111,7 +3105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3128,7 +3122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3144,7 +3138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3159,7 +3153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3175,7 +3169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3195,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3222,7 +3216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3242,7 +3236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3256,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3275,7 +3269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3297,7 +3291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3311,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3323,17 +3317,6 @@
 <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22_SGD_PWY-821-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_58199_HOMOCYSMET-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58199> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3343,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3360,7 +3343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3380,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3397,7 +3380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3411,7 +3394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3427,7 +3410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3442,7 +3425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3455,7 +3438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3467,7 +3450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3484,7 +3467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3500,7 +3483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3511,7 +3494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3522,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3533,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3544,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3556,7 +3539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3582,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3595,7 +3578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3606,7 +3589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3620,7 +3603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3640,7 +3623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3654,7 +3637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3674,7 +3657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3690,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3701,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3712,7 +3695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3724,7 +3707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3743,7 +3726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3771,7 +3754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3787,7 +3770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3799,7 +3782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3821,7 +3804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3851,7 +3834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3867,7 +3850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3879,7 +3862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3899,7 +3882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3926,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3946,7 +3929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3965,7 +3948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3979,7 +3962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -3991,7 +3974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4011,7 +3994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4028,7 +4011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4044,7 +4027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4059,7 +4042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4079,7 +4062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4092,7 +4075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4107,7 +4090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4123,7 +4106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4142,7 +4125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4153,29 +4136,12 @@
           <http://model.geneontology.org/reaction_1.8.4.8-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/7b227ce6-82c3-4f8c-9cec-08319f2fba7d_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-SYNTHASE-RXN_RO_0002413_CYSTATHIONINE-BETA-LYASE-RXN_null_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4190,7 +4156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4204,7 +4170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4221,7 +4187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4237,7 +4203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4258,7 +4224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4274,7 +4240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4291,7 +4257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4307,7 +4273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4319,7 +4285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4335,7 +4301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4346,7 +4312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4364,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4380,11 +4346,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
+] .
 
 <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004781> ;
@@ -4405,7 +4388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4413,22 +4396,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SULFATE-ADENYLYLTRANS-RXN_RO_0002233_CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SULFATE-ADENYLYLTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_SULFATE-ADENYLYLTRANS-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4436,7 +4413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4447,23 +4424,29 @@
           <http://model.geneontology.org/SGD_S000003898_CPLX3O-23_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002233_CHEBI_16136_ACETYLHOMOSER-CYS-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/a0477e6d-33f9-4d6e-8e4f-ea2678c866f3_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_S-ADENMETSYN-RXN_RO_0002234_CHEBI_29888_S-ADENMETSYN-RXN_SGD_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4475,7 +4458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4495,7 +4478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4506,6 +4489,23 @@
           <http://model.geneontology.org/PWY-821-1/PWY-821-1>
 ] .
 
+<http://model.geneontology.org/9566f59f-7ee9-480a-861a-d6d8f236b438_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-821-1SmallMolecule30990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_58161_CYSTATHIONINE-BETA-SYNTHASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58161> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4515,7 +4515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4523,12 +4523,34 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' 'null' 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_null_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/HOMOCYSMET-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_CYSTAGLY-RXN_RO_0002234_CHEBI_16134_CYSTAGLY-RXN_SGD_PWY-821-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4540,7 +4562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4551,34 +4573,12 @@
           <http://model.geneontology.org/CHEBI_15378_SULFITE-REDUCT-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '<i>O</i>-acetyl-L-homoserine + hydrogen sulfide &rarr; L-homocysteine + acetate + H<SUP>+</SUP>' 'null' 'L-homocysteine + 5-methyltetrahydropteroyl tri-L-glutamate &harr; L-methionine + tetrahydropteroyl tri-L-glutamate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002413_HOMOCYSMET-RXN_null_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/HOMOCYSMET-RXN>
-] .
-
-<http://model.geneontology.org/reaction_RXN-721_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
-
 <http://model.geneontology.org/ev_w_id_CYSTATHIONINE-BETA-LYASE-RXN_RO_0002234_CHEBI_58199_CYSTATHIONINE-BETA-LYASE-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4593,7 +4593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4606,11 +4606,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22_SGD_PWY-821-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a0477e6d-33f9-4d6e-8e4f-ea2678c866f3_RXN3O-22_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4618,7 +4618,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8bcce7e7-42b3-45c4-8ca0-13be07c740a4_RXN3O-22>
+          <http://model.geneontology.org/a0477e6d-33f9-4d6e-8e4f-ea2678c866f3_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/CHEBI_58161_CYSTAGLY-RXN>
@@ -4630,7 +4630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4652,7 +4652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4664,7 +4664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4687,7 +4687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4707,7 +4707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4724,7 +4724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4746,7 +4746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4761,7 +4761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4774,7 +4774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4786,7 +4786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4803,7 +4803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4819,7 +4819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4834,7 +4834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4850,7 +4850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4862,7 +4862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4882,7 +4882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4897,7 +4897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4924,7 +4924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4938,7 +4938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4954,7 +4954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -4968,7 +4968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4993,7 +4993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5013,7 +5013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5026,7 +5026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5040,7 +5040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5055,7 +5055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5068,7 +5068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5080,7 +5080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5097,7 +5097,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5120,7 +5120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5134,7 +5134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5153,7 +5153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5169,7 +5169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5180,7 +5180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5195,7 +5195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5209,7 +5209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5225,7 +5225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5238,7 +5238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of sulfur amino acid biosynthesis (<i>Saccharomyces cerevisiae</i>) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5251,7 +5251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5262,7 +5262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5274,7 +5274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5291,7 +5291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5321,7 +5321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5337,7 +5337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5351,7 +5351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5368,7 +5368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5384,7 +5384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5408,7 +5408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5424,7 +5424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5439,7 +5439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5452,7 +5452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5469,7 +5469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5483,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5495,7 +5495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5511,7 +5511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5525,7 +5525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5537,7 +5537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5556,7 +5556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5572,7 +5572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5581,40 +5581,12 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
-] .
-
 <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002411_HOMOSERINE-O-ACETYLTRANSFERASE-RXN_SGD_PWY-821-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY-821-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5639,7 +5611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5647,13 +5619,41 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_PWY-821-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY-821-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYLYLSULFKIN-RXN_BFO_0000050_PWY-821-1/PWY-821-1_SGD_PWY-821-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENYLYLSULFKIN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY-821-1/PWY-821-1>
+] .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SULFITE-REDUCT-RXN_RO_0002234_CHEBI_17359_SULFITE-REDUCT-RXN_SGD_PWY-821-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5673,7 +5673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5686,7 +5686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5701,7 +5701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5715,7 +5715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5732,7 +5732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5748,7 +5748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5766,7 +5766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5786,7 +5786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5799,7 +5799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5811,7 +5811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5827,7 +5827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5839,7 +5839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5856,7 +5856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5872,7 +5872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5883,7 +5883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5895,7 +5895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5915,7 +5915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5937,7 +5937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5957,7 +5957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5970,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -5988,7 +5988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6001,7 +6001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6012,7 +6012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6025,7 +6025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6038,7 +6038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6050,7 +6050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6073,7 +6073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6096,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6110,7 +6110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6130,7 +6130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6145,7 +6145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6160,7 +6160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6177,7 +6177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6196,7 +6196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6212,7 +6212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6223,7 +6223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6241,7 +6241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6258,7 +6258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6275,7 +6275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6291,7 +6291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6302,7 +6302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6313,7 +6313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6324,7 +6324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6336,7 +6336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6352,7 +6352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6366,7 +6366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6382,7 +6382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6394,7 +6394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6410,7 +6410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6423,7 +6423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6436,7 +6436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6447,7 +6447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6459,7 +6459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6476,7 +6476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6493,7 +6493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6512,7 +6512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6527,7 +6527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6541,7 +6541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6561,7 +6561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6578,7 +6578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6594,7 +6594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6606,7 +6606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6628,7 +6628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6640,7 +6640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6656,7 +6656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>
@@ -6667,7 +6667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-821-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-821-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY-901-PWY-901.ttl
+++ b/models/PWY-901-PWY-901.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -504,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methylglyoxal catabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -772,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-901" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-901" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY-922-PWY-922.ttl
+++ b/models/PWY-922-PWY-922.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -183,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -503,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -740,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -841,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,7 +917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1113,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1141,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1237,7 +1237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1308,7 +1308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,7 +1359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1382,7 +1382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1409,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1550,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1584,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1600,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1659,7 +1659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1706,7 +1706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1714,29 +1714,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_58349_1.1.1.34-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADP<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922SmallMolecule74723> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_MEVALONATE-KINASE-RXN_RO_0002413_PHOSPHOMEVALONATE-KINASE-RXN_null_PWY-922>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1747,11 +1730,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_58349_1.1.1.34-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_58349> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADP<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY-922SmallMolecule74723> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1759,7 +1759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1810,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -1835,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1849,7 +1849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1902,7 +1902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1942,7 +1942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1959,7 +1959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1996,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2011,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2031,7 +2031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2048,7 +2048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2068,7 +2068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2081,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2093,7 +2093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2109,7 +2109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2120,7 +2120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2131,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2143,7 +2143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2177,7 +2177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2207,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2223,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2234,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2266,7 +2266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,7 +2283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2326,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mevalonate pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2346,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2359,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2373,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2384,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2399,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2419,7 +2419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2433,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2463,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,7 +2480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2497,7 +2497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2511,7 +2511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2527,7 +2527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2538,7 +2538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2549,7 +2549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2566,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,7 +2601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,7 +2621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2639,7 +2639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2658,7 +2658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,25 +2685,6 @@
           <http://model.geneontology.org/MEVALONATE-KINASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YMR208W-MONOMER_MEVALONATE-KINASE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-922> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACETYL-COA-ACETYLTRANSFER-RXN>
@@ -2715,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2723,12 +2704,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_BFO_0000066_reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829_null_PWY-922> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_HYDROXYMETHYLGLUTARYL-COA-SYNTHASE-RXN_RO_0002413_1.1.1.34-RXN_null_PWY-922>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2742,7 +2742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY-922" ;
         <http://purl.org/pav/providedBy>
@@ -2757,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY-922" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY0-162-PWY0-162.ttl
+++ b/models/PWY0-162-PWY0-162.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -397,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -619,7 +619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -686,7 +686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -763,7 +763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -833,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -867,7 +867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -884,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -898,7 +898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -937,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1094,7 +1094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,7 +1131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1149,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1266,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1278,7 +1278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1298,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,7 +1312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,7 +1348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1478,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1495,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1532,7 +1532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1568,7 +1568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1619,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1633,7 +1633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1650,7 +1650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,7 +1666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1681,7 +1681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1709,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1723,7 +1723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1739,7 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1750,7 +1750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1762,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1793,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1829,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1846,7 +1846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1862,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1893,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -1917,7 +1917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1967,7 +1967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2000,7 +2000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2050,7 +2050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2087,7 +2087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2098,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2112,7 +2112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2129,7 +2129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2145,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2157,7 +2157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2190,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2210,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2224,7 +2224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2247,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2261,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2281,7 +2281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2297,7 +2297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2320,7 +2320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2337,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2350,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2364,7 +2364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2386,7 +2386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2402,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2417,7 +2417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2431,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2451,7 +2451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2464,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2475,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2500,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2514,7 +2514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2530,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2541,7 +2541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2553,7 +2553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2569,7 +2569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2587,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2601,7 +2601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2620,7 +2620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2635,7 +2635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2648,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2662,7 +2662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2682,7 +2682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2698,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2709,7 +2709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2721,7 +2721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2737,7 +2737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2755,7 +2755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2778,7 +2778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2792,7 +2792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2829,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2849,7 +2849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2865,7 +2865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2876,7 +2876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2888,7 +2888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2904,7 +2904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2919,7 +2919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of pyrimidine ribonucleotides <i>de novo</i> biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2932,7 +2932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -2947,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2965,7 +2965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2979,7 +2979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2995,7 +2995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3007,7 +3007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3023,7 +3023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3038,7 +3038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3052,7 +3052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3068,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3081,7 +3081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3098,7 +3098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3111,7 +3111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3123,7 +3123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3143,7 +3143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3157,7 +3157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3173,7 +3173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3185,7 +3185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3207,7 +3207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3218,7 +3218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3235,7 +3235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3255,7 +3255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3268,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3279,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3291,7 +3291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3319,7 +3319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3332,7 +3332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3349,7 +3349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3383,7 +3383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3399,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3410,7 +3410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3421,7 +3421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3435,7 +3435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3447,7 +3447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3469,7 +3469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3488,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3499,7 +3499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3513,7 +3513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3527,7 +3527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3541,7 +3541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3557,7 +3557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3568,7 +3568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3579,7 +3579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3591,7 +3591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3607,7 +3607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3618,7 +3618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3635,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3647,7 +3647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3687,7 +3687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3703,7 +3703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3715,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3735,7 +3735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3751,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3763,7 +3763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3783,7 +3783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3800,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3813,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3836,7 +3836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,7 +3856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3872,7 +3872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-162" ;
         <http://purl.org/pav/providedBy>
@@ -3884,7 +3884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3907,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-162" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY0-662-PWY0-662.ttl
+++ b/models/PWY0-662-PWY0-662.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -154,6 +154,17 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY0-662>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY0-662" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YOL061W-MONOMER_PRPPSYN-RXN_controller>
         a       <http://identifiers.org/sgd/S000005422> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -161,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -169,24 +180,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002234_CHEBI_58017_PRPPSYN-RXN_SGD_PWY0-662>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY0-662" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PRPPSYN-RXN_RO_0002233_CHEBI_78346_PRPPSYN-RXN_SGD_PWY0-662> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY0-662" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "PRPP biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY0-662" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-0-PWY3O-0.ttl
+++ b/models/PWY3O-0-PWY3O-0.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -445,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -543,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fructose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-0" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-0" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-0" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-1-PWY3O-1.ttl
+++ b/models/PWY3O-1-PWY3O-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,7 +236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -476,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -862,7 +862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,24 +1006,13 @@
           <http://model.geneontology.org/CHEBI_28938_AMP-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENOSINE-KINASE-RXN_RO_0002233_CHEBI_16335_ADENOSINE-KINASE-RXN_SGD_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,6 +1023,17 @@
           <http://model.geneontology.org/CHEBI_16335_ADENOSINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002233_CHEBI_16708_ADENINE-DEAMINASE-RXN_SGD_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58017_HYPOXANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58017> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1043,7 +1043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1130,7 +1130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1184,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1237,7 +1237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1285,28 +1285,13 @@
 <http://model.geneontology.org/reaction_HYPOXANPRIBOSYLTRAN-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller>
-        a       <http://identifiers.org/sgd/S000003866> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "adenosine kinase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1Protein47545> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_16235_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1317,6 +1302,32 @@
           <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/YJR105W-MONOMER_ADENOSINE-KINASE-RXN_controller>
+        a       <http://identifiers.org/sgd/S000003866> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "adenosine kinase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1Protein47545> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456215_ADENPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456215> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1326,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1334,24 +1345,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_456215_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_BFO_0000050_PWY3O-1/PWY3O-1_SGD_PWY3O-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1409,7 +1409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1420,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1466,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1480,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1496,7 +1496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1507,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1579,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1590,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1627,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1654,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1674,22 +1674,25 @@
 <http://purl.obolibrary.org/obo/CHEBI_28938>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0004422>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY3O-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.obolibrary.org/obo/GO_0004422>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/GO_0003876>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1697,7 +1700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1707,9 +1710,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57720_INOPHOSPHOR-RXN>
 ] .
-
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/XANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0000310> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1728,7 +1728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1741,7 +1741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1764,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1789,7 +1789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1806,7 +1806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1829,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1843,7 +1843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1862,7 +1862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1894,7 +1894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1928,7 +1928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,7 +1948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1965,7 +1965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1988,7 +1988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2005,7 +2005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2024,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2044,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2057,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2068,7 +2068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2079,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2097,7 +2097,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2128,7 +2128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2162,7 +2162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2190,7 +2190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2206,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2240,7 +2240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2265,7 +2265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2288,7 +2288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,7 +2302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2318,7 +2318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2347,7 +2347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2367,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2414,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2435,7 +2435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,7 +2486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2506,7 +2506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2540,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2557,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2571,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2587,7 +2587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2599,7 +2599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2619,7 +2619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2635,7 +2635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2651,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2662,7 +2662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2673,7 +2673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2684,7 +2684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2696,7 +2696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2712,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2723,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2738,7 +2738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of purines and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2751,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2763,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2782,7 +2782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2799,7 +2799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2813,19 +2813,19 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_BFO_0000050_PWY3O-1/PWY3O-1_SGD_PWY3O-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/YDR441C-MONOMER_ADENPRIBOSYLTRAN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002849> ;
@@ -2834,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2847,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2860,7 +2860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2880,7 +2880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2893,7 +2893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2908,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -2939,7 +2939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2956,7 +2956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2986,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3000,7 +3000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3020,7 +3020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3040,7 +3040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3057,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3072,7 +3072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3086,7 +3086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3106,7 +3106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3123,7 +3123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3142,7 +3142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3158,7 +3158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3169,7 +3169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3182,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3202,7 +3202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3218,7 +3218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3246,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3260,7 +3260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3295,7 +3295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3317,7 +3317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3358,7 +3358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3369,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1" ;
         <http://purl.org/pav/providedBy>
@@ -3383,7 +3383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-10-PWY3O-10.ttl
+++ b/models/PWY3O-10-PWY3O-10.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -662,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -793,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -807,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -841,7 +841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -875,7 +875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -895,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -925,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -979,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -995,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1009,7 +1009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,7 +1053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1064,7 +1064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1143,7 +1143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1160,7 +1160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,7 +1238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1297,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1329,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1357,7 +1357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1377,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1419,7 +1419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1455,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1481,7 +1481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1500,7 +1500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1539,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1557,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1570,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1605,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1622,7 +1622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1650,7 +1650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1667,7 +1667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1697,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1710,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1765,7 +1765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,23 +1799,23 @@
           <http://model.geneontology.org/CHEBI_15378_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_null_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-10" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-10>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-10" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_BFO_0000066_reaction_ACP-S-ACETYLTRANSFER-RXN_location_lociGO_0005829_null_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -1860,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1874,7 +1874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1891,7 +1891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,7 +1908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1946,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1982,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1998,7 +1998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2010,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2027,7 +2027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2043,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2058,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2071,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2144,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,7 +2164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2184,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2201,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2215,7 +2215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2231,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2262,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2274,7 +2274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2291,7 +2291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2321,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2335,7 +2335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2367,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2383,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2418,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2433,7 +2433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2464,7 +2464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2486,7 +2486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2503,7 +2503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2519,7 +2519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2528,7 +2528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2556,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2564,12 +2564,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-10>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-10>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2581,7 +2581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2592,12 +2592,12 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002233_CHEBI_57288_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-10>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-8_ACETYL-COA-CARBOXYLTRANSFER-RXN_controller_BFO_0000051_SGD_S000005299_CPLX3O-8_component_SGD_PWY3O-10>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2612,7 +2612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2629,7 +2629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2649,7 +2649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2666,7 +2666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid biosynthesis, initial steps - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2696,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2708,7 +2708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2724,7 +2724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2738,7 +2738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2755,7 +2755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2803,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2816,7 +2816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2827,7 +2827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-10" ;
         <http://purl.org/pav/providedBy>
@@ -2838,7 +2838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-10" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-10" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-103-PWY3O-103.ttl
+++ b/models/PWY3O-103-PWY3O-103.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,6 +24,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_498d2622-86bf-4f6f-8f38-bc9b38e2cad4_CDPDIGLYSYN-RXN_SGD_PWY3O-103>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-103" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -42,7 +53,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -111,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -142,11 +153,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70454> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/498d2622-86bf-4f6f-8f38-bc9b38e2cad4_CDPDIGLYSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -159,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,13 +209,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_37563_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29089_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
+                <http://model.geneontology.org/498d2622-86bf-4f6f-8f38-bc9b38e2cad4_CDPDIGLYSYN-RXN> , <http://model.geneontology.org/CHEBI_29888_CDPDIGLYSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -203,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -212,30 +240,13 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-103SmallMolecule70439> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002333_YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller_SGD_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,23 +257,12 @@
           <http://model.geneontology.org/YBR029C-MONOMER_CDPDIGLYSYN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN_SGD_PWY3O-103>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-103" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_CHEBI_29888_CDPDIGLYSYN-RXN_SGD_PWY3O-103>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,11 +335,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN_SGD_PWY3O-103> ;
+          <http://model.geneontology.org/ev_w_id_CDPDIGLYSYN-RXN_RO_0002234_498d2622-86bf-4f6f-8f38-bc9b38e2cad4_CDPDIGLYSYN-RXN_SGD_PWY3O-103> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -347,7 +347,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CDPDIGLYSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/75c8bd5f-4d01-4797-9088-ebdf5c5cd394_CDPDIGLYSYN-RXN>
+          <http://model.geneontology.org/498d2622-86bf-4f6f-8f38-bc9b38e2cad4_CDPDIGLYSYN-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-103" ;
         <http://purl.org/pav/providedBy>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "CDP-diacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-103" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-1109-PWY3O-1109.ttl
+++ b/models/PWY3O-1109-PWY3O-1109.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +54,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -175,7 +175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -455,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-hydroxybenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -952,7 +952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1017,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,7 +1082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1178,7 +1178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1226,7 +1226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1370,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1420,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1607,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1618,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1630,7 +1630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1646,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1658,7 +1658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,7 +1677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1691,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1731,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1744,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1772,7 +1772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1784,7 +1784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1821,7 +1821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1834,7 +1834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1857,7 +1857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1877,7 +1877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,7 +1891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1919,7 +1919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1956,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1969,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -1983,7 +1983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +2013,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2063,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2074,7 +2074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2103,7 +2103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,7 +2120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2139,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2151,7 +2151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2201,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2223,7 +2223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2234,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2246,7 +2246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2262,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2274,7 +2274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2293,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2304,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1109" ;
         <http://purl.org/pav/providedBy>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-114-PWY3O-114.ttl
+++ b/models/PWY3O-114-PWY3O-114.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,17 +342,6 @@
           <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601_SGD_PWY3O-114>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-114" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_35235_RXN-6622>
         a       <http://purl.obolibrary.org/obo/CHEBI_35235> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -362,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -534,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -567,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -589,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -679,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,6 +678,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_GLUTCYSLIG-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_ab7d0fde-69b7-4141-bbce-d71f80042d1d_RXN-6601_SGD_PWY3O-114>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-114" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_35235>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -865,7 +865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -912,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -984,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1001,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1170,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1183,7 +1183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1232,7 +1232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutathione metabolism (truncated &gamma;-glutamyl cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1307,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1326,7 +1326,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57925_RXN-6601> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_61694_RXN-6601> , <http://model.geneontology.org/cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601> ;
+                <http://model.geneontology.org/ab7d0fde-69b7-4141-bbce-d71f80042d1d_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1334,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1350,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1362,7 +1362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1388,7 +1388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,11 +1432,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601_SGD_PWY3O-114> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_ab7d0fde-69b7-4141-bbce-d71f80042d1d_RXN-6601_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1444,7 +1444,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601>
+          <http://model.geneontology.org/ab7d0fde-69b7-4141-bbce-d71f80042d1d_RXN-6601>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1453,7 +1453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1472,7 +1472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1483,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1498,7 +1498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1534,7 +1534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1551,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1572,7 +1572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1582,6 +1582,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-114/PWY3O-114>
 ] .
+
+<http://model.geneontology.org/ab7d0fde-69b7-4141-bbce-d71f80042d1d_RXN-6601>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/GLUTCYSLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004357> ;
@@ -1602,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1610,30 +1627,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/cb874f05-a8c9-42e5-8113-224f006fb014_RXN-6601>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-114SmallMolecule62339> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUTATHIONE-SYN-RXN_RO_0002233_CHEBI_30616_GLUTATHIONE-SYN-RXN_SGD_PWY3O-114> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1660,7 +1660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1686,7 +1686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1700,7 +1700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1717,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1767,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1779,7 +1779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-114" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-114" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-123-PWY3O-123.ttl
+++ b/models/PWY3O-123-PWY3O-123.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -117,11 +117,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29656> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/c052d834-a5d3-47b5-bd8c-7a9ef94fc411_2.4.1.83-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a dolichyl &beta;-D-mannosyl phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -130,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -240,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -320,11 +337,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN_SGD_PWY3O-123> ;
+          <http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_c052d834-a5d3-47b5-bd8c-7a9ef94fc411_2.4.1.83-RXN_SGD_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +349,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.4.1.83-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN>
+          <http://model.geneontology.org/c052d834-a5d3-47b5-bd8c-7a9ef94fc411_2.4.1.83-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_58189>
@@ -356,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -369,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -389,13 +406,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16214_2.4.1.83-RXN> , <http://model.geneontology.org/CHEBI_57527_2.4.1.83-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> , <http://model.geneontology.org/c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN> ;
+                <http://model.geneontology.org/c052d834-a5d3-47b5-bd8c-7a9ef94fc411_2.4.1.83-RXN> , <http://model.geneontology.org/CHEBI_58189_2.4.1.83-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YPR183W-MONOMER_2.4.1.83-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -432,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -538,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -674,7 +691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -747,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -755,6 +772,17 @@
 
 <http://purl.obolibrary.org/obo/GO_0004582>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58189_MANNPGUANYLTRANGDP-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58189> ;
@@ -765,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -773,24 +801,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_43474_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_RO_0002233_CHEBI_48066_MANNPISOM-RXN_SGD_PWY3O-123> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,23 +921,6 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a dolichyl &beta;-D-mannosyl phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-123SmallMolecule29606> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_43474_MANNPGUANYLTRANGDP-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -964,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,23 +1029,23 @@
 <http://identifiers.org/sgd/S000001849>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58189_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002234_CHEBI_57527_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_MANNPGUANYLTRANGDP-RXN_RO_0002233_CHEBI_58189_MANNPGUANYLTRANGDP-RXN_SGD_PWY3O-123>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1059,7 +1059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1141,17 +1141,6 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_c8cc0675-073e-4434-946a-b744ed05b6b6_2.4.1.83-RXN_SGD_PWY3O-123>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1162,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,7 +1164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,6 +1201,17 @@
           <http://model.geneontology.org/PWY3O-123/PWY3O-123>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002234_c052d834-a5d3-47b5-bd8c-7a9ef94fc411_2.4.1.83-RXN_SGD_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0008928>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1221,7 +1221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,29 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_16214_2.4.1.83-RXN_SGD_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-123" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_PWY3O-123/PWY3O-123_SGD_PWY3O-123>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-123" ;
         <http://purl.org/pav/providedBy>
@@ -1277,13 +1255,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl phosphate D-mannose biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/ev_w_id_MANNPISOM-RXN_BFO_0000050_PWY3O-123/PWY3O-123_SGD_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.4.1.83-RXN_RO_0002233_CHEBI_16214_2.4.1.83-RXN_SGD_PWY3O-123>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-123" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YFL045C-MONOMER_PHOSMANMUT-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001849> ;
@@ -1292,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,7 +1306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1328,7 +1328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-123" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-13-PWY3O-13.ttl
+++ b/models/PWY3O-13-PWY3O-13.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -100,7 +100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -132,7 +132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of glutamate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -269,7 +269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -328,7 +328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -583,7 +583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -816,7 +816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -847,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1023,7 +1023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1056,7 +1056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1276,7 +1276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,7 +1307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1352,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1510,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1524,7 +1524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1585,7 +1585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1654,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1670,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1682,7 +1682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1698,7 +1698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1723,7 +1723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1746,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1776,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1826,7 +1826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1854,7 +1854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-13" ;
         <http://purl.org/pav/providedBy>
@@ -1869,7 +1869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,7 +1918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1938,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1955,7 +1955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1972,7 +1972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1992,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-13" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-15-PWY3O-15.ttl
+++ b/models/PWY3O-15-PWY3O-15.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -19,7 +19,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-15" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-15" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-1565-PWY3O-1565.ttl
+++ b/models/PWY3O-1565-PWY3O-1565.ttl
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -39,19 +39,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_58223>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_46398>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY3O-1565>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_46398>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -345,19 +345,19 @@
 <http://purl.obolibrary.org/obo/GO_0004614>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0003983>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002233_CHEBI_46398_GLUC1PURIDYLTRANS-RXN_SGD_PWY3O-1565>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003983>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -499,26 +499,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
-        a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphoglucomutase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1565Protein28785> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -526,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,6 +521,21 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16214_2.4.1.117-RXN>
 ] .
+
+<http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
+        a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphoglucomutase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-1565Protein28785> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/GLUC1PURIDYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003983> ;
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dolichyl glucosyl phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -805,7 +805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -951,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -985,7 +985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1018,6 +1018,17 @@
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_null_PWY3O-1565>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-1565" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58601_PHOSPHOGLUCMUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58601> ;
@@ -1028,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,24 +1047,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_2.4.1.117-RXN_null_PWY3O-1565>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-1565" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002333_YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller_SGD_PWY3O-1565> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1134,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1565" ;
         <http://purl.org/pav/providedBy>
@@ -1148,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1565" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-17-PWY3O-17.ttl
+++ b/models/PWY3O-17-PWY3O-17.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -148,24 +148,13 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_null_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_THIAMIN-PYROPHOSPHOKINASE-RXN_RO_0002233_CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN_SGD_PWY3O-17> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,6 +165,17 @@
           <http://model.geneontology.org/CHEBI_30616_THIAMIN-PYROPHOSPHOKINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002413_THI-P-SYN-RXN_null_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_456216_PYRIMSYN3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -357,7 +357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -575,7 +575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -725,7 +725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -803,23 +803,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-82_PYRIMSYN3-RXN_controller_BFO_0000051_SGD_S000006179_CPLX3O-82_component_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9804_RO_0002233_CHEBI_57595_RXN3O-9804_SGD_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -918,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1202,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,7 +1218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1262,7 +1262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1277,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1293,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1307,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1329,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1341,7 +1341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1363,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,7 +1426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1463,6 +1463,34 @@
           <http://model.geneontology.org/RXNQT-4301> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_139151_RXNQT-4301>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_PWY3O-17> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-401> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_17154_RXN3O-401>
 ] .
 
 <http://model.geneontology.org/CPLX3O-25_THIAMIN-PYROPHOSPHOKINASE-RXN_controller>
@@ -1474,41 +1502,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17Complex69113> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002234_CHEBI_17154_RXN3O-401_SGD_PWY3O-17> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-401> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_17154_RXN3O-401>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXNQT-4191_RO_0002234_CHEBI_43474_RXNQT-4191_SGD_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16892_RXN3O-9804>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16892> ;
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,7 +1533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,7 +1549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1589,7 +1589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1642,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1657,7 +1657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1688,7 +1688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1705,7 +1705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1721,7 +1721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1732,7 +1732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1744,7 +1744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1764,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1780,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1791,7 +1791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1802,7 +1802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1855,7 +1855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1874,7 +1874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1890,18 +1890,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/SGD_S000005416_CPLX3O-80_component>
-        a       <http://identifiers.org/sgd/S000005416> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1911,7 +1902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1931,13 +1922,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69077> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/SGD_S000005416_CPLX3O-80_component>
+        a       <http://identifiers.org/sgd/S000005416> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1947,7 +1947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1963,7 +1963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -1978,7 +1978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2005,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2016,7 +2016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2030,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2045,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2062,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2109,7 +2109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2123,7 +2123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2143,7 +2143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2163,7 +2163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2180,7 +2180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2196,7 +2196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2212,18 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_PWY3O-17>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2246,12 +2235,23 @@
           <http://model.geneontology.org/CPLX3O-80_OHMETPYRKIN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002234_CHEBI_456216_PYRIMSYN3-RXN_SGD_PWY3O-17>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000006135_CPLX3O-9180_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000006135> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2260,7 +2260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2278,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thiamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2286,25 +2286,25 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_null_PWY3O-17>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-17" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PYRIMSYN3-RXN_RO_0002333_CPLX3O-80_PYRIMSYN3-RXN_controller_SGD_PWY3O-17>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-401_RO_0002629_RXNQT-4301_null_PWY3O-17>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2314,7 +2314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2334,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2350,7 +2350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2403,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2418,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2432,7 +2432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2475,7 +2475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2502,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2516,7 +2516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2535,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2547,7 +2547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2567,7 +2567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2584,7 +2584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2600,7 +2600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2614,7 +2614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2629,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2646,7 +2646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2662,7 +2662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2677,7 +2677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2690,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2715,7 +2715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2727,7 +2727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2746,7 +2746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2763,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2779,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2791,7 +2791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2807,7 +2807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2830,7 +2830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2843,7 +2843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -2864,7 +2864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2878,7 +2878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2895,7 +2895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2914,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2931,7 +2931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,7 +2948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2965,7 +2965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2982,7 +2982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2999,7 +2999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3031,7 +3031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3044,7 +3044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3058,7 +3058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3075,7 +3075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3092,7 +3092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3108,7 +3108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3119,7 +3119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3130,7 +3130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3140,7 +3140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3163,28 +3163,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule68874> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_57841_THI-P-SYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57841> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "HMP-PP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69223> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3197,11 +3180,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69001> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_57841_THI-P-SYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57841> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "HMP-PP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-17SmallMolecule69223> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3224,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3238,7 +3238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3254,7 +3254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3266,7 +3266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3286,7 +3286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3303,7 +3303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3317,7 +3317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3333,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3361,7 +3361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3374,7 +3374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3390,7 +3390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3401,7 +3401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3413,7 +3413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3429,7 +3429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3440,7 +3440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3454,7 +3454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3474,7 +3474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3490,7 +3490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3501,7 +3501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3516,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3529,7 +3529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-17" ;
         <http://purl.org/pav/providedBy>
@@ -3550,7 +3550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3567,7 +3567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3581,7 +3581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-17" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-1743-PWY3O-1743.ttl
+++ b/models/PWY3O-1743-PWY3O-1743.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -271,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -286,19 +286,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_57634>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/GO_0004476>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9791_RO_0002234_CHEBI_48066_RXN3O-9791_SGD_PWY3O-1743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004476>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -349,7 +349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -522,7 +522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -535,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "mannose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -769,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1743" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-1801-PWY3O-1801.ttl
+++ b/models/PWY3O-1801-PWY3O-1801.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -297,7 +297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -488,7 +488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -697,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -757,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -788,7 +788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitoleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1801" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1801" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-1874-PWY3O-1874.ttl
+++ b/models/PWY3O-1874-PWY3O-1874.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "p-aminobenzoate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -551,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,25 +568,25 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_PWY3O-1874>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-1874" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002233_CHEBI_58359_PABASYN-RXN_SGD_PWY3O-1874>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PABASYN-RXN_RO_0002413_ADCLY-RXN_null_PWY3O-1874>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -614,7 +614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-1874" ;
         <http://purl.org/pav/providedBy>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-1874" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-188-PWY3O-188.ttl
+++ b/models/PWY3O-188-PWY3O-188.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -106,7 +106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -249,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -287,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -425,22 +425,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_PWY3O-188> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9794> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-9794>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-9794>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -451,9 +445,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9794_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> , <http://model.geneontology.org/36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794> ;
+                <http://model.geneontology.org/CHEBI_15379_RXN3O-9794> , <http://model.geneontology.org/724c5601-bada-4fb8-960e-7f18ceba6430_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
+                <http://model.geneontology.org/cc476289-7e15-4817-baec-fbc8692e5f80_RXN3O-9794> , <http://model.geneontology.org/CHEBI_15377_RXN3O-9794> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-117_RXN3O-9794_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -461,7 +455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -469,16 +463,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002333_YML120C-MONOMER_RXN3O-165_controller_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_CHEBI_15379_RXN3O-9794_SGD_PWY3O-188> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9794> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-9794>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -486,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,7 +519,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_8cc767ad-dd9c-4186-8e26-4130094c25c7_RXN3O-168_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,29 +618,12 @@
 <http://identifiers.org/sgd/S000000750>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "oxidized cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/SGD_S000002937_CPLX3O-109_component>
         a       <http://identifiers.org/sgd/S000002937> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -638,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -647,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -710,7 +704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,19 +720,36 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
+<http://model.geneontology.org/8cc767ad-dd9c-4186-8e26-4130094c25c7_RXN3O-168>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "oxidized cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_cc476289-7e15-4817-baec-fbc8692e5f80_RXN3O-9794_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -746,7 +757,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9794> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794>
+          <http://model.geneontology.org/cc476289-7e15-4817-baec-fbc8692e5f80_RXN3O-9794>
 ] .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -758,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -797,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -825,9 +836,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/531536d2-7e21-4a06-9f80-673707fed5ed_RXN3O-168>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "reduced cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -838,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -919,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -930,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -941,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -950,23 +978,12 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -995,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1023,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,12 +1068,23 @@
           <http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_cc476289-7e15-4817-baec-fbc8692e5f80_RXN3O-9794_SGD_PWY3O-188>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/SGD_S000003581_CPLX3O-44_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003581> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1065,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1080,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,13 +1139,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_531536d2-7e21-4a06-9f80-673707fed5ed_RXN3O-168_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_BFO_0000050_PWY3O-188/PWY3O-188_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1145,7 +1184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1162,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,12 +1215,12 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_PWY3O-188>
+<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1190,25 +1229,25 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002234_CHEBI_29806_SUCC-FUM-OXRED-UBI-RXN_SGD_PWY3O-188>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002413_RXN3O-168_null_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003159_CPLX3O-117_component_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1217,35 +1256,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "oxidized cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SGD_S000003702_CPLX3O-109_component>
         a       <http://identifiers.org/sgd/S000003702> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1263,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1280,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1310,11 +1332,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_531536d2-7e21-4a06-9f80-673707fed5ed_RXN3O-168_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1322,7 +1344,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168>
+          <http://model.geneontology.org/531536d2-7e21-4a06-9f80-673707fed5ed_RXN3O-168>
 ] .
 
 <http://model.geneontology.org/ev_w_id_SUCC-FUM-OXRED-UBI-RXN_RO_0002333_CPLX3O-742_SUCC-FUM-OXRED-UBI-RXN_controller_SGD_PWY3O-188>
@@ -1330,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1361,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1385,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1412,7 +1434,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-188" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_724c5601-bada-4fb8-960e-7f18ceba6430_RXN3O-9794_SGD_PWY3O-188>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1423,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1432,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1443,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1500,11 +1533,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002233_724c5601-bada-4fb8-960e-7f18ceba6430_RXN3O-9794_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1545,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9794> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794>
+          <http://model.geneontology.org/724c5601-bada-4fb8-960e-7f18ceba6430_RXN3O-9794>
 ] .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
@@ -1524,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1537,7 +1570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1551,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,7 +1600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1582,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1592,17 +1625,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000007270_CPLX3O-109_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9794_RO_0002234_10985bda-4cc7-4e2c-8052-9653034f403c_RXN3O-9794_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000003964>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1616,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1629,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,7 +1683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1675,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1707,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,7 +1749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1740,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1767,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1790,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1803,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1834,7 +1856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,7 +1876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1873,7 +1895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1884,36 +1906,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000000141>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "reduced cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000003155_CPLX3O-117_component_SGD_PWY3O-188>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1928,7 +1933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1944,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -1956,7 +1961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1973,7 +1978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +1994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2000,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2015,7 +2020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,11 +2036,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168_SGD_PWY3O-188> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_8cc767ad-dd9c-4186-8e26-4130094c25c7_RXN3O-168_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2043,7 +2048,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-168> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168>
+          <http://model.geneontology.org/8cc767ad-dd9c-4186-8e26-4130094c25c7_RXN3O-168>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2052,7 +2057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2068,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2080,7 +2085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2114,9 +2119,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-168_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_52970_RXN3O-168> , <http://model.geneontology.org/2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168> ;
+                <http://model.geneontology.org/CHEBI_52970_RXN3O-168> , <http://model.geneontology.org/8cc767ad-dd9c-4186-8e26-4130094c25c7_RXN3O-168> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_52971_RXN3O-168> , <http://model.geneontology.org/e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168> ;
+                <http://model.geneontology.org/531536d2-7e21-4a06-9f80-673707fed5ed_RXN3O-168> , <http://model.geneontology.org/CHEBI_52971_RXN3O-168> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-109_RXN3O-168_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2124,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2143,7 +2148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2180,7 +2185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2196,7 +2201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2210,28 +2215,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/36f8ebca-c8cd-4737-aac4-eac86ff10bc1_RXN3O-9794>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "reduced cytochrome c" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000002585>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2245,7 +2233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2261,7 +2249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2278,7 +2266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2295,7 +2283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2329,26 +2317,60 @@
 <http://identifiers.org/sgd/S000004387>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.org/dc/elements/1.1/title>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/cc476289-7e15-4817-baec-fbc8692e5f80_RXN3O-9794>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "oxidized cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17279> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-165_BFO_0000066_reaction_RXN3O-165_location_lociGO_0005829_null_PWY3O-188>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://purl.org/dc/elements/1.1/title>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/724c5601-bada-4fb8-960e-7f18ceba6430_RXN3O-9794>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "reduced cytochrome c" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-188SmallMolecule17257> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/SGD_S000007281_CPLX3O-117_component>
         a       <http://identifiers.org/sgd/S000007281> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2363,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2372,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2385,7 +2407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "aerobic respiration, electron transport chain - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2398,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2408,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2424,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2436,7 +2458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2452,7 +2474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2462,7 +2484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2478,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2489,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2505,7 +2527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2516,27 +2538,13 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-9794>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_29806>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002233_2963d3a1-1d07-43ec-9fac-941a343255c5_RXN3O-168_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-165_RO_0002233_CHEBI_52971_RXN3O-165_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2547,13 +2555,16 @@
           <http://model.geneontology.org/CHEBI_52971_RXN3O-165>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_29806>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-117_RXN3O-9794_controller_BFO_0000051_SGD_S000001093_CPLX3O-117_component_SGD_PWY3O-188> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2567,23 +2578,12 @@
 <http://identifiers.org/sgd/S000001929>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-168_RO_0002234_e143b0c8-fd0e-4257-84af-8e93463941c9_RXN3O-168_SGD_PWY3O-188>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-188" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/SGD_S000005591_CPLX3O-109_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005591> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2592,7 +2592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2601,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2610,7 +2610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2626,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2643,7 +2643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2662,7 +2662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2676,7 +2676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2696,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2713,7 +2713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2727,7 +2727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2743,7 +2743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2757,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2768,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2779,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>
@@ -2790,7 +2790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-188" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-188" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-19-PWY3O-19.ttl
+++ b/models/PWY3O-19-PWY3O-19.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,15 +199,12 @@
           <http://model.geneontology.org/CHEBI_52970_RXN3O-102>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24331>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_Reduced-ferredoxins_RXN3O-58_SGD_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -222,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -236,12 +233,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_Apo-Ferredoxins_RXN3O-58_SGD_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -492,7 +492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -571,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -624,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -643,7 +643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -683,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,12 +796,29 @@
 <http://model.geneontology.org/reaction_2.1.1.114-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41596> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_PWY3O-19/PWY3O-19_SGD_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -812,28 +829,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41596> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_RXN3O-102_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -929,7 +929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1027,7 +1027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1039,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1090,24 +1090,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ubiquinol-6 biosynthesis from 4-hydroxybenzoate (eukaryotic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -1117,7 +1106,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15379_RXN3O-58_SGD_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1163,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1177,7 +1177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,25 +1282,25 @@
           <http://model.geneontology.org/RXN3O-58>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_null_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002333_YNR041C-MONOMER_RXN-9003_controller_SGD_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_null_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1323,7 +1323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1437,7 +1437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1470,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,23 +1481,12 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_null_PWY3O-19>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-19" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-12_BFO_0000050_PWY3O-19/PWY3O-19_SGD_PWY3O-19>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1510,7 +1499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1518,28 +1507,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-73_BFO_0000066_reaction_RXN3O-73_location_lociGO_0005829_null_PWY3O-19>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_PWY3O-19/PWY3O-19_SGD_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/2.1.1.114-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-19/PWY3O-19>
-] .
 
 <http://model.geneontology.org/PWY3O-19/PWY3O-19>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1548,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1556,22 +1539,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-58> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58373_RXN3O-58>
-] .
+<http://model.geneontology.org/CHEBI_57856_RXN3O-54>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "SAH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41448> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1585,7 +1568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,12 +1576,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_PWY3O-19/PWY3O-19_SGD_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/2.1.1.114-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-19/PWY3O-19>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002413_RXN3O-102_null_PWY3O-19>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1609,28 +1609,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_57856_RXN3O-54>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57856> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "SAH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41448> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-58> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58373_RXN3O-58>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1669,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1706,7 +1706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1726,7 +1726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1739,7 +1739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1759,7 +1759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1804,7 +1804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1826,7 +1826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1887,7 +1887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1915,7 +1915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1934,7 +1934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1967,7 +1967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1997,7 +1997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2042,7 +2042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,28 +2055,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_29888_RXN-9003>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41377> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_84492_RXN3O-58>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_84492> ;
@@ -2087,13 +2070,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41362> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY3O-19>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-19" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-12>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -2104,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2112,16 +2106,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002234_CHEBI_58373_RXN3O-58_SGD_PWY3O-19>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_29888_RXN-9003>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-19" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41377> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_59789_RXN3O-102>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
@@ -2132,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2165,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,13 +2187,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_59789_RXN3O-102> , <http://model.geneontology.org/CHEBI_64253_RXN3O-102> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_RXN3O-102> , <http://model.geneontology.org/CHEBI_52970_RXN3O-102> , <http://model.geneontology.org/CHEBI_57856_RXN3O-102> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN3O-102> , <http://model.geneontology.org/CHEBI_57856_RXN3O-102> , <http://model.geneontology.org/CHEBI_52970_RXN3O-102> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOL096C-MONOMER_RXN3O-102_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2207,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2239,7 +2239,7 @@
 ] .
 
 <http://model.geneontology.org/CHEBI_17499_RXN3O-75>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2247,7 +2247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2263,7 +2263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2296,7 +2296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2313,7 +2313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2354,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2366,7 +2366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,7 +2385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2396,7 +2396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2424,7 +2424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2438,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2453,7 +2453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2470,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,7 +2484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2504,7 +2504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2524,7 +2524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2541,7 +2541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2564,7 +2564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2577,7 +2577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2592,7 +2592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,7 +2609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2629,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2645,7 +2645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2662,7 +2662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2678,7 +2678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2696,7 +2696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2705,7 +2705,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15339_RXN3O-75>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24331> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2713,7 +2713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2727,7 +2727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2743,7 +2743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2754,7 +2754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2766,7 +2766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,7 +2783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2809,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2848,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2863,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2879,7 +2879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2896,7 +2896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2913,7 +2913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,7 +2930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2949,7 +2949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2963,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2980,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -2992,7 +2992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3009,7 +3009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3025,7 +3025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3037,7 +3037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3053,7 +3053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3064,7 +3064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3077,7 +3077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3094,7 +3094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3107,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3122,7 +3122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3139,7 +3139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3156,7 +3156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3170,7 +3170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3186,7 +3186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3198,7 +3198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3207,6 +3207,23 @@
           <http://model.geneontology.org/RXN3O-58> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN3O-58>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-12_SGD_PWY3O-19> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-12> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_1109_RXN3O-12>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-12>
@@ -3218,30 +3235,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-19SmallMolecule41480> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_1109_RXN3O-12_SGD_PWY3O-19> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-12> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_1109_RXN3O-12>
-] .
 
 <http://model.geneontology.org/RXN3O-58>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3262,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3275,7 +3275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3288,7 +3288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3301,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>
@@ -3313,7 +3313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3329,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-19" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-19" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-2-PWY3O-2.ttl
+++ b/models/PWY3O-2-PWY3O-2.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,30 +22,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32077> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/reaction_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -59,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -165,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,6 +226,28 @@
           <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_368cc7ee-e5b7-4bed-b08c-040d5470614e_PHOSPHASERSYN-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_fa9bbdec-af0e-42c6-a06b-25686cc9502f_2.1.1.17-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/PWY3O-2/PWY3O-2>
         a       <http://purl.obolibrary.org/obo/GO_0008150> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -252,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -260,24 +265,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16038_PHOSPHASERDECARB-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -296,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -322,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,12 +343,40 @@
           <http://model.geneontology.org/2.7.7.14-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_ae4c283b-7569-481d-b1aa-fc3366bd8c3b_RXN3O-349_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/d3f007d1-8b99-4a7a-815a-d3f996eb8150_RXN4FS-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,16 +436,13 @@
           <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,12 +453,15 @@
           <http://model.geneontology.org/PWY3O-2/PWY3O-2>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002413_2.1.1.71-RXN_null_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +622,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN4FS-2_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
+                <http://model.geneontology.org/d3f007d1-8b99-4a7a-815a-d3f996eb8150_RXN4FS-2> , <http://model.geneontology.org/CHEBI_59789_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16110_RXN4FS-2> , <http://model.geneontology.org/CHEBI_15378_RXN4FS-2> , <http://model.geneontology.org/CHEBI_57856_RXN4FS-2> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -608,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -622,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,12 +655,23 @@
           <http://model.geneontology.org/CHEBI_59789_RXN3O-349>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_fe523b0a-436b-4965-8d04-5635c692d0e4_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_15378_2.7.7.15-RXN_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -649,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -678,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +806,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_d3f007d1-8b99-4a7a-815a-d3f996eb8150_RXN4FS-2_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -882,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -911,7 +955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,23 +997,6 @@
           <http://model.geneontology.org/PWY3O-2/PWY3O-2>
 ] .
 
-<http://model.geneontology.org/e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://identifiers.org/sgd/S000003389>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -978,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1024,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1038,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1086,7 +1113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1131,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,7 +1175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1178,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,7 +1222,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHASERSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/368cc7ee-e5b7-4bed-b08c-040d5470614e_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_11750_PHOSPHASERSYN-RXN> , <http://model.geneontology.org/CHEBI_15378_PHOSPHASERSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1205,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1246,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1271,7 +1298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1323,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,20 +1363,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_null_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1360,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1368,13 +1384,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_BFO_0000066_reaction_ETHANOLAMINE-KINASE-RXN_location_lociGO_0005829_null_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1409,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1422,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1478,11 +1505,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_fa9bbdec-af0e-42c6-a06b-25686cc9502f_2.1.1.17-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1490,19 +1517,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.17-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN>
+          <http://model.geneontology.org/fa9bbdec-af0e-42c6-a06b-25686cc9502f_2.1.1.17-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1512,7 +1528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1561,11 +1577,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_e44c7fa9-f04e-44e4-bc0e-94a0866d8205_PGPPHOSPHA-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,7 +1589,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PGPPHOSPHA-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN>
+          <http://model.geneontology.org/e44c7fa9-f04e-44e4-bc0e-94a0866d8205_PGPPHOSPHA-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1582,7 +1598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1602,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1633,23 +1649,23 @@
 <http://identifiers.org/sgd/S000003239>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002234_CHEBI_16526_PHOSPHASERDECARB-RXN_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_57856_2.1.1.71-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1660,7 +1676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1685,7 +1701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,11 +1720,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_ae4c283b-7569-481d-b1aa-fc3366bd8c3b_RXN3O-349_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,7 +1732,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-349> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349>
+          <http://model.geneontology.org/ae4c283b-7569-481d-b1aa-fc3366bd8c3b_RXN3O-349>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57880>
@@ -1731,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1744,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1755,7 +1771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1783,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1797,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1830,20 +1846,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-349_RO_0002233_3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1856,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1870,7 +1875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1886,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1898,7 +1903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1911,11 +1916,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_06e5a483-7aed-4e6e-b338-0fd8a3d9e5d6_2.1.1.71-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1923,7 +1928,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN>
+          <http://model.geneontology.org/06e5a483-7aed-4e6e-b338-0fd8a3d9e5d6_2.1.1.71-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINE-KINASE-RXN_SGD_PWY3O-2>
@@ -1931,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1957,7 +1962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1968,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -1980,7 +1985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2002,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2017,7 +2022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,13 +2036,30 @@
 <http://identifiers.org/sgd/S000001165>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/06e5a483-7aed-4e6e-b338-0fd8a3d9e5d6_2.1.1.71-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002234_CHEBI_29888_2.7.7.14-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,7 +2078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2083,11 +2105,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_368cc7ee-e5b7-4bed-b08c-040d5470614e_PHOSPHASERSYN-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2095,7 +2117,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHASERSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN>
+          <http://model.geneontology.org/368cc7ee-e5b7-4bed-b08c-040d5470614e_PHOSPHASERSYN-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2106,7 +2128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2126,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2146,7 +2168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2162,7 +2184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2179,7 +2201,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16038_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
+                <http://model.geneontology.org/CHEBI_57856_2.1.1.17-RXN> , <http://model.geneontology.org/fa9bbdec-af0e-42c6-a06b-25686cc9502f_2.1.1.17-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.17-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR157W-MONOMER_2.1.1.17-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2187,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2203,7 +2225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2214,12 +2236,29 @@
           <http://model.geneontology.org/RXN-5781>
 ] .
 
+<http://model.geneontology.org/ae4c283b-7569-481d-b1aa-fc3366bd8c3b_RXN3O-349>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_BFO_0000066_reaction_2.1.1.17-RXN_location_lociGO_0005829_null_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2233,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2248,7 +2287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2265,7 +2304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2276,29 +2315,12 @@
           <http://model.geneontology.org/CHEBI_60377_RXN-5781>
 ] .
 
-<http://model.geneontology.org/3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_CHEBI_57597_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2319,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2329,11 +2351,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002233_fe523b0a-436b-4965-8d04-5635c692d0e4_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2341,7 +2363,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/fe523b0a-436b-4965-8d04-5635c692d0e4_PHOSPHAGLYPSYN-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_2.7.7.15-RXN_location_lociGO_0005829>
@@ -2353,7 +2375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2381,7 +2403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,11 +2416,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_d3f007d1-8b99-4a7a-815a-d3f996eb8150_RXN4FS-2_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2406,7 +2428,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN4FS-2> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2>
+          <http://model.geneontology.org/d3f007d1-8b99-4a7a-815a-d3f996eb8150_RXN4FS-2>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_CHEBI_15378_2.1.1.71-RXN_SGD_PWY3O-2>
@@ -2414,7 +2436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2426,7 +2448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2442,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2456,7 +2478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2473,7 +2495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2489,7 +2511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2505,7 +2527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2522,7 +2544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2539,7 +2561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2550,13 +2572,30 @@
           <http://model.geneontology.org/CHEBI_64716_CARDIOLIPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/e44c7fa9-f04e-44e4-bc0e-94a0866d8205_PGPPHOSPHA-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-5781_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2572,7 +2611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2587,7 +2626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2601,7 +2640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2618,7 +2657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2632,23 +2671,12 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2663,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2680,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2695,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2708,7 +2736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2731,7 +2759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2748,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2762,7 +2790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2778,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2789,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2803,7 +2831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2815,7 +2843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2832,7 +2860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2843,23 +2871,6 @@
           <http://model.geneontology.org/CHEBI_57856_RXN3O-349>
 ] .
 
-<http://model.geneontology.org/59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/RXN3O-349>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2869,7 +2880,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-349_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3dae3b0b-fb97-401f-b061-10bac079f14f_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
+                <http://model.geneontology.org/ae4c283b-7569-481d-b1aa-fc3366bd8c3b_RXN3O-349> , <http://model.geneontology.org/CHEBI_59789_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57856_RXN3O-349> , <http://model.geneontology.org/CHEBI_16110_RXN3O-349> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2877,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2890,7 +2901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2904,7 +2915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2920,7 +2931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2938,7 +2949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2958,7 +2969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2977,7 +2988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -2989,7 +3000,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3006,7 +3017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,7 +3033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3035,13 +3046,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2Protein32306> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/e06191ba-591a-46fb-8fbc-0d4a98f56c58_2.7.8.11-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16110_RXN-5781>
         a       <http://purl.obolibrary.org/obo/CHEBI_16110> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3052,7 +3080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3069,9 +3097,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/fe523b0a-436b-4965-8d04-5635c692d0e4_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_57597_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/CHEBI_60377_PHOSPHAGLYPSYN-RXN> , <http://model.geneontology.org/816d2918-d1bc-4886-b7d1-3f076d5ddcab_PHOSPHAGLYPSYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YCL004W-MONOMER_PHOSPHAGLYPSYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3079,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3093,7 +3121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3123,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3136,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3151,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3165,7 +3193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3184,7 +3212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3200,7 +3228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3221,7 +3249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3234,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3246,7 +3274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3262,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3273,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3287,7 +3315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3299,7 +3327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3319,7 +3347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3327,22 +3355,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/f7a3a5bd-9141-4973-8a2d-da8d21269426_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_e06191ba-591a-46fb-8fbc-0d4a98f56c58_2.7.8.11-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3350,7 +3372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3369,7 +3391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3380,7 +3402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3408,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3422,7 +3444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3445,7 +3467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3458,7 +3480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3473,7 +3495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3489,7 +3511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3504,7 +3526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3518,7 +3540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3538,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3552,7 +3574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3571,7 +3593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3582,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3593,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3605,7 +3627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3624,7 +3646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3644,7 +3666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3657,7 +3679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3668,7 +3690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3685,7 +3707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3702,7 +3724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3722,13 +3744,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31958> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_816d2918-d1bc-4886-b7d1-3f076d5ddcab_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3738,7 +3771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3757,13 +3790,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN>
+<http://model.geneontology.org/816d2918-d1bc-4886-b7d1-3f076d5ddcab_PHOSPHAGLYPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -3772,7 +3805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3785,7 +3818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3797,7 +3830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3814,7 +3847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3834,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3850,7 +3883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3865,7 +3898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3879,7 +3912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3901,7 +3934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3912,12 +3945,23 @@
           <http://model.geneontology.org/CARDIOLIPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_RO_0002233_e44c7fa9-f04e-44e4-bc0e-94a0866d8205_PGPPHOSPHA-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000066_reaction_PGPPHOSPHA-RXN_location_lociGO_0005829_null_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -3930,7 +3974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3943,20 +3987,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_null_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-2" ;
+                "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3966,7 +4010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3977,14 +4021,14 @@
           <http://model.geneontology.org/CHEBI_30616_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_CHEBI_15378_2.1.1.17-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002413_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_null_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
+                "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3994,7 +4038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4014,7 +4058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4028,7 +4072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4045,7 +4089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4075,7 +4119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4093,7 +4137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4101,12 +4145,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_4b5ed781-66dd-493c-b507-3063f5d325db_2.1.1.71-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4115,13 +4159,24 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002233_06e5a483-7aed-4e6e-b338-0fd8a3d9e5d6_2.1.1.71-RXN_SGD_PWY3O-2>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4140,7 +4195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4152,7 +4207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4172,7 +4227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4189,7 +4244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4200,13 +4255,35 @@
           <http://model.geneontology.org/YGR007W-MONOMER_2.7.7.14-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002233_CHEBI_59789_2.1.1.17-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4217,34 +4294,12 @@
           <http://model.geneontology.org/CHEBI_59789_2.1.1.17-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PGPPHOSPHA-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_30616_ETHANOLAMINE-KINASE-RXN_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4255,7 +4310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4266,7 +4321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4281,7 +4336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4296,7 +4351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4310,7 +4365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4330,7 +4385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4347,7 +4402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4366,7 +4421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4383,7 +4438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4403,7 +4458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4423,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4437,7 +4492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4457,7 +4512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4474,7 +4529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4491,7 +4546,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4507,7 +4562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4519,7 +4574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4536,7 +4591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4555,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4566,7 +4621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4577,7 +4632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4592,7 +4647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4608,7 +4663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4619,7 +4674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4633,7 +4688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4649,7 +4704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4661,7 +4716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4678,7 +4733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4689,17 +4744,6 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERSYN-RXN_RO_0002233_05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_59789> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4709,7 +4753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4717,25 +4761,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/368cc7ee-e5b7-4bed-b08c-040d5470614e_PHOSPHASERSYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_17268>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CARDIOLIPSYN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.7.15-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4746,13 +4790,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32004> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CARDIOLIPSYN-RXN_RO_0002234_CHEBI_62237_CARDIOLIPSYN-RXN_SGD_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CARDIOLIPSYN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_62237_CARDIOLIPSYN-RXN>
+] .
 
 <http://model.geneontology.org/2.7.8.11-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003881> ;
@@ -4763,7 +4824,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/e06191ba-591a-46fb-8fbc-0d4a98f56c58_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_57880_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -4771,7 +4832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4792,7 +4853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4812,7 +4873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4826,7 +4887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4842,7 +4903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4859,7 +4920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4871,7 +4932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4887,18 +4948,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/fe523b0a-436b-4965-8d04-5635c692d0e4_PHOSPHAGLYPSYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.7.7.15-RXN_RO_0002233_CHEBI_37563_2.7.7.15-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4909,7 +4987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -4918,30 +4996,13 @@
 <http://model.geneontology.org/reaction_CARDIOLIPSYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/05749029-f1e6-4d25-a438-85f6ca3a73bb_PHOSPHASERSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32189> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4964,7 +5025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4975,29 +5036,12 @@
           <http://model.geneontology.org/CHEBI_15378_CHOLINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002333_YGR007W-MONOMER_2.7.7.14-RXN_controller_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5005,11 +5049,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_4b5ed781-66dd-493c-b507-3063f5d325db_2.1.1.71-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5017,7 +5061,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.1.1.71-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN>
+          <http://model.geneontology.org/4b5ed781-66dd-493c-b507-3063f5d325db_2.1.1.71-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5026,7 +5070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5046,7 +5090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phospholipid biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5063,9 +5107,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.1.1.71-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_59789_2.1.1.71-RXN> , <http://model.geneontology.org/06e5a483-7aed-4e6e-b338-0fd8a3d9e5d6_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_2.1.1.71-RXN> , <http://model.geneontology.org/CHEBI_57856_2.1.1.71-RXN> , <http://model.geneontology.org/4b5ed781-66dd-493c-b507-3063f5d325db_2.1.1.71-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YJR073C-MONOMER_2.1.1.71-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5073,7 +5117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5090,7 +5134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5098,25 +5142,25 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000066_reaction_PHOSPHAGLYPSYN-RXN_location_lociGO_0005829_null_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5129,7 +5173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5149,7 +5193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5166,7 +5210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5179,18 +5223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.1.1.71-RXN_RO_0002234_c2d627a5-411c-4e2c-9c33-642877ca75d3_2.1.1.71-RXN_SGD_PWY3O-2>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5201,7 +5234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5216,7 +5249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5229,7 +5262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5241,7 +5274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5260,7 +5293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5275,7 +5308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5294,7 +5327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5311,7 +5344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5328,7 +5361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5339,23 +5372,29 @@
           <http://model.geneontology.org/CHEBI_60377_PHOSPHASERSYN-RXN>
 ] .
 
+<http://model.geneontology.org/4b5ed781-66dd-493c-b507-3063f5d325db_2.1.1.71-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-dimethylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule31967> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002233_CHEBI_17815_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-2>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5372,7 +5411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5392,7 +5431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5409,7 +5448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5422,7 +5461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5437,11 +5476,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32240> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/fa9bbdec-af0e-42c6-a06b-25686cc9502f_2.1.1.17-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -5459,7 +5515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5472,7 +5528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5491,7 +5547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5507,7 +5563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5522,7 +5578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5535,11 +5591,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_RO_0002234_816d2918-d1bc-4886-b7d1-3f076d5ddcab_PHOSPHAGLYPSYN-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5547,33 +5603,16 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHAGLYPSYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN>
+          <http://model.geneontology.org/816d2918-d1bc-4886-b7d1-3f076d5ddcab_PHOSPHAGLYPSYN-RXN>
 ] .
-
-<http://model.geneontology.org/ae4ef991-cb10-487f-98e5-5a821414d936_PHOSPHAGLYPSYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-(3-<i>sn</i>-phosphatidyl)-<i>sn</i>-glycerol 3-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32319> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN_SGD_PWY3O-2> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_e06191ba-591a-46fb-8fbc-0d4a98f56c58_2.7.8.11-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5581,32 +5620,15 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/59c05441-2c12-4055-b82f-bdbd1928c381_2.7.8.11-RXN>
+          <http://model.geneontology.org/e06191ba-591a-46fb-8fbc-0d4a98f56c58_2.7.8.11-RXN>
 ] .
-
-<http://model.geneontology.org/6488e8b4-82f7-43b1-ba60-c0754e1eebcf_2.1.1.71-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a phosphatidyl-<i>N</i>-methylethanolamine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32435> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PHOSPHAGLYPSYN-RXN_BFO_0000050_PWY3O-2/PWY3O-2_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5620,7 +5642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5639,7 +5661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5659,7 +5681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5672,7 +5694,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5683,7 +5716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5698,7 +5731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5706,24 +5739,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002233_CHEBI_11750_PHOSPHASERDECARB-RXN_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002234_CHEBI_57856_RXN4FS-2_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5739,7 +5761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5751,7 +5773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5781,7 +5803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5794,7 +5816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5805,18 +5827,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.1.1.17-RXN_RO_0002234_e92f5b16-64c6-4daf-9c28-723dae82120e_2.1.1.17-RXN_SGD_PWY3O-2>
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-2> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY3O-2>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5841,7 +5880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5849,41 +5888,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002234_CHEBI_15378_RXN-5781_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-2> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ETHANOLAMINEPHOSPHOTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.7.14-RXN_RO_0002233_CHEBI_37563_2.7.7.14-RXN_SGD_PWY3O-2> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5900,7 +5911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5916,7 +5927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2" ;
         <http://purl.org/pav/providedBy>
@@ -5933,7 +5944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5953,7 +5964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5970,7 +5981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5990,7 +6001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6007,7 +6018,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PGPPHOSPHA-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/8a2f3051-cc97-43e7-8243-b659aa68f5b4_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PGPPHOSPHA-RXN> , <http://model.geneontology.org/e44c7fa9-f04e-44e4-bc0e-94a0866d8205_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PGPPHOSPHA-RXN> , <http://model.geneontology.org/CHEBI_64716_PGPPHOSPHA-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -6015,35 +6026,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2BiochemicalReaction32309> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_RXN4FS-2_RO_0002233_a19b29c0-30b5-4c14-9725-ae99ece62555_RXN4FS-2_SGD_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_null_PWY3O-2>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-2" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_PHOSPHASERDECARB-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -6054,13 +6043,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-2SmallMolecule32482> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHASERDECARB-RXN_RO_0002413_2.1.1.17-RXN_null_PWY3O-2>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-2" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_59789>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6071,7 +6071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-20-PWY3O-20.ttl
+++ b/models/PWY3O-20-PWY3O-20.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,6 +37,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_9ed44651-df72-40a0-a8b9-7c0c667261b6_RXN0-2921_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -50,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -63,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -74,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -98,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,6 +134,17 @@
           <http://model.geneontology.org/PWY3O-20/PWY3O-20>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_4865898c-664b-486e-a456-b19f0286b511_GLYOHMETRANS-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -132,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate polyglutamylation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -200,7 +222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -236,23 +258,12 @@
           <http://model.geneontology.org/PWY3O-20/PWY3O-20>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN_SGD_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_29985_RXN3O-681_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,24 +286,13 @@
           <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_29985_RXN3O-681_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,6 +306,23 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/af61ee00-b1a8-49e3-bcbd-8a6b7c7ff519_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -315,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,6 +363,23 @@
           <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN>
 ] .
 
+<http://model.geneontology.org/b55858db-6dc6-4ae7-9a65-50fdfe6570c4_FORMATETHFLIG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/RXN3O-22>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -355,15 +389,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/a271181a-3a6c-4127-8d62-4e9aa03d4626_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> , <http://model.geneontology.org/13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22> ;
+                <http://model.geneontology.org/36e1b0d9-8be7-4e3d-98ec-502fe8a4e679_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -374,30 +408,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_29985>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_43474_RXN3O-22_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,30 +425,13 @@
           <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_566c5498-668c-4c71-972c-3c0601dcf3d9_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,25 +439,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/566c5498-668c-4c71-972c-3c0601dcf3d9_FORMYLTHFGLUSYNTH-RXN>
 ] .
-
-<http://model.geneontology.org/7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -466,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,8 +477,36 @@
           <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/59319205-a82d-4b37-9a32-c14cf082209d_RXN3O-681>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_59319205-a82d-4b37-9a32-c14cf082209d_RXN3O-681_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -506,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -514,23 +525,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_RXN3O-22_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_36e1b0d9-8be7-4e3d-98ec-502fe8a4e679_RXN3O-22_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -541,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -623,11 +634,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_1ad46f9d-b646-47fc-890f-5061f39c6823_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -635,8 +646,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/1ad46f9d-b646-47fc-890f-5061f39c6823_DIHYDROFOLATEREDUCT-RXN>
 ] .
+
+<http://model.geneontology.org/a9d2467b-4506-4b46-88fa-247d60338cbd_FOLYLPOLYGLUTAMATESYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000288> ;
@@ -645,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,11 +683,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_a9d2467b-4506-4b46-88fa-247d60338cbd_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +695,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN>
+          <http://model.geneontology.org/a9d2467b-4506-4b46-88fa-247d60338cbd_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_43474_RXN0-2921_SGD_PWY3O-20>
@@ -675,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -701,7 +729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -734,7 +762,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_566c5498-668c-4c71-972c-3c0601dcf3d9_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,18 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +855,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_be1da13b-370b-415b-baf4-8f5b8a54160a_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -842,9 +881,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/c9d8c7ce-c558-4de2-bb0e-f179aaf0f494_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/b55858db-6dc6-4ae7-9a65-50fdfe6570c4_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -852,30 +891,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20BiochemicalReaction65070> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -889,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -903,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -925,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -937,7 +959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -962,16 +984,22 @@
 <http://purl.obolibrary.org/obo/GO_0008841>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ee90f422-8281-46cd-8958-bd20e6aedeb3_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -981,7 +1009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1003,11 +1031,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_c66c961b-b2a5-44f2-8bc1-ebb040bf303d_1.5.1.20-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,7 +1043,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN>
+          <http://model.geneontology.org/c66c961b-b2a5-44f2-8bc1-ebb040bf303d_1.5.1.20-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1026,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1042,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1053,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1092,11 +1120,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_c9d8c7ce-c558-4de2-bb0e-f179aaf0f494_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,7 +1132,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/c9d8c7ce-c558-4de2-bb0e-f179aaf0f494_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-20>
@@ -1112,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1123,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1138,28 +1166,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64805> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1168,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1183,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,30 +1222,13 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_CHEBI_43474_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1251,7 +1245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1262,24 +1256,13 @@
           <http://model.geneontology.org/CHEBI_456216_DIHYDROFOLATESYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_36e1b0d9-8be7-4e3d-98ec-502fe8a4e679_RXN3O-22_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1270,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22>
+          <http://model.geneontology.org/36e1b0d9-8be7-4e3d-98ec-502fe8a4e679_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1296,7 +1279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1307,23 +1290,6 @@
           <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
-<http://model.geneontology.org/63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004326> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1333,15 +1299,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/be1da13b-370b-415b-baf4-8f5b8a54160a_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_29985_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
+                <http://model.geneontology.org/a9d2467b-4506-4b46-88fa-247d60338cbd_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FOLYLPOLYGLUTAMATESYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1375,24 +1341,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64881> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1402,7 +1357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1436,7 +1391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1453,7 +1408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1469,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1484,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,12 +1450,29 @@
           <http://model.geneontology.org/YOR241W-MONOMER_FOLYLPOLYGLUTAMATESYNTH-RXN_controller>
 ] .
 
+<http://model.geneontology.org/9ed44651-df72-40a0-a8b9-7c0c667261b6_RXN0-2921>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_CHEBI_30616_RXN3O-681_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1511,26 +1483,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/566c5498-668c-4c71-972c-3c0601dcf3d9_FORMYLTHFGLUSYNTH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1539,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1550,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1564,7 +1536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1614,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1636,28 +1608,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1665,7 +1620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1679,13 +1634,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/4865898c-664b-486e-a456-b19f0286b511_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_59319205-a82d-4b37-9a32-c14cf082209d_RXN3O-681_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1693,15 +1665,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681>
+          <http://model.geneontology.org/59319205-a82d-4b37-9a32-c14cf082209d_RXN3O-681>
 ] .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_c66c961b-b2a5-44f2-8bc1-ebb040bf303d_1.5.1.20-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1716,15 +1699,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-681_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-681> , <http://model.geneontology.org/59319205-a82d-4b37-9a32-c14cf082209d_RXN3O-681> , <http://model.geneontology.org/CHEBI_29985_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681> , <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-681> , <http://model.geneontology.org/CHEBI_456216_RXN3O-681> , <http://model.geneontology.org/d5206dd6-6972-4cf8-83e9-fd78b49aacbc_RXN3O-681> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1734,11 +1717,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_4865898c-664b-486e-a456-b19f0286b511_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1746,7 +1729,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/4865898c-664b-486e-a456-b19f0286b511_GLYOHMETRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000005767>
@@ -1761,15 +1744,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-2921_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> , <http://model.geneontology.org/4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_29985_RXN0-2921> , <http://model.geneontology.org/CHEBI_30616_RXN0-2921> , <http://model.geneontology.org/f078067a-9ce6-499c-afaa-d25c49de05b7_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> , <http://model.geneontology.org/63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN0-2921> , <http://model.geneontology.org/CHEBI_456216_RXN0-2921> , <http://model.geneontology.org/9ed44651-df72-40a0-a8b9-7c0c667261b6_RXN0-2921> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN0-2921_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1782,7 +1765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1794,7 +1777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1810,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +1814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1842,16 +1825,13 @@
           <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_17839>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1862,23 +1842,15 @@
           <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_17839>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN0-2921_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_12b9bd21-6d86-4ead-842a-a286dbec7da7_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1893,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1908,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,11 +1890,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_f078067a-9ce6-499c-afaa-d25c49de05b7_RXN0-2921_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1930,7 +1902,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921>
+          <http://model.geneontology.org/f078067a-9ce6-499c-afaa-d25c49de05b7_RXN0-2921>
 ] .
 
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20>
@@ -1938,7 +1910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1950,7 +1922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1980,7 +1952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -1995,15 +1967,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/566c5498-668c-4c71-972c-3c0601dcf3d9_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/7b0abd20-7cf9-489f-9bad-ec2293888157_FORMYLTHFGLUSYNTH-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMYLTHFGLUSYNTH-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2011,29 +1983,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002333_YOR241W-MONOMER_RXN3O-681_controller_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2047,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2060,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2073,7 +2028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2088,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2150,7 +2105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2158,11 +2113,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_7b0abd20-7cf9-489f-9bad-ec2293888157_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2170,22 +2125,28 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMYLTHFGLUSYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN>
+          <http://model.geneontology.org/7b0abd20-7cf9-489f-9bad-ec2293888157_FORMYLTHFGLUSYNTH-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000005762>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/7b0abd20-7cf9-489f-9bad-ec2293888157_FORMYLTHFGLUSYNTH-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000005762>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-681_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005767> ;
@@ -2194,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2208,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2228,7 +2189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2241,7 +2202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2252,28 +2213,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_af61ee00-b1a8-49e3-bcbd-8a6b7c7ff519_GLYOHMETRANS-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2281,7 +2236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2301,9 +2256,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c1a57896-90d0-47cc-b80c-bdcd43c287aa_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/4865898c-664b-486e-a456-b19f0286b511_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/af61ee00-b1a8-49e3-bcbd-8a6b7c7ff519_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2313,13 +2268,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20BiochemicalReaction65010> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/d5206dd6-6972-4cf8-83e9-fd78b49aacbc_RXN3O-681>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2329,7 +2301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2346,7 +2318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2357,6 +2329,17 @@
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_d5206dd6-6972-4cf8-83e9-fd78b49aacbc_RXN3O-681_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/GO_0004489>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2366,7 +2349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2383,23 +2366,12 @@
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002233_f5194eb8-0783-4939-be96-f3c47822d108_RXN3O-681_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_BFO_0000050_PWY3O-20/PWY3O-20_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2411,7 +2383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2422,6 +2394,23 @@
           <http://model.geneontology.org/CHEBI_29985_RXN3O-22>
 ] .
 
+<http://model.geneontology.org/f078067a-9ce6-499c-afaa-d25c49de05b7_RXN0-2921>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2430,7 +2419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2467,7 +2456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2481,7 +2470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2497,7 +2486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2512,24 +2501,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule65054> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_RXN0-2921>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -2540,13 +2518,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64784> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/36e1b0d9-8be7-4e3d-98ec-502fe8a4e679_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_30616_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_RXN3O-681>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -2557,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2565,13 +2571,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_1ad46f9d-b646-47fc-890f-5061f39c6823_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_CHEBI_43474_RXN3O-681_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2587,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2599,7 +2616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,9 +2632,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_b55858db-6dc6-4ae7-9a65-50fdfe6570c4_FORMATETHFLIG-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2626,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2642,7 +2670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2656,7 +2684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2675,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2686,7 +2714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2698,7 +2726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2709,24 +2737,13 @@
           <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_ee90f422-8281-46cd-8958-bd20e6aedeb3_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2734,7 +2751,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/ee90f422-8281-46cd-8958-bd20e6aedeb3_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2743,7 +2760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2757,6 +2774,17 @@
 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002233_f078067a-9ce6-499c-afaa-d25c49de05b7_RXN0-2921_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_RXN3O-22>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2766,7 +2794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2779,7 +2807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2794,7 +2822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2809,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2823,7 +2851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2834,29 +2862,12 @@
           <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/4520c429-4506-4f36-8a9a-90480e8016f8_RXN0-2921>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002333_YOR241W-MONOMER_FORMYLTHFGLUSYNTH-RXN_controller_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2865,24 +2876,13 @@
 <http://identifiers.org/sgd/S000004719>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_CHEBI_456216_RXN0-2921_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2900,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2917,7 +2917,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2930,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -2945,7 +2945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2958,11 +2958,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_b55858db-6dc6-4ae7-9a65-50fdfe6570c4_FORMATETHFLIG-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2970,7 +2970,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/b55858db-6dc6-4ae7-9a65-50fdfe6570c4_FORMATETHFLIG-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2979,7 +2979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2990,12 +2990,23 @@
           <http://model.geneontology.org/FORMATETHFLIG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_7b0abd20-7cf9-489f-9bad-ec2293888157_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_CHEBI_456216_RXN3O-22_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3010,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3024,7 +3035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3043,28 +3054,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3074,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3085,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3097,7 +3091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3113,7 +3107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3131,7 +3125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3145,7 +3139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3164,11 +3158,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_9635b245-cc8a-4be8-95a2-f23ef1b38e3d_1.5.1.20-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3176,7 +3170,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN>
+          <http://model.geneontology.org/9635b245-cc8a-4be8-95a2-f23ef1b38e3d_1.5.1.20-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3187,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3199,7 +3193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3219,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3232,18 +3226,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002234_07adf079-0fda-43f9-af0f-37891cfda9aa_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
+<http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_a9d2467b-4506-4b46-88fa-247d60338cbd_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3257,7 +3251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3268,29 +3262,12 @@
           <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-22_BFO_0000066_reaction_RXN3O-22_location_lociGO_0005829_null_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3302,7 +3279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3313,24 +3290,13 @@
           <http://model.geneontology.org/CHEBI_30616_RXN3O-22>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_13ca4a9e-11c3-47fb-a8d0-df959a31b386_RXN3O-22_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_CHEBI_29985_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3348,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3365,7 +3331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3375,28 +3341,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002411_RXN3O-22_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3407,12 +3356,40 @@
           <http://model.geneontology.org/RXN3O-22>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/DIHYDROFOLATESYNTH-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_30616_DIHYDROFOLATESYNTH-RXN>
+] .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_c9d8c7ce-c558-4de2-bb0e-f179aaf0f494_FORMATETHFLIG-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_BFO_0000066_reaction_FORMYLTHFGLUSYNTH-RXN_location_lociGO_0005829_null_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3425,7 +3402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3438,7 +3415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3450,7 +3427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,12 +3438,29 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-681>
 ] .
 
+<http://model.geneontology.org/c9d8c7ce-c558-4de2-bb0e-f179aaf0f494_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002234_CHEBI_15378_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3478,7 +3472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3489,30 +3483,13 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/d74b52c3-a279-4992-b951-49e8e2de2e25_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002233_be1da13b-370b-415b-baf4-8f5b8a54160a_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3520,7 +3497,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FOLYLPOLYGLUTAMATESYNTH-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/bf60b27d-7dd1-4df9-8173-258932e09cc8_FOLYLPOLYGLUTAMATESYNTH-RXN>
+          <http://model.geneontology.org/be1da13b-370b-415b-baf4-8f5b8a54160a_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-20>
@@ -3528,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3543,7 +3520,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3563,7 +3540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3576,7 +3553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3591,13 +3568,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64972> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a271181a-3a6c-4127-8d62-4e9aa03d4626_RXN3O-22_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3611,7 +3599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3619,27 +3607,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_b214408a-ab41-41eb-ac42-25453a7f1f39_FORMATETHFLIG-RXN_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2921_RO_0002234_9ed44651-df72-40a0-a8b9-7c0c667261b6_RXN0-2921_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3647,7 +3624,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2921> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/63e3eaa7-2c6e-4c4c-bc75-df334bd53a83_RXN0-2921>
+          <http://model.geneontology.org/9ed44651-df72-40a0-a8b9-7c0c667261b6_RXN0-2921>
 ] .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-681>
@@ -3659,7 +3636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3673,7 +3650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3687,18 +3664,35 @@
 <http://model.geneontology.org/reaction_FOLYLPOLYGLUTAMATESYNTH-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/c66c961b-b2a5-44f2-8bc1-ebb040bf303d_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_FOLYLPOLYGLUTAMATESYNTH-RXN_RO_0002234_CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN>
+<http://model.geneontology.org/9635b245-cc8a-4be8-95a2-f23ef1b38e3d_1.5.1.20-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -3707,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3724,7 +3718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3744,9 +3738,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/7ff29186-c701-4a1a-883b-14fdbaaddf84_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/ee90f422-8281-46cd-8958-bd20e6aedeb3_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/b9925ec1-f2b9-448b-9b31-b6cb31620018_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/1ad46f9d-b646-47fc-890f-5061f39c6823_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3754,7 +3748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3767,7 +3761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3782,7 +3776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3795,7 +3789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3809,7 +3803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3829,7 +3823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3846,7 +3840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3863,7 +3857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3877,13 +3871,30 @@
 <http://identifiers.org/sgd/S000003436>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/be1da13b-370b-415b-baf4-8f5b8a54160a_FOLYLPOLYGLUTAMATESYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_CHEBI_15378_1.5.1.20-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3894,17 +3905,6 @@
           <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FORMYLTHFGLUSYNTH-RXN_RO_0002233_613c6fe4-bbb4-4f1f-b95b-0f4b951e08c9_FORMYLTHFGLUSYNTH-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/1.5.1.20-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004489> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3914,9 +3914,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/c8b3488e-7f72-4cf8-b07f-ee09c0b64789_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/9635b245-cc8a-4be8-95a2-f23ef1b38e3d_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/c66c961b-b2a5-44f2-8bc1-ebb040bf303d_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3924,7 +3924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3937,7 +3937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3948,7 +3948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -3962,7 +3962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3973,17 +3973,6 @@
           <http://model.geneontology.org/reaction_RXN0-2921_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681_SGD_PWY3O-20>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_43474_RXN3O-681>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3993,7 +3982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4001,22 +3990,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_9635b245-cc8a-4be8-95a2-f23ef1b38e3d_1.5.1.20-RXN_SGD_PWY3O-20>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4024,7 +4007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4046,7 +4029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4055,23 +4038,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_57540>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/1ad46f9d-b646-47fc-890f-5061f39c6823_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64790> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_CHEBI_33384_GLYOHMETRANS-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-20" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_6a78baa4-a757-43b2-8a6d-c3c3da91d145_1.5.1.20-RXN_SGD_PWY3O-20>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4092,7 +4081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4105,28 +4094,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22_SGD_PWY3O-20> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/847da574-05c6-4fe0-8922-928b07c42d6c_RXN3O-22>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4137,7 +4109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4145,12 +4117,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_a271181a-3a6c-4127-8d62-4e9aa03d4626_RXN3O-22_SGD_PWY3O-20> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/a271181a-3a6c-4127-8d62-4e9aa03d4626_RXN3O-22>
+] .
+
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002233_CHEBI_30616_DIHYDROFOLATESYNTH-RXN_SGD_PWY3O-20>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4165,7 +4154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4195,7 +4184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4208,7 +4197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4219,7 +4208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4230,7 +4219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4242,7 +4231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4255,11 +4244,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-681_RO_0002234_d5206dd6-6972-4cf8-83e9-fd78b49aacbc_RXN3O-681_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4267,25 +4256,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-681> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/13bab02e-6c8e-4bab-bfc2-9ff9bb064684_RXN3O-681>
+          <http://model.geneontology.org/d5206dd6-6972-4cf8-83e9-fd78b49aacbc_RXN3O-681>
 ] .
-
-<http://model.geneontology.org/1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64957> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_43474_DIHYDROFOLATESYNTH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4296,7 +4268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4316,7 +4288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4329,7 +4301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4337,11 +4309,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_af61ee00-b1a8-49e3-bcbd-8a6b7c7ff519_GLYOHMETRANS-RXN_SGD_PWY3O-20> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4349,7 +4321,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1345fec3-e1db-4d6f-b069-267f543ee7ea_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/af61ee00-b1a8-49e3-bcbd-8a6b7c7ff519_GLYOHMETRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -4358,7 +4330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4375,7 +4347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4395,7 +4367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4412,7 +4384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4432,7 +4404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4449,7 +4421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4460,12 +4432,29 @@
           <http://model.geneontology.org/CHEBI_456216_FOLYLPOLYGLUTAMATESYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/a271181a-3a6c-4127-8d62-4e9aa03d4626_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule64931> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002333_YBR084W-MONOMER_FORMATETHFLIG-RXN_controller_SGD_PWY3O-20>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-20" ;
         <http://purl.org/pav/providedBy>
@@ -4480,10 +4469,21 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-20SmallMolecule65023> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_ee90f422-8281-46cd-8958-bd20e6aedeb3_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-20>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-20" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-20" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .

--- a/models/PWY3O-214-PWY3O-214.ttl
+++ b/models/PWY3O-214-PWY3O-214.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -209,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -226,7 +226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -616,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,7 +633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -660,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1018,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1066,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1103,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,7 +1122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1137,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1154,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1307,7 +1307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1321,7 +1321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1358,7 +1358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1418,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tryptophan degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1461,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1489,7 +1489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1509,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1522,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1534,7 +1534,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1573,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1594,7 +1594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1607,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1634,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1648,7 +1648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1665,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1681,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1697,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1727,7 +1727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1755,7 +1755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1816,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +1831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1851,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1865,7 +1865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1891,7 +1891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1907,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1935,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1947,7 +1947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -1956,24 +1956,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_57912>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-214" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_RO_0002234_CHEBI_58095_2.6.1.28-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1984,13 +1973,24 @@
           <http://model.geneontology.org/CHEBI_58095_2.6.1.28-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.6.1.28-RXN_BFO_0000050_PWY3O-214/PWY3O-214_SGD_PWY3O-214>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-214" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TRYPTOPHAN-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_29985_TRYPTOPHAN-AMINOTRANSFERASE-RXN_SGD_PWY3O-214> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2008,7 +2008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2023,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2040,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2054,7 +2054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2073,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2084,7 +2084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-214" ;
         <http://purl.org/pav/providedBy>
@@ -2096,7 +2096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2116,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-214" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-2220-PWY3O-2220.ttl
+++ b/models/PWY3O-2220-PWY3O-2220.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of adenine, hypoxanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -259,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +470,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -624,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -728,7 +728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -947,7 +947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1021,14 +1021,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004001>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1036,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,6 +1044,9 @@
           <http://model.geneontology.org/YNL141W-MONOMER_ADENINE-DEAMINASE-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004001>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1056,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1084,7 +1084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1174,7 +1174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1225,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1343,7 +1343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,6 +1354,17 @@
           <http://model.geneontology.org/CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY3O-2220>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-2220" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenosine + ATP &rarr; AMP + ADP + H<SUP>+</SUP>' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -1362,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1373,17 +1384,6 @@
           <http://model.geneontology.org/AMP-DEAMINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_AMP-DEAMINASE-RXN_RO_0002234_CHEBI_28938_AMP-DEAMINASE-RXN_SGD_PWY3O-2220>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-2220" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_ADENOSINE-KINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1393,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1434,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1463,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1480,7 +1480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1542,7 +1542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1554,7 +1554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1591,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1639,7 +1639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1673,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1789,7 +1789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1805,7 +1805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1833,7 +1833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1884,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1921,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1934,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -1965,7 +1965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,7 +2009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2040,7 +2040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2099,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2125,7 +2125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,7 +2160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2222,7 +2222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2236,7 +2236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2289,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2322,7 +2322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>
@@ -2349,7 +2349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2362,7 +2362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-2220" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-2220" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-224-PWY3O-224.ttl
+++ b/models/PWY3O-224-PWY3O-224.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -339,7 +339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -407,7 +407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -422,7 +422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-224" ;
         <http://purl.org/pav/providedBy>
@@ -450,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-224" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-230-PWY3O-230.ttl
+++ b/models/PWY3O-230-PWY3O-230.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -19,7 +19,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,40 +36,6 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50230> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -81,11 +47,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_71cd966a-31f5-4c08-8143-37adf8f5cd61_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,7 +59,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/71cd966a-31f5-4c08-8143-37adf8f5cd61_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller>
@@ -103,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,17 +89,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN_SGD_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -143,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -183,6 +138,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_33384>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_71cd966a-31f5-4c08-8143-37adf8f5cd61_GLYOHMETRANS-RXN_SGD_PWY3O-230>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/PWY3O-230/PWY3O-230>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -192,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -205,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -237,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,6 +214,17 @@
           <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_4c67c2bd-f2c0-4c2a-b9f1-61974ef00a4c_GLYOHMETRANS-RXN_SGD_PWY3O-230>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-230" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -256,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -286,32 +263,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN_SGD_PWY3O-230>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/71cd966a-31f5-4c08-8143-37adf8f5cd61_GLYOHMETRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-230" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50230> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY3O-230>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -322,11 +305,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_4c67c2bd-f2c0-4c2a-b9f1-61974ef00a4c_GLYOHMETRANS-RXN_SGD_PWY3O-230> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +317,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/4c67c2bd-f2c0-4c2a-b9f1-61974ef00a4c_GLYOHMETRANS-RXN>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -352,15 +335,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/32cb800c-b06a-4d5a-9ecb-daffee96fc5d_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/71cd966a-31f5-4c08-8143-37adf8f5cd61_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/2ed5e0fb-a4f3-4dad-9c1c-a6eb1ba88fc3_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/4c67c2bd-f2c0-4c2a-b9f1-61974ef00a4c_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -385,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -415,6 +398,23 @@
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/4c67c2bd-f2c0-4c2a-b9f1-61974ef00a4c_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-230SmallMolecule50253> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-230" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-230" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "serine biosynthesis from glyoxylate - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-236-PWY3O-236.ttl
+++ b/models/PWY3O-236-PWY3O-236.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -281,7 +281,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -656,7 +656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-236" ;
         <http://purl.org/pav/providedBy>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinate riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -709,7 +709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -742,7 +742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-236" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-238-PWY3O-238.ttl
+++ b/models/PWY3O-238-PWY3O-238.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -83,7 +83,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -93,6 +93,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_16a91d2b-6344-42ab-b82d-de9b55f4d349_RXN3O-22_SGD_PWY3O-238>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -106,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -186,6 +197,17 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b723ee80-caeb-4037-9d38-b1393f3aa62d_RXN3O-22_SGD_PWY3O-238>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-238" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -194,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -203,8 +225,8 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+<http://model.geneontology.org/16a91d2b-6344-42ab-b82d-de9b55f4d349_RXN3O-22>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -212,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -271,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,44 +316,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22_SGD_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22_SGD_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b723ee80-caeb-4037-9d38-b1393f3aa62d_RXN3O-22_SGD_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +333,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22>
+          <http://model.geneontology.org/b723ee80-caeb-4037-9d38-b1393f3aa62d_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -348,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,17 +353,6 @@
           <http://model.geneontology.org/CHEBI_58199_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22_SGD_PWY3O-238>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-238" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -378,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -418,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -494,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -547,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -560,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -574,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -690,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -772,9 +755,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/3134a7e0-2a02-49a0-8d61-a2208f05d3ce_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/b723ee80-caeb-4037-9d38-b1393f3aa62d_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22> , <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/16a91d2b-6344-42ab-b82d-de9b55f4d349_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -782,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -801,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -809,11 +792,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22_SGD_PWY3O-238> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_16a91d2b-6344-42ab-b82d-de9b55f4d349_RXN3O-22_SGD_PWY3O-238> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +804,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ef6cf556-cb87-41b4-87b3-b578d8a24665_RXN3O-22>
+          <http://model.geneontology.org/16a91d2b-6344-42ab-b82d-de9b55f4d349_RXN3O-22>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -830,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,11 +862,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/b723ee80-caeb-4037-9d38-b1393f3aa62d_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-238SmallMolecule42808> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-238" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-238" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-242-PWY3O-242.ttl
+++ b/models/PWY3O-242-PWY3O-242.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-10938_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938> , <http://model.geneontology.org/CHEBI_15377_RXN-10938> ;
+                <http://model.geneontology.org/d7d88912-86cc-4d8d-a381-8a93dc15f5e9_RXN-10938> , <http://model.geneontology.org/CHEBI_15377_RXN-10938> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17283_RXN-10938> , <http://model.geneontology.org/CHEBI_43474_RXN-10938> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,20 +129,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002413_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_null_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -155,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -168,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -183,13 +172,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43136> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002413_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_null_PWY3O-242>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -328,12 +328,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/d7d88912-86cc-4d8d-a381-8a93dc15f5e9_RXN-10938>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-72_RXN-10938_controller_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -417,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -453,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -469,7 +486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +508,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_17283_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
+                <http://model.geneontology.org/CHEBI_456216_2.7.1.150-RXN> , <http://model.geneontology.org/74838cb3-5d8f-47f9-b277-ec59a1c1ae79_2.7.1.150-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFR019W-MONOMER_2.7.1.150-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -499,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,6 +527,23 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/580e5a04-238b-468c-8bab-a7aad7273cfc_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -519,7 +553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -571,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -616,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,13 +661,16 @@
 <http://identifiers.org/sgd/S000003871>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_17526_2.7.1.68-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -668,7 +705,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -701,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -712,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -735,15 +772,12 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-364>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002413_2.7.1.68-RXN_null_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,6 +800,23 @@
           <http://model.geneontology.org/CHEBI_17283_RXN-10938>
 ] .
 
+<http://model.geneontology.org/74838cb3-5d8f-47f9-b277-ec59a1c1ae79_2.7.1.150-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -774,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -785,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -796,9 +847,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_580e5a04-238b-468c-8bab-a7aad7273cfc_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -809,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -826,7 +888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -845,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -875,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,7 +954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +1016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -965,29 +1027,12 @@
           <http://model.geneontology.org/CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
 ] .
 
-<http://model.geneontology.org/fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_BFO_0000050_PWY3O-242/PWY3O-242_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1025,11 +1070,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_74838cb3-5d8f-47f9-b277-ec59a1c1ae79_2.7.1.150-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,7 +1082,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.150-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN>
+          <http://model.geneontology.org/74838cb3-5d8f-47f9-b277-ec59a1c1ae79_2.7.1.150-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1046,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,12 +1122,31 @@
           <http://model.geneontology.org/MONOMER3O-72_RXN-10961_controller>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_null_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2.7.1.68-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1097,32 +1161,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule42987> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + H<sub>2</sub>O &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + phosphate' 'null' 'a 1-phosphatidyl-1D-<i>myo</i>-inositol 4-phosphate + ATP &rarr; a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate + ADP + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002413_2.7.1.68-RXN_null_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2.7.1.68-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_43474_RXN3O-364>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_43474> ;
@@ -1133,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1148,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1164,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1175,7 +1220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1281,7 +1326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1297,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1312,7 +1357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1349,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1393,7 +1438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1410,7 +1455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1452,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1465,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1479,7 +1524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1510,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1523,7 +1568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1538,7 +1583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1575,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1589,7 +1634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1606,7 +1651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1625,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1637,23 +1682,23 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_RXN3O-364_null_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1695,7 +1740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1711,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1744,22 +1789,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_CHEBI_15378_2.7.1.68-RXN_SGD_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.org/dc/elements/1.1/source>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1767,7 +1804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1778,15 +1815,23 @@
           <http://model.geneontology.org/MONOMER3O-365_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_controller>
 ] .
 
-<http://purl.org/dc/elements/1.1/source>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_RO_0002413_RXN3O-364_null_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-69_RXN3O-364_controller_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1798,7 +1843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1814,7 +1859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1828,7 +1873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1845,7 +1890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1877,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1890,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1903,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1920,28 +1965,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43043> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1950,7 +1978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -1961,28 +1989,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-phosphatidyl-1D-myo-inositol 3,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43060> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1990,7 +2001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2061,7 +2072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2077,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2088,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2103,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,16 +2125,13 @@
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000002616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://identifiers.org/sgd/S000001915>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/GO_0004438>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://identifiers.org/sgd/S000002616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://purl.obolibrary.org/obo/GO_0016308>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_15378_2.7.1.150-RXN>
@@ -2135,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2143,13 +2151,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/MONOMER3O-86_RXN-10938_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005269> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphatidylinositol 3,5-bisphosphate 5-phosphatase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43069> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002233_CHEBI_57880_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2160,45 +2183,13 @@
           <http://model.geneontology.org/CHEBI_57880_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/MONOMER3O-86_RXN-10938_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005269> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphatidylinositol 3,5-bisphosphate 5-phosphatase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242Protein43069> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002233_CHEBI_30616_2.7.1.68-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2216,7 +2207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2229,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2251,31 +2242,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY3O-242> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-10938> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_43474_RXN-10938>
+] .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_BFO_0000066_reaction_2.7.1.68-RXN_location_lociGO_0005829_null_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_fca34c9d-dccd-4daf-a373-5953939f8ec7_2.7.1.150-RXN_SGD_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2285,7 +2282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,12 +2293,15 @@
           <http://model.geneontology.org/CHEBI_17283_RXN3O-364>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0016308>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002333_MONOMER3O-72_RXN-10961_controller_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2316,7 +2316,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN> , <http://model.geneontology.org/CHEBI_57880_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_57880_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN> , <http://model.geneontology.org/CHEBI_30616_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_17283_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN> , <http://model.geneontology.org/CHEBI_456216_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN> , <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2326,7 +2326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2334,29 +2334,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002234_CHEBI_43474_RXN-10938_SGD_PWY3O-242> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-10938> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_43474_RXN-10938>
-] .
-
 <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002333_MONOMER3O-72_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_controller_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2371,7 +2354,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/580e5a04-238b-468c-8bab-a7aad7273cfc_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_43474_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> , <http://model.geneontology.org/CHEBI_17526_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -2381,7 +2364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2398,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2411,7 +2394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2422,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2433,7 +2416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2451,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2467,7 +2450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2483,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2514,7 +2497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2530,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2541,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2553,7 +2536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2587,12 +2570,15 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_17283>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002233_CHEBI_17526_RXN-10961_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2603,14 +2589,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_17283>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-69_RXN-10938_controller>
         a       <http://identifiers.org/sgd/S000005050> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -2619,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2632,9 +2615,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_d7d88912-86cc-4d8d-a381-8a93dc15f5e9_RXN-10938_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2643,7 +2637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2654,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2665,7 +2659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2681,7 +2675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2696,7 +2690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2710,7 +2704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2730,7 +2724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2743,7 +2737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -2757,7 +2751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2776,7 +2770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2796,7 +2790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2816,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2835,7 +2829,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_17526_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
+                <http://model.geneontology.org/1c45f28f-9d2b-4b1d-abfc-c8ced4c5f718_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_15378_2.7.1.68-RXN> , <http://model.geneontology.org/CHEBI_456216_2.7.1.68-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR208W-MONOMER_2.7.1.68-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2843,7 +2837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2854,6 +2848,17 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_1c45f28f-9d2b-4b1d-abfc-c8ced4c5f718_2.7.1.68-RXN_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/MONOMER3O-69_RXN-10961_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005050> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2861,7 +2866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2871,11 +2876,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_1c45f28f-9d2b-4b1d-abfc-c8ced4c5f718_2.7.1.68-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2883,7 +2888,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.1.68-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN>
+          <http://model.geneontology.org/1c45f28f-9d2b-4b1d-abfc-c8ced4c5f718_2.7.1.68-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN>
@@ -2895,7 +2900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2909,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2920,24 +2925,13 @@
           <http://model.geneontology.org/CHEBI_456216_1-PHOSPHATIDYLINOSITOL-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.68-RXN_RO_0002234_e4e5478b-3c58-4a85-9ced-cd968dcb2d41_2.7.1.68-RXN_SGD_PWY3O-242>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-364_RO_0002333_MONOMER3O-55_RXN3O-364_controller_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2954,7 +2948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2974,7 +2968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2988,7 +2982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3005,7 +2999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,7 +3016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3041,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3053,7 +3047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3064,12 +3058,29 @@
           <http://model.geneontology.org/CHEBI_43474_RXN-10961>
 ] .
 
+<http://model.geneontology.org/1c45f28f-9d2b-4b1d-abfc-c8ced4c5f718_2.7.1.68-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-242SmallMolecule43085> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-10961_RO_0002234_CHEBI_57880_RXN-10961_SGD_PWY3O-242>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3084,7 +3095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3104,7 +3115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3117,7 +3128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3142,7 +3153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3155,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3170,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3186,7 +3197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3196,6 +3207,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/reaction_2.7.1.68-RXN_location_lociGO_0005829>
 ] .
+
+<http://purl.obolibrary.org/obo/RO_0002233>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/GO_0000285>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3208,7 +3222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3226,7 +3240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3239,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3253,7 +3267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3264,19 +3278,27 @@
           <http://model.geneontology.org/reaction_RXN3O-364_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/RO_0002233>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/ev_w_id_2.7.1.150-RXN_RO_0002234_74838cb3-5d8f-47f9-b277-ec59a1c1ae79_2.7.1.150-RXN_SGD_PWY3O-242>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-242" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_2.7.1.68-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_d7d88912-86cc-4d8d-a381-8a93dc15f5e9_RXN-10938_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3284,7 +3306,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-10938> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938>
+          <http://model.geneontology.org/d7d88912-86cc-4d8d-a381-8a93dc15f5e9_RXN-10938>
 ] .
 
 <http://model.geneontology.org/YLR240W-MONOMER_1-PHOSPHATIDYLINOSITOL-3-KINASE-RXN_controller>
@@ -3294,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3317,7 +3339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3333,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3364,7 +3386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3380,7 +3402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3391,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3399,11 +3421,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242> ;
+          <http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_580e5a04-238b-468c-8bab-a7aad7273cfc_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3411,7 +3433,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
+          <http://model.geneontology.org/580e5a04-238b-468c-8bab-a7aad7273cfc_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002333_MONOMER3O-55_RXN-10938_controller_SGD_PWY3O-242>
@@ -3419,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3430,7 +3452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3451,7 +3473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3465,7 +3487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3482,7 +3504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3498,7 +3520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3510,7 +3532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3530,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3546,7 +3568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3557,34 +3579,12 @@
           <http://model.geneontology.org/RXN-10961>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_RO_0002233_b6f63f5d-72f7-4caf-b31a-c1f305c87f49_PHOSPHATIDYLINOSITOL-BISPHOSPHATASE-RXN_SGD_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_RO_0002234_CHEBI_17526_1-PHOSPHATIDYLINOSITOL-KINASE-RXN_SGD_PWY3O-242>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-242" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-10938_RO_0002233_3ad72622-d234-4040-93ad-cbb6656f92b5_RXN-10938_SGD_PWY3O-242>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3599,7 +3599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3612,7 +3612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3627,7 +3627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3644,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3658,7 +3658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3678,7 +3678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3695,7 +3695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3711,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3723,7 +3723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3739,7 +3739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3754,7 +3754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3767,7 +3767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-242" ;
         <http://purl.org/pav/providedBy>
@@ -3779,7 +3779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-242" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-246-PWY3O-246.ttl
+++ b/models/PWY3O-246-PWY3O-246.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -183,7 +183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "(R,R)-butanediol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -271,7 +271,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-246" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-246" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-246" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-259-PWY3O-259.ttl
+++ b/models/PWY3O-259-PWY3O-259.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -273,7 +273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -483,7 +483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phospholipid biosynthesis II (Kennedy pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,19 +633,19 @@
           <http://model.geneontology.org/CHEBI_15378_2.7.7.14-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_30616>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINE-KINASE-RXN_RO_0002233_CHEBI_57603_ETHANOLAMINE-KINASE-RXN_SGD_PWY3O-259>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_30616>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,16 +821,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/date>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002333_YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller_SGD_PWY3O-259> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -841,12 +838,15 @@
           <http://model.geneontology.org/YHR123W-MONOMER_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_controller>
 ] .
 
+<http://purl.org/dc/elements/1.1/date>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_RO_0002234_CHEBI_16038_ETHANOLAMINEPHOSPHOTRANSFERASE-RXN_SGD_PWY3O-259>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1005,7 +1005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1033,7 +1033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1085,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1119,7 +1119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1166,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1204,7 +1204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-259" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-259" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-261-PWY3O-261.ttl
+++ b/models/PWY3O-261-PWY3O-261.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -55,7 +55,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,13 +231,24 @@
           <http://model.geneontology.org/PWY3O-261/PWY3O-261>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_8a56465f-9808-4129-9c6c-58fad528eaf0_GLYOHMETRANS-RXN_SGD_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -276,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -300,17 +311,6 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN_SGD_PWY3O-261>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -422,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -511,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -561,7 +561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -573,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -652,7 +652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -731,11 +731,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_8a56465f-9808-4129-9c6c-58fad528eaf0_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/8a56465f-9808-4129-9c6c-58fad528eaf0_GLYOHMETRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57524_RXN0-5114>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,11 +808,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41148> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/f1ab1c73-52cd-4f7a-9c3d-b1ed73ea085c_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -825,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -838,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -870,7 +887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -907,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -926,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -953,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -984,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1077,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1104,11 +1121,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_f1ab1c73-52cd-4f7a-9c3d-b1ed73ea085c_GLYOHMETRANS-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1133,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/f1ab1c73-52cd-4f7a-9c3d-b1ed73ea085c_GLYOHMETRANS-RXN>
 ] .
 
 <http://identifiers.org/sgd/S000001336>
@@ -1134,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1160,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1210,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1253,7 +1270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1280,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1292,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1308,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1322,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1360,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1371,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1382,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1393,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1411,15 +1428,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/8a56465f-9808-4129-9c6c-58fad528eaf0_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/f1ab1c73-52cd-4f7a-9c3d-b1ed73ea085c_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,7 +1450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1450,7 +1467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1473,7 +1490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of serine and glycine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1490,7 +1507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1498,36 +1515,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0004617>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002233_CHEBI_57524_RXN0-5114_SGD_PWY3O-261>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule41006> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/GO_0004617>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/MONOMER3O-372_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_controller>
         a       <http://identifiers.org/sgd/S000001864> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1536,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1550,7 +1550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1570,7 +1570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,24 +1581,13 @@
           <http://model.geneontology.org/YIL074C-MONOMER_PGLYCDEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_57524918-f3b2-473e-bf02-9353db46262a_GLYOHMETRANS-RXN_SGD_PWY3O-261>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-261" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002234_CHEBI_57305_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,28 +1609,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0eb1793d-f35e-412e-b99e-726065151aba_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1649,7 +1621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1685,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1699,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1715,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1729,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1757,7 +1729,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,7 +1746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1790,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1831,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1862,7 +1834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1878,18 +1850,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/8a56465f-9808-4129-9c6c-58fad528eaf0_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-261SmallMolecule40983> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_PSERTRANSAM-RXN_RO_0002233_CHEBI_16810_PSERTRANSAM-RXN_SGD_PWY3O-261>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1907,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1923,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1943,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -1987,7 +1976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2021,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2034,7 +2023,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2046,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2074,7 +2063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,13 +2074,24 @@
           <http://model.geneontology.org/CHEBI_57945_PGLYCDEHYDROG-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_f1ab1c73-52cd-4f7a-9c3d-b1ed73ea085c_GLYOHMETRANS-RXN_SGD_PWY3O-261>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-261" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_RO_0002233_CHEBI_57972_ALANINE--GLYOXYLATE-AMINOTRANSFERASE-RXN_SGD_PWY3O-261> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2107,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2130,7 +2130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2146,7 +2146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2158,7 +2158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2177,7 +2177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2190,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2206,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2237,7 +2237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2253,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2264,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-261" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-261" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-285-PWY3O-285.ttl
+++ b/models/PWY3O-285-PWY3O-285.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,7 +66,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -101,7 +101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,7 +154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,7 +171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -185,7 +185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -530,14 +530,14 @@
 <http://purl.obolibrary.org/obo/GO_0004731>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-285" ;
+                "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -549,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -636,9 +636,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000066_reaction_RXN0-745_location_lociGO_0005829_null_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -651,32 +662,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33577> , <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein33574> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000001550> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -685,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +690,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,27 +724,24 @@
           <http://model.geneontology.org/YKL067W-MONOMER_DGDPKIN-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-745_BFO_0000050_PWY3O-285/PWY3O-285_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_BFO_0000066_reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829_null_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_ADENPRIBOSYLTRAN-RXN_location_lociGO_0005829>
+] .
 
 <http://model.geneontology.org/CHEBI_456216_DGDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -868,12 +868,23 @@
 <http://purl.obolibrary.org/obo/GO_0004422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_858fde6f-cb47-437b-90e5-06fb331b0546_GART-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GMP-SYN-GLUT-RXN_BFO_0000066_reaction_GMP-SYN-GLUT-RXN_location_lociGO_0005829_null_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -888,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -901,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -914,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -942,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -993,7 +1004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1074,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1101,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1112,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1141,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1168,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1180,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1196,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1219,24 +1230,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1316,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1350,7 +1350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1418,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1434,7 +1434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1463,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1549,7 +1549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1579,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1596,7 +1596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1643,7 +1643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1657,7 +1657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1674,7 +1674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1690,7 +1690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1705,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1722,7 +1722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1775,7 +1775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1795,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1809,7 +1809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1837,7 +1837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1854,7 +1854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1892,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -1905,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1919,7 +1919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1937,7 +1937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1968,7 +1968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1991,7 +1991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,23 +2002,6 @@
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_AIRS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2028,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2042,7 +2025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2053,12 +2036,29 @@
           <http://model.geneontology.org/PWY3O-285/PWY3O-285>
 ] .
 
+<http://model.geneontology.org/CHEBI_29888_GUANPRIBOSYLTRAN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_29888> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33693> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-745_RO_0002234_CHEBI_15377_RXN0-745_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2070,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2089,7 +2089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2101,7 +2101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2117,7 +2117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2130,7 +2130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2144,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,7 +2164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2177,7 +2177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2188,7 +2188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2213,7 +2213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2230,7 +2230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2243,7 +2243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2275,7 +2275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2295,7 +2295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2309,7 +2309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,7 +2325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2339,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2351,7 +2351,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2368,7 +2368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2385,7 +2385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2413,7 +2413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2433,7 +2433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2447,7 +2447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2470,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2484,7 +2484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2500,7 +2500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2512,7 +2512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2528,7 +2528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2550,7 +2550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2565,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2582,7 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2595,7 +2595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2606,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2617,7 +2617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2632,7 +2632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2646,7 +2646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2657,23 +2657,23 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_29991_SAICARSYN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2685,7 +2685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2702,7 +2702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2720,7 +2720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2733,7 +2733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2750,7 +2750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2769,7 +2769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2780,7 +2780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2795,11 +2795,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33286> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/37757fd7-b9c3-4a85-8ef4-f136a86f3760_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2809,7 +2826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2828,7 +2845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -2840,7 +2857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2860,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2874,7 +2891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2893,7 +2910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2910,7 +2927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2927,7 +2944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2947,7 +2964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2964,7 +2981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2980,7 +2997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3000,7 +3017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3019,7 +3036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3036,7 +3053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3056,9 +3073,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58457_GART-RXN> , <http://model.geneontology.org/37757fd7-b9c3-4a85-8ef4-f136a86f3760_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
+                <http://model.geneontology.org/CHEBI_58426_GART-RXN> , <http://model.geneontology.org/858fde6f-cb47-437b-90e5-06fb331b0546_GART-RXN> , <http://model.geneontology.org/CHEBI_15378_GART-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR408C-MONOMER_GART-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3066,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3083,7 +3100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3099,7 +3116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3123,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3136,7 +3153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3148,7 +3165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3164,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3175,7 +3192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3188,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3201,7 +3218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3219,7 +3236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3233,7 +3250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3249,7 +3266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3261,7 +3278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3277,7 +3294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3295,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3309,7 +3326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3332,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3349,7 +3366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3362,7 +3379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3377,7 +3394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3391,7 +3408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3402,23 +3419,6 @@
           <http://model.geneontology.org/CHEBI_29888_HYPOXANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33472> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_29806_AICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_29806> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3428,11 +3428,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33834> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_16526_AIRCARBOXY-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33472> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3455,7 +3472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3469,7 +3486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3492,7 +3509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3507,7 +3524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3523,7 +3540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3542,28 +3559,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CPLX3O-270_GDPREDUCT-RXN_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3574,7 +3574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3591,7 +3591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3607,7 +3607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3615,11 +3615,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_06df146c-a946-4ba5-9957-88af418fec5a_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3627,22 +3627,10 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/06df146c-a946-4ba5-9957-88af418fec5a_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3653,7 +3641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3664,6 +3652,29 @@
           <http://model.geneontology.org/reaction_GART-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/SGD_S000003412_CPLX3O-270_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003412> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_16526>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58681_PRPPAMIDOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58681> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3673,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3681,24 +3692,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002333_YER170W-MONOMER_ADENYL-KIN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3718,7 +3718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3745,7 +3745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3757,7 +3757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3774,7 +3774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3797,24 +3797,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33858> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002411_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YER170W-MONOMER_ADENYL-KIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000972> ;
@@ -3823,7 +3812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3831,12 +3820,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002411_GMP-SYN-NH3-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000000872_CPLX3O-270_component_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3847,7 +3847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3862,7 +3862,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3876,7 +3876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3892,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3907,7 +3907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3927,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3940,7 +3940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -3953,7 +3953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3973,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3987,7 +3987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4007,7 +4007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4021,7 +4021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4037,7 +4037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4048,7 +4048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4060,7 +4060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4090,7 +4090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4103,7 +4103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4115,7 +4115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4131,7 +4131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4143,7 +4143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4159,7 +4159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4174,7 +4174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4193,7 +4193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4208,7 +4208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4235,7 +4235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4249,7 +4249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4265,7 +4265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4277,7 +4277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4295,7 +4295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4309,7 +4309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4329,7 +4329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4343,7 +4343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4359,7 +4359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4371,7 +4371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4387,7 +4387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4402,7 +4402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4422,7 +4422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4436,7 +4436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4456,7 +4456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4469,7 +4469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4481,7 +4481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4500,7 +4500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4517,7 +4517,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4547,7 +4547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4567,7 +4567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4587,7 +4587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4600,7 +4600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4611,7 +4611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4622,7 +4622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4640,7 +4640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4654,7 +4654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4674,7 +4674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4692,7 +4692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4709,7 +4709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4739,7 +4739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4756,7 +4756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4773,7 +4773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4787,7 +4787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4807,7 +4807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4827,24 +4827,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33858> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4858,7 +4847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4875,7 +4864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4892,7 +4881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4903,45 +4892,13 @@
           <http://model.geneontology.org/CHEBI_57464_GMP-SYN-GLUT-RXN>
 ] .
 
-<http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004915> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "GPAT" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34074> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/CHEBI_15378_GART-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33444> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4952,6 +4909,38 @@
           <http://model.geneontology.org/CHEBI_15378_AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_15378_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33444> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004915> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "GPAT" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285Protein34074> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'adenylo-succinate &harr; fumarate + AMP' 'null' 'AMP + H<SUP>+</SUP> + H<sub>2</sub>O &rarr; IMP + ammonium' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -4960,7 +4949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4979,7 +4968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -4990,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5001,7 +4990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5013,7 +5002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5033,7 +5022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5049,7 +5038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5060,7 +5049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5085,7 +5074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5102,7 +5091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5121,7 +5110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5137,7 +5126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5148,7 +5137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5159,7 +5148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5170,7 +5159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5181,7 +5170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5193,7 +5182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5209,7 +5198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5220,7 +5209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5231,7 +5220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5243,7 +5232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5259,7 +5248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5271,7 +5260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5287,7 +5276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5298,7 +5287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5312,7 +5301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5324,7 +5313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5344,7 +5333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5357,7 +5346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5372,7 +5361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5388,7 +5377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5403,7 +5392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5423,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5437,7 +5426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5457,7 +5446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5470,7 +5459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5481,7 +5470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5492,7 +5481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5507,7 +5496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5521,7 +5510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5544,7 +5533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5557,28 +5546,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58017_ADENPRIBOSYLTRAN-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_FGAMSYN-RXN_RO_0002233_CHEBI_30616_FGAMSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5591,11 +5563,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002234_CHEBI_58017_ADENPRIBOSYLTRAN-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENPRIBOSYLTRAN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58017_ADENPRIBOSYLTRAN-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SAICARSYN-RXN_RO_0002233_CHEBI_30616_SAICARSYN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5606,17 +5595,6 @@
           <http://model.geneontology.org/CHEBI_30616_SAICARSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456215_GMP-SYN-GLUT-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456215> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -5626,7 +5604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5643,7 +5621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5662,7 +5640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5690,7 +5668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5703,7 +5681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5715,7 +5693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5731,7 +5709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5743,7 +5721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5763,7 +5741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5776,7 +5754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5787,7 +5765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5799,7 +5777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5817,7 +5795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5830,7 +5808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5845,7 +5823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5862,7 +5840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5875,7 +5853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -5889,7 +5867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5906,7 +5884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5927,7 +5905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5941,7 +5919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5964,7 +5942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5978,7 +5956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5997,7 +5975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6012,7 +5990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6025,7 +6003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6039,7 +6017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6059,7 +6037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6072,7 +6050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6080,6 +6058,17 @@
 
 <http://model.geneontology.org/reaction_AMP-DEAMINASE-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_RXN-7607_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58115_GMP-SYN-NH3-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58115> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6090,24 +6079,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33624> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7607_RO_0002233_CHEBI_58053_RXN-7607_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15377_GMP-SYN-GLUT-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6118,7 +6096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6131,7 +6109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6143,7 +6121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6159,11 +6137,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_476e6284-ec7b-40dc-9142-bc73fd9b5d15_AICARTRANSFORM-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6171,7 +6149,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/AICARTRANSFORM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN>
+          <http://model.geneontology.org/476e6284-ec7b-40dc-9142-bc73fd9b5d15_AICARTRANSFORM-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -6182,11 +6160,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_37757fd7-b9c3-4a85-8ef4-f136a86f3760_GART-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6194,7 +6172,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN>
+          <http://model.geneontology.org/37757fd7-b9c3-4a85-8ef4-f136a86f3760_GART-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -6203,7 +6181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6219,7 +6197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6230,7 +6208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6244,7 +6222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6261,7 +6239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6277,7 +6255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6289,7 +6267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6305,7 +6283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6316,7 +6294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6331,7 +6309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6351,7 +6329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6367,7 +6345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6378,7 +6356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6396,7 +6374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6410,7 +6388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6430,7 +6408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6444,7 +6422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6460,7 +6438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6471,7 +6449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6482,7 +6460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6493,7 +6471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6504,7 +6482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6519,7 +6497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6532,7 +6510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6547,7 +6525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6564,7 +6542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6583,7 +6561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6598,7 +6576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6614,7 +6592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6629,7 +6607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of purine biosynthesis and salvage pathways - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -6643,7 +6621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6663,7 +6641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6677,7 +6655,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6697,7 +6675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6714,11 +6692,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/476e6284-ec7b-40dc-9142-bc73fd9b5d15_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -6741,7 +6736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6757,7 +6752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6780,7 +6775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6807,7 +6802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6822,7 +6817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6835,7 +6830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6847,7 +6842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6863,7 +6858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -6878,7 +6873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6892,7 +6887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6912,7 +6907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6928,7 +6923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6948,7 +6943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6962,7 +6957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6979,7 +6974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6999,7 +6994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7012,7 +7007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7023,7 +7018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7035,7 +7030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7055,7 +7050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7072,7 +7067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7092,7 +7087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7108,7 +7103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7119,7 +7114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7134,7 +7129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7151,7 +7146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7168,7 +7163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7183,7 +7178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7208,7 +7203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7219,7 +7214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7231,7 +7226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7247,7 +7242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7272,7 +7267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7289,7 +7284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7303,7 +7298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7320,7 +7315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7339,7 +7334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7351,7 +7346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7367,7 +7362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7393,7 +7388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7401,12 +7396,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY3O-285>
+<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7418,7 +7413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7438,7 +7433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7449,6 +7444,17 @@
           <http://model.geneontology.org/CHEBI_137981_AIRCARBOXY-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_AIRCARBOXY-RXN_RO_0002233_CHEBI_15378_AIRCARBOXY-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_58564_SAICARSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_58564> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -7458,28 +7464,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33431> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_456216_ADENOSINE-KINASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -7489,7 +7478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7500,23 +7489,29 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/CHEBI_456216_ADENOSINE-KINASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33408> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_DGDPKIN-RXN_RO_0002234_CHEBI_61429_DGDPKIN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7527,7 +7522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7538,7 +7533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7553,7 +7548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7573,7 +7568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7587,7 +7582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7603,7 +7598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7615,7 +7610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7635,7 +7630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7649,7 +7644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7666,7 +7661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7688,7 +7683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7699,7 +7694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7710,7 +7705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7735,7 +7730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7752,7 +7747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7765,7 +7760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7777,7 +7772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7797,7 +7792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7819,7 +7814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7837,7 +7832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7845,29 +7840,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GUANYL-KIN-RXN_BFO_0000066_reaction_GUANYL-KIN-RXN_location_lociGO_0005829_null_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7878,7 +7856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7892,7 +7870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7907,7 +7885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7921,23 +7899,12 @@
 <http://model.geneontology.org/reaction_ADPREDUCT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_ad9ab964-1ad4-4b9b-94f0-3124148e4bd9_GART-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_58595_GDPREDUCT-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7949,7 +7916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7965,7 +7932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7976,7 +7943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -7991,7 +7958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8007,7 +7974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8018,7 +7985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8033,7 +8000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8049,7 +8016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8060,7 +8027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8075,7 +8042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8091,7 +8058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8105,7 +8072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8116,29 +8083,12 @@
           <http://model.geneontology.org/reaction_AICARSYN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002413_AMPSYN-RXN_null_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8150,7 +8100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8161,13 +8111,30 @@
           <http://model.geneontology.org/CHEBI_58426_FGAMSYN-RXN>
 ] .
 
+<http://model.geneontology.org/06df146c-a946-4ba5-9957-88af418fec5a_AICARTRANSFORM-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33900> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENPRIBOSYLTRAN-RXN_RO_0002333_YML022W-MONOMER_ADENPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8183,7 +8150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8197,7 +8164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8213,7 +8180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8224,7 +8191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8236,7 +8203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8253,7 +8220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8269,7 +8236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8277,11 +8244,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN_SGD_PWY3O-285> ;
+          <http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002234_858fde6f-cb47-437b-90e5-06fb331b0546_GART-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8289,7 +8256,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GART-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0b3a9448-e2f6-4c07-a57d-d83d5b9da410_GART-RXN>
+          <http://model.geneontology.org/858fde6f-cb47-437b-90e5-06fb331b0546_GART-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_GUANYL-KIN-RXN_location_lociGO_0005829>
@@ -8301,7 +8268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8319,7 +8286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8346,7 +8313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8362,7 +8329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8373,7 +8340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8385,7 +8352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8405,7 +8372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8418,7 +8385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8430,7 +8397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8447,7 +8414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8466,7 +8433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8480,13 +8447,24 @@
 <http://model.geneontology.org/reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_null_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002333_YML056C-MONOMER_IMP-DEHYDROG-RXN_controller_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8497,23 +8475,12 @@
           <http://model.geneontology.org/YML056C-MONOMER_IMP-DEHYDROG-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GMP-SYN-NH3-RXN_BFO_0000066_reaction_GMP-SYN-NH3-RXN_location_lociGO_0005829_null_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_HYPOXANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_HYPOXANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8524,7 +8491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8535,7 +8502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8548,7 +8515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8568,7 +8535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8581,7 +8548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8595,7 +8562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8607,7 +8574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8624,7 +8591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8640,7 +8607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8651,7 +8618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8662,7 +8629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8676,7 +8643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8693,7 +8660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8713,7 +8680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8727,7 +8694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8743,7 +8710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8758,7 +8725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8771,7 +8738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8783,7 +8750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8803,7 +8770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8819,7 +8786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8834,7 +8801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -8847,7 +8814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -8859,7 +8826,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8876,7 +8843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8893,7 +8860,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8904,6 +8871,17 @@
           <http://model.geneontology.org/CHEBI_29888_ADENPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002411_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_43474_RXN-7607>
         a       <http://purl.obolibrary.org/obo/CHEBI_43474> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -8913,7 +8891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8921,24 +8899,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002411_HYPOXANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADENINE-DEAMINASE-RXN_RO_0002234_CHEBI_28938_ADENINE-DEAMINASE-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8958,7 +8925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8975,7 +8942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8994,7 +8961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9015,7 +8982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9029,7 +8996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9049,7 +9016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9065,7 +9032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9080,7 +9047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9096,7 +9063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9112,7 +9079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9123,7 +9090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9138,7 +9105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9151,7 +9118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9166,7 +9133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9182,7 +9149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9204,7 +9171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9219,7 +9186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9232,7 +9199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9246,7 +9213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9258,7 +9225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9278,7 +9245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9292,7 +9259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9308,7 +9275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -9321,7 +9288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9335,7 +9302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9351,7 +9318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9362,7 +9329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9374,7 +9341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9391,7 +9358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9411,7 +9378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9425,7 +9392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9441,7 +9408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9453,7 +9420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9473,7 +9440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9486,7 +9453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9498,7 +9465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9518,7 +9485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9535,7 +9502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9558,7 +9525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9578,7 +9545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9591,7 +9558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9602,18 +9569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY3O-285>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9624,7 +9580,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_DADPKIN-RXN_RO_0002234_CHEBI_61404_DADPKIN-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9635,7 +9602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9647,7 +9614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9663,7 +9630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9677,7 +9644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9699,7 +9666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9710,7 +9677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9721,7 +9688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9733,7 +9700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9753,7 +9720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9770,7 +9737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9783,7 +9750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9795,7 +9762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9818,7 +9785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9831,7 +9798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9842,7 +9809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9854,7 +9821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9870,7 +9837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9885,7 +9852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9899,7 +9866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9919,7 +9886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9939,7 +9906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9956,7 +9923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9970,7 +9937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9986,7 +9953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -9998,7 +9965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10014,7 +9981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10023,13 +9990,24 @@
 <http://identifiers.org/sgd/S000003563>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002233_06df146c-a946-4ba5-9957-88af418fec5a_AICARTRANSFORM-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GDPKIN-RXN_RO_0002234_CHEBI_37565_GDPKIN-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10051,7 +10029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10067,7 +10045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10085,7 +10063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10093,8 +10071,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -10102,7 +10088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10113,6 +10099,9 @@
           <http://model.geneontology.org/CHEBI_15377_AMP-DEAMINASE-RXN>
 ] .
 
+<http://www.geneontology.org/formats/oboInOwl#hasDbXref>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -10121,7 +10110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10132,17 +10121,6 @@
           <http://model.geneontology.org/reaction_DGDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002233_CHEBI_456215_ADENYL-KIN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_137981_AIRCARBOXY-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_137981> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -10152,7 +10130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10166,7 +10144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10184,7 +10162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10197,7 +10175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10212,7 +10190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10228,7 +10206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10245,7 +10223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10261,7 +10239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10276,7 +10254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10293,7 +10271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10307,7 +10285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10327,7 +10305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10340,7 +10318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10351,7 +10329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10362,7 +10340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10373,7 +10351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10386,7 +10364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10399,7 +10377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10419,7 +10397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10431,7 +10409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10450,7 +10428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -10460,7 +10438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10476,7 +10454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10487,7 +10465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10502,7 +10480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10518,7 +10496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10536,7 +10514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10549,7 +10527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10577,7 +10555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10591,7 +10569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10607,7 +10585,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_AICARTRANSFORM-RXN_RO_0002234_476e6284-ec7b-40dc-9142-bc73fd9b5d15_AICARTRANSFORM-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10618,7 +10607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10630,7 +10619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10646,7 +10635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10660,7 +10649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10676,7 +10665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10691,7 +10680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10705,7 +10694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10735,7 +10724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10751,7 +10740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10773,7 +10762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10801,7 +10790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10817,7 +10806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10832,7 +10821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10848,7 +10837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10866,7 +10855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10883,7 +10872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -10903,7 +10892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10924,7 +10913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -10937,18 +10926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10959,7 +10937,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYRIBONUCSYN-RXN_RO_0002234_CHEBI_15378_GLYRIBONUCSYN-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10970,7 +10959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -10983,7 +10972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11000,7 +10989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11014,7 +11003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11031,7 +11020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11051,7 +11040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11068,7 +11057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11088,7 +11077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11101,7 +11090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11116,7 +11105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11132,7 +11121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11151,7 +11140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11162,7 +11151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11174,7 +11163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11193,7 +11182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11204,7 +11193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11215,7 +11204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11228,7 +11217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11241,7 +11230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11253,7 +11242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11273,7 +11262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11289,7 +11278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11301,7 +11290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11321,7 +11310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11338,7 +11327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11355,7 +11344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11369,7 +11358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11386,7 +11375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11397,17 +11386,6 @@
           <http://model.geneontology.org/CPLX3O-270_ADPREDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_456216_FGAMSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -11417,7 +11395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11425,12 +11403,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_GDPREDUCT-RXN_RO_0002233_CHEBI_15377_GDPREDUCT-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11442,7 +11431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11458,7 +11447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11470,7 +11459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11487,7 +11476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11504,7 +11493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11520,7 +11509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11535,7 +11524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11554,7 +11543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11570,7 +11559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11581,7 +11570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11592,7 +11581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11604,7 +11593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11620,7 +11609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11635,7 +11624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11655,7 +11644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11684,7 +11673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11698,7 +11687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11721,7 +11710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11734,7 +11723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11749,7 +11738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11769,9 +11758,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_AICARTRANSFORM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/4d2f6964-920d-4985-8bf6-63c13615ee11_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/CHEBI_58475_AICARTRANSFORM-RXN> , <http://model.geneontology.org/06df146c-a946-4ba5-9957-88af418fec5a_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> , <http://model.geneontology.org/a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN> ;
+                <http://model.geneontology.org/476e6284-ec7b-40dc-9142-bc73fd9b5d15_AICARTRANSFORM-RXN> , <http://model.geneontology.org/CHEBI_58467_AICARTRANSFORM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR028C-MONOMER_AICARTRANSFORM-RXN_controller> , <http://model.geneontology.org/YMR120C-MONOMER_AICARTRANSFORM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -11779,7 +11768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11793,7 +11782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11813,7 +11802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11838,7 +11827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11851,7 +11840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11863,7 +11852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11880,7 +11869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11910,7 +11899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -11923,7 +11912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11935,7 +11924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11951,7 +11940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11962,7 +11951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -11980,7 +11969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -11997,7 +11986,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12013,7 +12002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12024,7 +12013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12038,7 +12027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12050,7 +12039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12067,7 +12056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12084,7 +12073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12106,7 +12095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12123,7 +12112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12142,7 +12131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12159,7 +12148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12179,7 +12168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12192,7 +12181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12207,7 +12196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12220,7 +12209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12233,7 +12222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12247,7 +12236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12267,7 +12256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12281,7 +12270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12297,7 +12286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12312,7 +12301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12325,7 +12314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12350,7 +12339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12364,7 +12353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12375,13 +12364,16 @@
           <http://model.geneontology.org/YMR300C-MONOMER_PRPPAMIDOTRANS-RXN_controller>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0004641>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_IMP-DEHYDROG-RXN_RO_0002234_CHEBI_57464_IMP-DEHYDROG-RXN_SGD_PWY3O-285> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12392,9 +12384,6 @@
           <http://model.geneontology.org/CHEBI_57464_IMP-DEHYDROG-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004641>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -12404,7 +12393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12420,7 +12409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12431,7 +12420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12445,7 +12434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12465,7 +12454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12476,29 +12465,12 @@
           <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN>
 ] .
 
-<http://model.geneontology.org/a433a4fa-ccb1-4fe0-be51-6c1e5756962f_AICARTRANSFORM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ADENYL-KIN-RXN_RO_0002411_ADPREDUCT-RXN_SGD_PWY3O-285>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12516,7 +12488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12530,7 +12502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12549,7 +12521,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12569,7 +12541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12585,7 +12557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12596,7 +12568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12607,7 +12579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12619,7 +12591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12636,7 +12608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12653,7 +12625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12672,7 +12644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12698,7 +12670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12711,7 +12683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12723,7 +12695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12742,7 +12714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12758,7 +12730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12770,7 +12742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12786,7 +12758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12797,7 +12769,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GART-RXN_RO_0002233_37757fd7-b9c3-4a85-8ef4-f136a86f3760_GART-RXN_SGD_PWY3O-285>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12808,7 +12791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12826,7 +12809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12843,7 +12826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12857,7 +12840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12877,7 +12860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12906,7 +12889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12933,7 +12916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -12946,7 +12929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12957,7 +12940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -12969,7 +12952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12988,7 +12971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13006,7 +12989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13019,7 +13002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13033,7 +13016,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13049,7 +13032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13060,7 +13043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13085,7 +13068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13099,7 +13082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13122,7 +13105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13139,7 +13122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13156,7 +13139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13173,7 +13156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13192,7 +13175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13203,22 +13186,16 @@
           <http://model.geneontology.org/reaction_GDPKIN-RXN_location_lociGO_0005829>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57464_XANPRIBOSYLTRAN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57464> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -13229,7 +13206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13237,23 +13214,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-270_ADPREDUCT-RXN_controller_BFO_0000051_SGD_S000001328_CPLX3O-270_component_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ADENYLOSUCCINATE-SYNTHASE-RXN_RO_0002234_CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN_SGD_PWY3O-285> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ADENYLOSUCCINATE-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57567_ADENYLOSUCCINATE-SYNTHASE-RXN>
+] .
 
 <http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002411_GUANYL-KIN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13267,7 +13250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13283,7 +13266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13295,7 +13278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13306,12 +13289,23 @@
           <http://model.geneontology.org/CHEBI_61404_DADPKIN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY3O-285>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-285" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_XANPRIBOSYLTRAN-RXN_RO_0002233_CHEBI_29888_XANPRIBOSYLTRAN-RXN_SGD_PWY3O-285>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13323,7 +13317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13334,16 +13328,22 @@
           <http://model.geneontology.org/CHEBI_16335_ADENOSINE-KINASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_INOPHOSPHOR-RXN_RO_0002233_CHEBI_17596_INOPHOSPHOR-RXN_SGD_PWY3O-285>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/858fde6f-cb47-437b-90e5-06fb331b0546_GART-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-285" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-285SmallMolecule33922> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YLR028C-MONOMER_IMPCYCLOHYDROLASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004018> ;
@@ -13352,7 +13352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13365,7 +13365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13382,7 +13382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13395,7 +13395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13408,7 +13408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13420,7 +13420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13450,7 +13450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13465,7 +13465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13478,7 +13478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13489,7 +13489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13501,7 +13501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13517,7 +13517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13528,7 +13528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13540,7 +13540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13556,7 +13556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13571,7 +13571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13584,7 +13584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13598,7 +13598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13614,7 +13614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13627,7 +13627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13657,7 +13657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13673,7 +13673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13693,7 +13693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13709,7 +13709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13724,7 +13724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13737,7 +13737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13748,7 +13748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13759,7 +13759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13771,7 +13771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13787,7 +13787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13799,7 +13799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13819,7 +13819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13832,7 +13832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13853,7 +13853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13869,7 +13869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13881,7 +13881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13911,7 +13911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13931,7 +13931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -13944,7 +13944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -13956,7 +13956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13973,7 +13973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -13989,7 +13989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -14001,7 +14001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14021,7 +14021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14037,7 +14037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>
@@ -14049,7 +14049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -14069,7 +14069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -14082,7 +14082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-285" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-285" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-3-PWY3O-3.ttl
+++ b/models/PWY3O-3-PWY3O-3.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -69,11 +69,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/6e9391b3-0d74-446c-a957-fd5e6c857c13_2.7.8.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a CDP-diacylglycerol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -90,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -103,11 +120,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN_SGD_PWY3O-3> ;
+          <http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_6e9391b3-0d74-446c-a957-fd5e6c857c13_2.7.8.11-RXN_SGD_PWY3O-3> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -115,7 +132,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/2.7.8.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN>
+          <http://model.geneontology.org/6e9391b3-0d74-446c-a957-fd5e6c857c13_2.7.8.11-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN>
@@ -127,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -141,23 +158,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a CDP-diacylglycerol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-3SmallMolecule43941> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylinositol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -241,7 +241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +264,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_2.7.8.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_17268_2.7.8.11-RXN> , <http://model.geneontology.org/6e9391b3-0d74-446c-a957-fd5e6c857c13_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_60377_2.7.8.11-RXN> , <http://model.geneontology.org/CHEBI_16749_2.7.8.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>
@@ -453,12 +453,12 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_510c0ce7-81f5-4362-8a43-4cf55ab9d712_2.7.8.11-RXN_SGD_PWY3O-3>
+<http://model.geneontology.org/ev_w_id_2.7.8.11-RXN_RO_0002233_6e9391b3-0d74-446c-a957-fd5e6c857c13_2.7.8.11-RXN_SGD_PWY3O-3>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-31704-PWY3O-31704.ttl
+++ b/models/PWY3O-31704-PWY3O-31704.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -88,9 +88,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-316_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316> , <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN66-316> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316> , <http://model.geneontology.org/CHEBI_15379_RXN66-316> , <http://model.geneontology.org/d1e00cf8-ec41-4eeb-b4f8-d20cbdfe4faa_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316> , <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> ;
+                <http://model.geneontology.org/f46d9938-d725-46a3-9927-aa41cc1504d0_RXN66-316> , <http://model.geneontology.org/CHEBI_15377_RXN66-316> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-316> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-316_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -214,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,7 +359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -467,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,6 +685,23 @@
           <http://model.geneontology.org/RXN66-312> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/RXN66-313>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_PWY3O-31704> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/LANOSTEROL-SYNTHASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15441_LANOSTEROL-SYNTHASE-RXN>
 ] .
 
 <http://model.geneontology.org/reaction_RXN66-306_location_lociGO_0005829>
@@ -699,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -709,28 +726,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_LANOSTEROL-SYNTHASE-RXN_RO_0002233_CHEBI_15441_LANOSTEROL-SYNTHASE-RXN_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_b06eb481-28ed-44b1-ac7a-6062eab269fe_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/LANOSTEROL-SYNTHASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15441_LANOSTEROL-SYNTHASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317_SGD_PWY3O-31704> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -738,7 +738,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317>
+          <http://model.geneontology.org/b06eb481-28ed-44b1-ac7a-6062eab269fe_RXN66-317>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_FERRICYTOCHROME-B5_RXN3O-218_SGD_PWY3O-31704>
@@ -746,7 +746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -803,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -819,7 +819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -859,7 +859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -894,7 +894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1063,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1119,18 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,11 +1175,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_e26c8d65-0d88-4a78-b095-ce8b08dc4dc5_RXN66-315_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1198,25 +1187,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-315> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315>
+          <http://model.geneontology.org/e26c8d65-0d88-4a78-b095-ce8b08dc4dc5_RXN66-315>
 ] .
-
-<http://model.geneontology.org/0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1224,7 +1196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1255,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1305,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1317,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1350,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1362,7 +1334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1378,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1406,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1421,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1434,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1452,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1493,7 +1465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1508,7 +1480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1521,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1535,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1583,7 +1555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,6 +1566,23 @@
           <http://model.geneontology.org/YGL001C-MONOMER_RXN66-313_controller>
 ] .
 
+<http://model.geneontology.org/f46d9938-d725-46a3-9927-aa41cc1504d0_RXN66-316>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -1603,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1636,7 +1625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1659,7 +1648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1703,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1715,7 +1704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1732,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1766,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1779,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1794,7 +1783,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_13390_RXN66-318> , <http://model.geneontology.org/4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318> ;
+                <http://model.geneontology.org/CHEBI_13390_RXN66-318> , <http://model.geneontology.org/6aa9d187-734a-493d-b278-478492bf396d_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16526_RXN66-318> , <http://model.geneontology.org/CHEBI_13392_RXN66-318> , <http://model.geneontology.org/CHEBI_52386_RXN66-318> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1804,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1820,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1835,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1851,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1863,7 +1852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,7 +1868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1894,7 +1883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1907,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -1922,7 +1911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1939,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1959,7 +1948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1979,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1993,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2015,7 +2004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2028,11 +2017,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_d1e00cf8-ec41-4eeb-b4f8-d20cbdfe4faa_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2040,7 +2029,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316>
+          <http://model.geneontology.org/d1e00cf8-ec41-4eeb-b4f8-d20cbdfe4faa_RXN66-316>
 ] .
 
 <http://identifiers.org/sgd/S000001114>
@@ -2052,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2068,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2080,7 +2069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,7 +2107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2154,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2179,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2192,7 +2181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2209,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2222,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2239,7 +2228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2252,7 +2241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2263,7 +2252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2294,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2311,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2325,7 +2314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2348,7 +2337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2368,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2381,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2392,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2404,7 +2393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2420,7 +2409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2434,7 +2423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2468,7 +2457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2482,7 +2471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2502,7 +2491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2521,7 +2510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2538,7 +2527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,7 +2544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2582,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2593,7 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2606,7 +2595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2621,7 +2610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2639,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2653,7 +2642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2692,7 +2681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2706,7 +2695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2717,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2732,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2746,7 +2735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2765,7 +2754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2776,7 +2765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2787,7 +2776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2804,7 +2793,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2821,7 +2810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,11 +2826,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/d1e00cf8-ec41-4eeb-b4f8-d20cbdfe4faa_RXN66-316>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2849,7 +2855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2869,7 +2875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2880,12 +2886,23 @@
           <http://model.geneontology.org/CHEBI_64925_RXN66-312>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_d1e00cf8-ec41-4eeb-b4f8-d20cbdfe4faa_RXN66-316_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-314_RO_0002333_YLR100W-MONOMER_RXN66-314_controller_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2899,7 +2916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2919,7 +2936,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2930,13 +2947,24 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-317>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002234_e26c8d65-0d88-4a78-b095-ce8b08dc4dc5_RXN66-315_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002233_FERROCYTOCHROME-B5_RXN3O-218_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2952,7 +2980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2963,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2974,7 +3002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -2991,7 +3019,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3011,7 +3039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,29 +3050,12 @@
           <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002234_CHEBI_18249_RXN3O-227_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3059,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3076,7 +3087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3093,7 +3104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3109,32 +3120,38 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://identifiers.org/sgd/S000004815>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/6aa9d187-734a-493d-b278-478492bf396d_RXN66-318>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000004815>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN66-318_BFO_0000066_reaction_RXN66-318_location_lociGO_0005829_null_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3149,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3162,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3180,7 +3197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3196,7 +3213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3210,7 +3227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3221,7 +3238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3234,7 +3251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3251,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ergosterol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3264,7 +3281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3276,7 +3293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3295,7 +3312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3312,7 +3329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3328,7 +3345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3340,7 +3357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3359,7 +3376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3376,7 +3393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3396,7 +3413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3415,7 +3432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3433,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3450,7 +3467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3458,12 +3475,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/b06eb481-28ed-44b1-ac7a-6062eab269fe_RXN66-317>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_FERROCYTOCHROME-B5_RXN66-311_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3476,7 +3510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3490,7 +3524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3507,7 +3541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3523,7 +3557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3537,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3552,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3568,7 +3602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3588,7 +3622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3599,19 +3633,19 @@
 <http://model.geneontology.org/reaction_RXN3O-227_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://geneontology.org/lego/evidence>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_RXN66-281_RO_0002233_CHEBI_13392_RXN66-281_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://geneontology.org/lego/evidence>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/reaction_RXN66-314_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -3625,7 +3659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3638,7 +3672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3653,7 +3687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3667,7 +3701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3684,7 +3718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3700,7 +3734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3712,7 +3746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3728,7 +3762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3745,7 +3779,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3765,7 +3799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3784,7 +3818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3804,7 +3838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3817,7 +3851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3831,7 +3865,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3842,6 +3876,17 @@
           <http://model.geneontology.org/RXN66-318>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_6aa9d187-734a-493d-b278-478492bf396d_RXN66-318_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3851,7 +3896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3865,7 +3910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3882,7 +3927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3898,7 +3943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3921,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3934,7 +3979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3945,7 +3990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3956,7 +4001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3967,7 +4012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -3984,7 +4029,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN66-315> , <http://model.geneontology.org/CHEBI_1949_RXN66-315> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15378_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
+                <http://model.geneontology.org/e26c8d65-0d88-4a78-b095-ce8b08dc4dc5_RXN66-315> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-315> , <http://model.geneontology.org/CHEBI_15377_RXN66-315> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3992,7 +4037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4005,7 +4050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4016,7 +4061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4027,7 +4072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4040,7 +4085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4053,7 +4098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4068,7 +4113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4088,7 +4133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4102,7 +4147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4118,7 +4163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4130,7 +4175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4149,7 +4194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4165,7 +4210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4183,7 +4228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4199,7 +4244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4216,7 +4261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4233,7 +4278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4250,7 +4295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4267,7 +4312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4297,7 +4342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4314,7 +4359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4328,7 +4373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4345,7 +4390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4361,18 +4406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4384,7 +4418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4404,7 +4438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4417,7 +4451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4426,23 +4460,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_13392>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_CHEBI_15378_RXN66-316_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4457,7 +4480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4470,7 +4493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4498,7 +4521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4512,7 +4535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4528,7 +4551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4545,7 +4568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4559,7 +4582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4576,7 +4599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4596,7 +4619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4612,7 +4635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4629,7 +4652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4640,24 +4663,13 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-218_RO_0002234_CHEBI_52972_RXN3O-218_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4668,22 +4680,16 @@
           <http://model.geneontology.org/CHEBI_52972_RXN3O-218>
 ] .
 
-<http://model.geneontology.org/74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+<http://model.geneontology.org/ev_w_id_RXN66-281_BFO_0000050_PWY3O-31704/PWY3O-31704_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4691,7 +4697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4708,7 +4714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4724,7 +4730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4735,7 +4741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4749,7 +4755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4761,7 +4767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4781,7 +4787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4798,7 +4804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4814,7 +4820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4832,7 +4838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4845,7 +4851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4859,7 +4865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4868,12 +4874,23 @@
 <http://purl.obolibrary.org/obo/CHEBI_87289>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_eb903abb-b15b-47d1-9017-d09329aad0b8_RXN66-317_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-130_BFO_0000066_reaction_RXN3O-130_location_lociGO_0005829_null_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4884,7 +4901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -4895,28 +4912,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4924,7 +4924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4934,6 +4934,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16933_1.3.1.71-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002233_b06eb481-28ed-44b1-ac7a-6062eab269fe_RXN66-317_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN66-281>
         a       <http://purl.obolibrary.org/obo/GO_0004310> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -4954,7 +4965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4968,7 +4979,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4985,7 +4996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5004,7 +5015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5020,7 +5031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5032,7 +5043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5052,7 +5063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5068,7 +5079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5083,7 +5094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5097,7 +5108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5117,7 +5128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5131,7 +5142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5148,7 +5159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5164,7 +5175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5180,7 +5191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5196,7 +5207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5214,7 +5225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5233,7 +5244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5244,7 +5255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5255,7 +5266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5270,7 +5281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5287,7 +5298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5302,7 +5313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5319,7 +5330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5332,7 +5343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5343,7 +5354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5355,7 +5366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5374,7 +5385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5394,7 +5405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5408,7 +5419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5424,7 +5435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5436,7 +5447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5452,7 +5463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5463,7 +5474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5478,7 +5489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -5494,7 +5505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5505,24 +5516,13 @@
           <http://model.geneontology.org/reaction_RXN66-318_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-227_RO_0002233_Red-NADPH-Hemoprotein-Reductases_RXN3O-227_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5533,20 +5533,16 @@
           <http://model.geneontology.org/Red-NADPH-Hemoprotein-Reductases_RXN3O-227>
 ] .
 
-<http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
-        a       <http://identifiers.org/sgd/S000005224> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "C-14 sterol reductase" ;
+<http://model.geneontology.org/ev_w_id_RXN66-315_RO_0002233_CHEBI_15378_RXN66-315_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44542> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5554,7 +5550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5565,22 +5561,20 @@
           <http://model.geneontology.org/CHEBI_87289_RXN66-310>
 ] .
 
-<http://model.geneontology.org/adf8ffb2-a431-42c6-9743-0bd4978dc217_RXN66-315>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/YNL280C-MONOMER_RXN66-306_controller>
+        a       <http://identifiers.org/sgd/S000005224> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+                "C-14 sterol reductase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704Protein44542> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5588,7 +5582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5604,7 +5598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5616,7 +5610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5632,7 +5626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5647,7 +5641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5664,7 +5658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5672,23 +5666,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN66-306_RO_0002234_CHEBI_15378_RXN66-306_SGD_PWY3O-31704>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5699,7 +5682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5714,9 +5697,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN66-317_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/74a4f120-284c-4cca-bf53-2fec68c57082_RXN66-317> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN66-317> , <http://model.geneontology.org/CHEBI_15379_RXN66-317> , <http://model.geneontology.org/b06eb481-28ed-44b1-ac7a-6062eab269fe_RXN66-317> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN66-317> , <http://model.geneontology.org/eb903abb-b15b-47d1-9017-d09329aad0b8_RXN66-317> , <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN66-317> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-317_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5724,7 +5707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5737,7 +5720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5752,7 +5735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5767,7 +5750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5784,7 +5767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5804,7 +5787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5817,7 +5800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5828,7 +5811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5839,7 +5822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5850,7 +5833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5865,7 +5848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5881,7 +5864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5897,7 +5880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5912,7 +5895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5929,7 +5912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5946,7 +5929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5963,7 +5946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5979,7 +5962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -5990,7 +5973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6002,7 +5985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6013,24 +5996,13 @@
           <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN66-316>
 ] .
 
-<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-203_RO_0002233_CHEBI_17038_RXN3O-203_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6041,6 +6013,17 @@
           <http://model.geneontology.org/CHEBI_17038_RXN3O-203>
 ] .
 
+<http://model.geneontology.org/ev_w_id_SQUALENE-MONOOXYGENASE-RXN_RO_0002234_CHEBI_15441_SQUALENE-MONOOXYGENASE-RXN_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -6049,7 +6032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6065,7 +6048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6080,7 +6063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6097,7 +6080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6120,7 +6103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6147,7 +6130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6160,7 +6143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6171,7 +6154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6186,7 +6169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6213,7 +6196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6229,7 +6212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6244,7 +6227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6257,7 +6240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6271,7 +6254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6287,7 +6270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6301,7 +6284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6317,7 +6300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6329,7 +6312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6345,7 +6328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6357,7 +6340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6373,7 +6356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6385,7 +6368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6402,7 +6385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6419,7 +6402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6436,7 +6419,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6453,7 +6436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6473,7 +6456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6486,7 +6469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6501,7 +6484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6514,7 +6497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6528,7 +6511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6544,7 +6527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6555,18 +6538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY3O-31704>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6591,13 +6563,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704BiochemicalReaction44309> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_RXN-12263_RO_0002234_CHEBI_57310_RXN-12263_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/eb903abb-b15b-47d1-9017-d09329aad0b8_RXN66-317>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-carboxy-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44198> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003292> ;
@@ -6606,7 +6606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6625,7 +6625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6640,7 +6640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6656,7 +6656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6668,7 +6668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6687,7 +6687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6707,7 +6707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6720,7 +6720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6731,7 +6731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6743,7 +6743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6754,13 +6754,24 @@
           <http://model.geneontology.org/YGR060W-MONOMER_RXN66-315_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY3O-31704>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002234_CHEBI_17038_RXN3O-178_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6771,23 +6782,12 @@
           <http://model.geneontology.org/CHEBI_17038_RXN3O-178>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002234_CHEBI_87287_RXN66-311_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN66-312_RO_0002233_CHEBI_87287_RXN66-312_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6800,7 +6800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6817,7 +6817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6831,7 +6831,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6851,7 +6851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6868,7 +6868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6887,7 +6887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6904,7 +6904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6920,7 +6920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6931,7 +6931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6942,7 +6942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6953,7 +6953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6964,7 +6964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -6989,7 +6989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7002,7 +7002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7020,7 +7020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7037,7 +7037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7050,7 +7050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7058,23 +7058,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_57856>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4&alpha;-formyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44191> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15379_RXN3O-218>
         a       <http://purl.obolibrary.org/obo/CHEBI_15379> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7085,7 +7068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7098,7 +7081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7109,7 +7092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7120,7 +7103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7135,7 +7118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7149,7 +7132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7166,7 +7149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7179,11 +7162,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-318_RO_0002233_6aa9d187-734a-493d-b278-478492bf396d_RXN66-318_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7191,7 +7174,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-318> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4855303d-2b0e-4096-ad14-ceb53e84cc57_RXN66-318>
+          <http://model.geneontology.org/6aa9d187-734a-493d-b278-478492bf396d_RXN66-318>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-130_RO_0002333_YHR007C-MONOMER_RXN3O-130_controller_SGD_PWY3O-31704>
@@ -7199,7 +7182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7211,7 +7194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7231,7 +7214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7245,7 +7228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7262,7 +7245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7279,7 +7262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7299,7 +7282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7318,7 +7301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7337,7 +7320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7353,7 +7336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7378,7 +7361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7391,7 +7374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7406,7 +7389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7423,7 +7406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7437,7 +7420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7453,7 +7436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7478,7 +7461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7495,7 +7478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7512,7 +7495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7529,7 +7512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7543,7 +7526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7559,7 +7542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7573,7 +7556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7590,7 +7573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7606,7 +7589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7618,7 +7601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7635,7 +7618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7651,7 +7634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7666,7 +7649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7683,7 +7666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7696,7 +7679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7708,7 +7691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7725,7 +7708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7741,7 +7724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7752,7 +7735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7767,7 +7750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7781,7 +7764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7801,7 +7784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7817,7 +7800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7829,7 +7812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7848,7 +7831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7866,7 +7849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7893,7 +7876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7907,6 +7890,23 @@
 <http://purl.obolibrary.org/obo/GO_0004337>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/e26c8d65-0d88-4a78-b095-ce8b08dc4dc5_RXN66-315>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4&alpha;-hydroxymethyl-5&alpha;-cholesta-8,24-dien-3&beta;-ol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-31704SmallMolecule44129> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YLR100W-MONOMER_RXN66-314_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004090> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -7914,7 +7914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7927,7 +7927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7939,7 +7939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7955,7 +7955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7966,18 +7966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-31704" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002233_0ba1fa36-bc10-43a2-8065-bb7575fb2dcb_RXN66-316_SGD_PWY3O-31704>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -7985,11 +7974,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-317_RO_0002234_eb903abb-b15b-47d1-9017-d09329aad0b8_RXN66-317_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7997,7 +7986,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-317> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/01ffb3c4-a843-49eb-8451-0b3d69f435ac_RXN66-317>
+          <http://model.geneontology.org/eb903abb-b15b-47d1-9017-d09329aad0b8_RXN66-317>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -8006,7 +7995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8026,7 +8015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8046,7 +8035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8063,7 +8052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8080,7 +8069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8097,7 +8086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8116,7 +8105,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8138,7 +8127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8168,7 +8157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8185,7 +8174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8198,7 +8187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8209,7 +8198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8220,7 +8209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8231,7 +8220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8246,7 +8235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8260,7 +8249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8276,7 +8265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8291,7 +8280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8304,7 +8293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8315,7 +8304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8329,7 +8318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8344,7 +8333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8361,7 +8350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8391,7 +8380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8405,7 +8394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8424,7 +8413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8437,7 +8426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8454,7 +8443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8471,7 +8460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8491,7 +8480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8508,7 +8497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8525,7 +8514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8542,7 +8531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8559,7 +8548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8575,7 +8564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8587,7 +8576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8606,7 +8595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8622,7 +8611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8633,7 +8622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8651,7 +8640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8666,7 +8655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8683,7 +8672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8696,7 +8685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8707,7 +8696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8725,7 +8714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8755,7 +8744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8772,7 +8761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8799,7 +8788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8818,7 +8807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8838,7 +8827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8851,7 +8840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8862,7 +8851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -8874,7 +8863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8891,7 +8880,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8908,7 +8897,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8928,7 +8917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8945,7 +8934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8962,7 +8951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8982,7 +8971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8996,7 +8985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9016,7 +9005,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9032,7 +9021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9047,7 +9036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9063,7 +9052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9074,7 +9063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9085,7 +9074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9100,7 +9089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9114,7 +9103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9125,23 +9114,23 @@
           <http://model.geneontology.org/PWY3O-31704/PWY3O-31704>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-311_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN66-310_RO_0002234_CHEBI_87289_RXN66-310_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9156,7 +9145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9164,19 +9153,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN66-311_RO_0002233_CHEBI_87289_RXN66-311_SGD_PWY3O-31704>
+<http://model.geneontology.org/ev_w_id_RXN3O-178_RO_0002333_MONOMER3O-188_RXN3O-178_controller_SGD_PWY3O-31704>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_87287_RXN66-311>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_87287> ;
@@ -9187,7 +9176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9207,7 +9196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9220,7 +9209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9232,7 +9221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9251,7 +9240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9271,7 +9260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9284,7 +9273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9295,7 +9284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9303,11 +9292,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316_SGD_PWY3O-31704> ;
+          <http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_f46d9938-d725-46a3-9927-aa41cc1504d0_RXN66-316_SGD_PWY3O-31704> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9315,7 +9304,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN66-316> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9118ba2e-e745-47f8-bd94-6e75704c296f_RXN66-316>
+          <http://model.geneontology.org/f46d9938-d725-46a3-9927-aa41cc1504d0_RXN66-316>
 ] .
 
 <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
@@ -9327,7 +9316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9341,7 +9330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9359,7 +9348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9375,7 +9364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9387,7 +9376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9404,7 +9393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9424,7 +9413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9438,7 +9427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9458,7 +9447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -9472,7 +9461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9489,7 +9478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -9505,7 +9494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
@@ -9516,8 +9505,19 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31704" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN66-316_RO_0002234_f46d9938-d725-46a3-9927-aa41cc1504d0_RXN66-316_SGD_PWY3O-31704>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31704" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-31704" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .

--- a/models/PWY3O-31723-PWY3O-31723.ttl
+++ b/models/PWY3O-31723-PWY3O-31723.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -19,7 +19,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -48,7 +48,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -150,7 +150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -258,7 +258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -511,7 +511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -606,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -620,7 +620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-31723" ;
         <http://purl.org/pav/providedBy>
@@ -660,7 +660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-31723" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acids biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-335-PWY3O-335.ttl
+++ b/models/PWY3O-335-PWY3O-335.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "acetoin biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -102,7 +102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,12 +119,12 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN_SGD_PWY3O-335>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_7db6d93a-8d7f-43e5-b223-132ef2ad7697_ACETOINDEHYDROG-RXN_SGD_PWY3O-335>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -254,11 +254,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN_SGD_PWY3O-335> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_7db6d93a-8d7f-43e5-b223-132ef2ad7697_ACETOINDEHYDROG-RXN_SGD_PWY3O-335> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/7db6d93a-8d7f-43e5-b223-132ef2ad7697_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,15 +345,12 @@
           <http://model.geneontology.org/reaction_RXN-6081_location_lociGO_0005829>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24331>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY3O-335>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -371,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -452,12 +449,12 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/7db6d93a-8d7f-43e5-b223-132ef2ad7697_ACETOINDEHYDROG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -465,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -499,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -527,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -584,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -616,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -662,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -723,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -754,7 +751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -819,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -848,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -861,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -882,7 +879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -902,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,14 +915,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17499_RXN-6081>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -933,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -988,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1014,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1065,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/a1fc94e5-1a99-4d51-9559-7eea7cbdc124_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/7db6d93a-8d7f-43e5-b223-132ef2ad7697_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1076,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1093,7 +1090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1110,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,7 +1119,7 @@
 ] .
 
 <http://model.geneontology.org/CHEBI_15339_RXN-6081>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1130,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1156,7 +1153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1175,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1223,7 +1220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>
@@ -1290,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1304,7 +1301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1337,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-335" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-335" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-351-PWY3O-351.ttl
+++ b/models/PWY3O-351-PWY3O-351.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -148,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -189,7 +189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -263,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -408,7 +408,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -502,7 +502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -562,7 +562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -593,7 +593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -691,7 +691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,7 +796,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -868,7 +868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -915,7 +915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +938,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1136,7 +1136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1249,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1302,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1320,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1334,7 +1334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1350,7 +1350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1362,7 +1362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1397,7 +1397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1494,7 +1494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1511,7 +1511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1528,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1544,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1570,7 +1570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,7 +1590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1620,7 +1620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1637,7 +1637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1651,7 +1651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1667,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1678,7 +1678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1707,7 +1707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,7 +1730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1748,7 +1748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1762,7 +1762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1782,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1819,7 +1819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1835,7 +1835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1852,7 +1852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1900,7 +1900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1913,7 +1913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1924,7 +1924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1938,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -1950,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1987,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2003,7 +2003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2073,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2087,7 +2087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2103,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2120,7 +2120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2143,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2157,7 +2157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2173,7 +2173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2210,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2222,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2238,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2261,7 +2261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2277,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2289,7 +2289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2305,7 +2305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2316,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2333,7 +2333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2356,7 +2356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2376,7 +2376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2390,7 +2390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2410,7 +2410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2426,7 +2426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2437,7 +2437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2448,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2474,7 +2474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2491,7 +2491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2508,7 +2508,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2524,7 +2524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2535,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2549,7 +2549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2568,7 +2568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2608,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2625,7 +2625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2642,7 +2642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2656,7 +2656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2686,7 +2686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2703,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2731,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2745,7 +2745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2765,7 +2765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,7 +2788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2808,7 +2808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2824,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2839,7 +2839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2862,7 +2862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,7 +2881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -2896,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2913,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2933,7 +2933,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2953,7 +2953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2970,7 +2970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2992,7 +2992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3003,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3020,7 +3020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3032,7 +3032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3048,7 +3048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3057,7 +3057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3069,7 +3069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3089,7 +3089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3102,7 +3102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3117,7 +3117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3137,7 +3137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3154,7 +3154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3167,7 +3167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3178,7 +3178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3206,7 +3206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3221,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3235,7 +3235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3254,7 +3254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3268,7 +3268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3284,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3295,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3307,7 +3307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3323,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3333,7 +3333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3363,7 +3363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3393,7 +3393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3410,7 +3410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3427,7 +3427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3443,7 +3443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3455,7 +3455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3471,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3482,7 +3482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3496,7 +3496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3513,7 +3513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3531,7 +3531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3545,7 +3545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3563,7 +3563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3580,7 +3580,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3610,7 +3610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3627,7 +3627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3643,7 +3643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3657,7 +3657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3669,7 +3669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3685,7 +3685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3696,7 +3696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3708,7 +3708,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3728,7 +3728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3745,7 +3745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3758,7 +3758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3775,7 +3775,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3791,7 +3791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3806,7 +3806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3822,7 +3822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3834,7 +3834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3851,7 +3851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,7 +3867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3881,7 +3881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3897,7 +3897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3912,7 +3912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3926,7 +3926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3943,7 +3943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3959,7 +3959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3973,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -3985,7 +3985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4008,7 +4008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4024,7 +4024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -4036,7 +4036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4056,7 +4056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -4072,7 +4072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-351" ;
         <http://purl.org/pav/providedBy>
@@ -4085,7 +4085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-351" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-355-PWY3O-355.ttl
+++ b/models/PWY3O-355-PWY3O-355.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -384,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -603,7 +603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -726,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -738,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -801,7 +801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "stearate biosynthesis III (fungi) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -851,7 +851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -925,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -941,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -952,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -964,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1074,7 +1074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1168,7 +1168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1218,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,28 +1269,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_15378_RXN-9624>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355SmallMolecule18742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-5293>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1301,7 +1284,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-355SmallMolecule18742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_15378_RXN-9624>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1315,7 +1315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,7 +1332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1348,7 +1348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1373,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1488,7 +1488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1503,7 +1503,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1558,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1582,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1613,7 +1613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,7 +1659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1689,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,7 +1753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1769,7 +1769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1806,7 +1806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1823,7 +1823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1848,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1863,7 +1863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1888,7 +1888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1903,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1933,7 +1933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1947,7 +1947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1966,7 +1966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +1994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2021,7 +2021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2036,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2053,7 +2053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2073,7 +2073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2087,7 +2087,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2103,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2114,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2129,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,23 +2137,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_PWY3O-355/PWY3O-355_SGD_PWY3O-355>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-355" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002233_Stearoyl-ACPs_RXN3O-5304_SGD_PWY3O-355>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-355" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-5304_BFO_0000050_PWY3O-355/PWY3O-355_SGD_PWY3O-355>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2165,7 +2165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,7 +2181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2193,7 +2193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2209,7 +2209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2220,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2248,7 +2248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>
@@ -2259,7 +2259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-355" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-355" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-3827-PWY3O-3827.ttl
+++ b/models/PWY3O-3827-PWY3O-3827.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glucose-6-phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -57,7 +57,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -306,7 +306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -396,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -465,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-3827" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-3827" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-4-PWY3O-4.ttl
+++ b/models/PWY3O-4-PWY3O-4.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -125,7 +125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "carnitine shuttle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -248,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -284,7 +284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -547,7 +547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -703,7 +703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -764,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +776,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-402-PWY3O-402.ttl
+++ b/models/PWY3O-402-PWY3O-402.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,11 +111,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46986> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/156971bd-006c-487d-8b56-9711989c3bad_RXN3O-9819>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -131,7 +148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -173,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -189,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,12 +246,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_4de0b267-a42c-42c2-9fd5-42e75c3eaffc_RXN3O-785_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002234_CHEBI_15378_RXN-7184_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -248,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -326,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,30 +385,13 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,23 +449,29 @@
           <http://model.geneontology.org/MONOMER3O-64_RXN-7184_controller>
 ] .
 
+<http://model.geneontology.org/0db3854e-b28a-45f7-998a-dc53a63d59db_RXN3O-9819>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4- or 6-diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002234_CHEBI_58130_RXN3O-785_SGD_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_ee827223-86fb-4205-9c7d-460367491653_RXN3O-785_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -469,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -607,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -624,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -637,9 +654,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_2e3cacbd-16d2-4c55-946e-13d84abc1f77_RXN3O-786_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -648,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -668,13 +696,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_16322_RXN-4941> , <http://model.geneontology.org/CHEBI_30616_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN-4941> , <http://model.geneontology.org/078ddd98-1635-4848-826e-e959157b9553_RXN-4941> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-64_RXN-4941_controller> , <http://model.geneontology.org/MONOMER3O-205_RXN-4941_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +733,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -732,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -776,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -821,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -832,46 +860,12 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-7184>
 ] .
 
-<http://model.geneontology.org/12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-143_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -889,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,7 +922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -945,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,30 +1022,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402BiochemicalReaction47132> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4- or 6-diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_30616_RXN-7163>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1062,7 +1039,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,11 +1055,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1092,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1109,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,8 +1100,22 @@
           <http://model.geneontology.org/CHEBI_57895_2.7.1.127-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/3b9a0dc5-71a5-4f1f-8121-fed6af60885f_RXN3O-258>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "4- or 6-diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1129,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1140,23 +1134,12 @@
           <http://model.geneontology.org/PWY3O-402/PWY3O-402>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_58130_RXN-7163_SGD_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1167,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1207,7 +1190,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_58628_RXN3O-143> , <http://model.geneontology.org/CHEBI_30616_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN3O-143> , <http://model.geneontology.org/1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143> ;
+                <http://model.geneontology.org/f4bc99c4-fc87-403b-97e5-b3c8b5b05d15_RXN3O-143> , <http://model.geneontology.org/CHEBI_456216_RXN3O-143> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-143_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1215,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1229,7 +1212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1245,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1286,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1294,11 +1277,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_2e3cacbd-16d2-4c55-946e-13d84abc1f77_RXN3O-786_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1289,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786>
+          <http://model.geneontology.org/2e3cacbd-16d2-4c55-946e-13d84abc1f77_RXN3O-786>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -1317,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1347,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,45 +1347,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46986> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ee827223-86fb-4205-9c7d-460367491653_RXN3O-785>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1412,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1436,7 +1385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,7 +1400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1464,7 +1413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,7 +1448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1535,7 +1484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1552,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1572,13 +1521,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47125> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_f4bc99c4-fc87-403b-97e5-b3c8b5b05d15_RXN3O-143_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1588,7 +1548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1624,7 +1584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1659,7 +1619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1676,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1692,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1709,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,6 +1680,23 @@
           <http://model.geneontology.org/MONOMER3O-64_RXN-4941_controller>
 ] .
 
+<http://model.geneontology.org/2e3cacbd-16d2-4c55-946e-13d84abc1f77_RXN3O-786>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_456216>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1729,7 +1706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1756,18 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1778,7 +1744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1789,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1801,7 +1767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1824,7 +1790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1834,11 +1800,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-143_RO_0002234_f4bc99c4-fc87-403b-97e5-b3c8b5b05d15_RXN3O-143_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1846,7 +1812,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-143> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1a662caf-343a-4636-81c4-4c0ef463235d_RXN3O-143>
+          <http://model.geneontology.org/f4bc99c4-fc87-403b-97e5-b3c8b5b05d15_RXN3O-143>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-7184_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402>
@@ -1854,11 +1820,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/078ddd98-1635-4848-826e-e959157b9553_RXN-4941>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1866,7 +1849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1882,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1893,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1907,7 +1890,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_156971bd-006c-487d-8b56-9711989c3bad_RXN3O-9819_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -1924,7 +1918,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_RXN3O-258> , <http://model.geneontology.org/CHEBI_58130_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN3O-258> , <http://model.geneontology.org/564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258> ;
+                <http://model.geneontology.org/CHEBI_456216_RXN3O-258> , <http://model.geneontology.org/3b9a0dc5-71a5-4f1f-8121-fed6af60885f_RXN3O-258> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-224_RXN3O-258_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1932,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,7 +1943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1963,7 +1957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1980,7 +1974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2000,13 +1994,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46986> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_9fe30478-f771-4b2a-9c53-e31105f8fdd4_3.1.4.11-RXN_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2016,7 +2021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2033,7 +2038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2046,11 +2051,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_9fe30478-f771-4b2a-9c53-e31105f8fdd4_3.1.4.11-RXN_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2058,7 +2063,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/3.1.4.11-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN>
+          <http://model.geneontology.org/9fe30478-f771-4b2a-9c53-e31105f8fdd4_3.1.4.11-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_456216_RXN3O-258>
@@ -2070,11 +2075,31 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46986> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/f4bc99c4-fc87-403b-97e5-b3c8b5b05d15_RXN3O-143>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2087,7 +2112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "inositol phosphate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2095,15 +2120,29 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+<http://model.geneontology.org/4de0b267-a42c-42c2-9fd5-42e75c3eaffc_RXN3O-785>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-7184_RO_0002233_CHEBI_30616_RXN-7184_SGD_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2117,7 +2156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2137,7 +2176,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2191,11 +2230,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47198> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/9fe30478-f771-4b2a-9c53-e31105f8fdd4_3.1.4.11-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol 4,5-bisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47183> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2207,7 +2263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2223,18 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2248,7 +2293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2262,7 +2307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2294,7 +2339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2311,7 +2356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2327,7 +2372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2338,7 +2383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2350,7 +2395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2400,7 +2445,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_078ddd98-1635-4848-826e-e959157b9553_RXN-4941_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2425,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2441,7 +2497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2458,7 +2514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2478,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2491,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2502,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2516,7 +2572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2533,7 +2589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2549,7 +2605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2564,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2584,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2601,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2617,7 +2673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2628,7 +2684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2642,7 +2698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2650,11 +2706,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_0db3854e-b28a-45f7-998a-dc53a63d59db_RXN3O-9819_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2662,7 +2718,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819>
+          <http://model.geneontology.org/0db3854e-b28a-45f7-998a-dc53a63d59db_RXN3O-9819>
 ] .
 
 <http://model.geneontology.org/reaction_RXN-7184_location_lociGO_0005829>
@@ -2673,7 +2729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2684,7 +2740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2696,7 +2752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2719,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2733,7 +2789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2749,7 +2805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2764,15 +2820,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9819_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> , <http://model.geneontology.org/5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819> ;
+                <http://model.geneontology.org/0db3854e-b28a-45f7-998a-dc53a63d59db_RXN3O-9819> , <http://model.geneontology.org/CHEBI_30616_RXN3O-9819> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> , <http://model.geneontology.org/49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819> ;
+                <http://model.geneontology.org/156971bd-006c-487d-8b56-9711989c3bad_RXN3O-9819> , <http://model.geneontology.org/CHEBI_456216_RXN3O-9819> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN3O-786> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,7 +2844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2808,7 +2864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2821,7 +2877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2833,7 +2889,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2844,12 +2900,23 @@
           <http://model.geneontology.org/CHEBI_15377_RXN3O-785>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_3b9a0dc5-71a5-4f1f-8121-fed6af60885f_RXN3O-258_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002413_RXN3O-9819_null_PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2860,7 +2927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2874,7 +2941,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2891,7 +2958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2908,7 +2975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2924,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2935,7 +3002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -2947,7 +3014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2960,11 +3027,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_4b5ce7b8-576b-41a1-9195-55e88cc311aa_RXN3O-786_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2972,7 +3039,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-786> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786>
+          <http://model.geneontology.org/4b5ce7b8-576b-41a1-9195-55e88cc311aa_RXN3O-786>
 ] .
 
 <http://model.geneontology.org/YDR315C-MONOMER_RXN-7163_controller>
@@ -2982,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2996,7 +3063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3015,7 +3082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3027,7 +3094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3038,6 +3105,17 @@
           <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-786_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_4b5ce7b8-576b-41a1-9195-55e88cc311aa_RXN3O-786_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_RXN3O-785>
         a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3047,7 +3125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3066,7 +3144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3082,46 +3160,29 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/5c86fd70-56c3-48ad-ac35-f1ff4443a42d_RXN3O-9819>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "4- or 6-diphosphoinositol pentakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46949> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_57627_2.7.1.151-RXN_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002233_0db3854e-b28a-45f7-998a-dc53a63d59db_RXN3O-9819_SGD_PWY3O-402>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3135,7 +3196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3146,6 +3207,17 @@
           <http://model.geneontology.org/reaction_RXN-7162_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_2.7.1.151-RXN_RO_0002234_CHEBI_15378_2.7.1.151-RXN_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_RXN3O-143>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3155,24 +3227,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46966> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PWY3O-402/PWY3O-402>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
@@ -3183,7 +3244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3191,29 +3252,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "[PP]<sub>2</sub>-IP<sub>4</sub>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46971> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_CHEBI_15377_RXN3O-786_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3228,7 +3272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3245,7 +3289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3262,7 +3306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3279,7 +3323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3301,7 +3345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3309,11 +3353,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-258_RO_0002234_3b9a0dc5-71a5-4f1f-8121-fed6af60885f_RXN3O-258_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3321,7 +3365,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-258> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/564fa27b-7f02-40fb-a515-815f132a621e_RXN3O-258>
+          <http://model.geneontology.org/3b9a0dc5-71a5-4f1f-8121-fed6af60885f_RXN3O-258>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.152-RXN_RO_0002233_CHEBI_58130_2.7.1.152-RXN_SGD_PWY3O-402>
@@ -3329,7 +3373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3340,7 +3384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3355,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3372,7 +3416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3385,7 +3429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3397,7 +3441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3416,7 +3460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3427,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3442,7 +3486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3469,7 +3513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3483,7 +3527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3503,7 +3547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3516,7 +3560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3528,7 +3572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3548,7 +3592,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-785_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ee827223-86fb-4205-9c7d-460367491653_RXN3O-785> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
+                <http://model.geneontology.org/4de0b267-a42c-42c2-9fd5-42e75c3eaffc_RXN3O-785> , <http://model.geneontology.org/CHEBI_15377_RXN3O-785> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58130_RXN3O-785> , <http://model.geneontology.org/CHEBI_43474_RXN3O-785> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -3558,7 +3602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3575,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3589,7 +3633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3609,7 +3653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3622,7 +3666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3633,7 +3677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3647,7 +3691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3662,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3676,7 +3720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3692,7 +3736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3707,7 +3751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3723,7 +3767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3734,23 +3778,6 @@
           <http://model.geneontology.org/RXN3O-786>
 ] .
 
-<http://model.geneontology.org/464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a diphospho-1D-myo-inositol tetrakisphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule47070> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0008440>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -3759,7 +3786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3771,7 +3798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3788,7 +3815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3806,7 +3833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3819,7 +3846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3834,7 +3861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3845,13 +3872,30 @@
           <http://model.geneontology.org/PWY3O-402/PWY3O-402>
 ] .
 
+<http://model.geneontology.org/4b5ce7b8-576b-41a1-9195-55e88cc311aa_RXN3O-786>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "diphosphoinositol pentakisphosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-402SmallMolecule46994> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_ee827223-86fb-4205-9c7d-460367491653_RXN3O-785_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-785_RO_0002233_4de0b267-a42c-42c2-9fd5-42e75c3eaffc_RXN3O-785_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3859,7 +3903,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-785> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ee827223-86fb-4205-9c7d-460367491653_RXN3O-785>
+          <http://model.geneontology.org/4de0b267-a42c-42c2-9fd5-42e75c3eaffc_RXN3O-785>
 ] .
 
 <http://model.geneontology.org/ev_w_id_2.7.1.127-RXN_RO_0002233_CHEBI_203600_2.7.1.127-RXN_SGD_PWY3O-402>
@@ -3867,7 +3911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3881,7 +3925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3898,7 +3942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3914,7 +3958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3927,7 +3971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3940,7 +3984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3952,7 +3996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +4015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -3985,18 +4029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4011,7 +4044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4030,7 +4063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4053,7 +4086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4070,7 +4103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4083,7 +4116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4095,7 +4128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4111,7 +4144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4122,7 +4155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4137,7 +4170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4148,17 +4181,6 @@
           <http://model.geneontology.org/CHEBI_30616_RXN-7162>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002234_2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'phytate + ATP + H<SUP>+</SUP> &rarr; 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate + ADP + H<SUP>+</SUP>' 'null' 'ATP + 1D-<i>myo</i>inositol 5-diphosphate 1,2,3,4,6-pentakisphosphate &rarr; ADP + [PP]<sub>2</sub>-IP<sub>4</sub>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -4167,7 +4189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4184,7 +4206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4200,7 +4222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4214,7 +4236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4225,7 +4247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4240,7 +4262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4260,7 +4282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4278,7 +4300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4292,7 +4314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4302,17 +4324,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN-7163>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-786_RO_0002233_12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-7162_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -4326,7 +4337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4341,7 +4352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4355,7 +4366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4375,7 +4386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4391,7 +4402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4411,7 +4422,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_3.1.4.11-RXN> , <http://model.geneontology.org/9fe30478-f771-4b2a-9c53-e31105f8fdd4_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_203600_3.1.4.11-RXN> , <http://model.geneontology.org/CHEBI_17815_3.1.4.11-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -4421,7 +4432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4434,7 +4445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4449,9 +4460,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-786_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN3O-786> , <http://model.geneontology.org/12136f4d-7c2d-4396-b67f-cc1e85d71372_RXN3O-786> ;
+                <http://model.geneontology.org/2e3cacbd-16d2-4c55-946e-13d84abc1f77_RXN3O-786> , <http://model.geneontology.org/CHEBI_15377_RXN3O-786> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-786> , <http://model.geneontology.org/2e73a549-5b3a-4640-bbdf-d647d2d9f9a8_RXN3O-786> ;
+                <http://model.geneontology.org/4b5ce7b8-576b-41a1-9195-55e88cc311aa_RXN3O-786> , <http://model.geneontology.org/CHEBI_43474_RXN3O-786> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR163W-MONOMER_RXN3O-786_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -4459,7 +4470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4473,7 +4484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4489,7 +4500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4502,7 +4513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4515,7 +4526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4531,7 +4542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4548,7 +4559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4561,7 +4572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4572,7 +4583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4587,7 +4598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4597,11 +4608,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9819_RO_0002234_156971bd-006c-487d-8b56-9711989c3bad_RXN3O-9819_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4609,7 +4620,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9819> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/49f93bbc-bd97-4fc2-a6ed-5db5862cad54_RXN3O-9819>
+          <http://model.geneontology.org/156971bd-006c-487d-8b56-9711989c3bad_RXN3O-9819>
 ] .
 
 <http://model.geneontology.org/reaction_3.1.4.11-RXN_location_lociGO_0005829>
@@ -4620,7 +4631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4631,7 +4642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4642,7 +4653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4650,6 +4661,17 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002333_MONOMER3O-64_RXN-7162_controller_SGD_PWY3O-402>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-402" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_30616_2.7.1.151-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -4660,7 +4682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4668,24 +4690,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-7162_RO_0002333_MONOMER3O-64_RXN-7162_controller_SGD_PWY3O-402>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-258_BFO_0000050_PWY3O-402/PWY3O-402_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4715,7 +4726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4728,7 +4739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4742,7 +4753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4759,7 +4770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4778,7 +4789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4794,7 +4805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4807,7 +4818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4821,7 +4832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4837,7 +4848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4848,7 +4859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4860,7 +4871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4877,7 +4888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4888,23 +4899,12 @@
           <http://model.geneontology.org/PWY3O-402/PWY3O-402>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3.1.4.11-RXN_RO_0002233_88a31b55-2c6e-4862-b8cf-a7fe8e5d0215_3.1.4.11-RXN_SGD_PWY3O-402>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-402" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN-7163_RO_0002234_CHEBI_15378_RXN-7163_SGD_PWY3O-402>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4916,7 +4916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4932,7 +4932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4943,7 +4943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4957,7 +4957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -4969,7 +4969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4985,11 +4985,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941_SGD_PWY3O-402> ;
+          <http://model.geneontology.org/ev_w_id_RXN-4941_RO_0002234_078ddd98-1635-4848-826e-e959157b9553_RXN-4941_SGD_PWY3O-402> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4997,7 +4997,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-4941> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/464eb323-58d1-4e82-8ac9-7dbf3e266557_RXN-4941>
+          <http://model.geneontology.org/078ddd98-1635-4848-826e-e959157b9553_RXN-4941>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -5008,7 +5008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5026,7 +5026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5042,7 +5042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-402" ;
         <http://purl.org/pav/providedBy>
@@ -5053,7 +5053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-402" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-402" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4031-PWY3O-4031.ttl
+++ b/models/PWY3O-4031-PWY3O-4031.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -267,11 +267,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668_SGD_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_4778ae1f-a4fe-41f8-a597-44b0293fbecc_RXN-7668_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -279,7 +279,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668>
+          <http://model.geneontology.org/4778ae1f-a4fe-41f8-a597-44b0293fbecc_RXN-7668>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002234_CHEBI_58885_GLUC1PURIDYLTRANS-RXN_SGD_PWY3O-4031>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -323,7 +323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -339,7 +339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -454,11 +454,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY3O-4031> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-7668_BFO_0000050_PWY3O-4031/PWY3O-4031_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,7 +491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -497,22 +514,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002234_GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_SGD_PWY3O-4031> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_90591782-8ed6-438e-bb17-16f9616a6dd7_RXN-7668_SGD_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -529,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -549,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -573,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -635,7 +646,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7669_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669> ;
+                <http://model.geneontology.org/93c19173-06d0-4fc1-8a15-6b85e7a2036b_RXN-7669> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_24384_RXN-7669> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -643,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -694,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -708,7 +719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -747,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -758,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -792,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -868,11 +879,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668_SGD_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_90591782-8ed6-438e-bb17-16f9616a6dd7_RXN-7668_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -880,7 +891,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7668> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668>
+          <http://model.geneontology.org/90591782-8ed6-438e-bb17-16f9616a6dd7_RXN-7668>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -891,7 +902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -907,7 +918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -922,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,6 +947,34 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_4778ae1f-a4fe-41f8-a597-44b0293fbecc_RXN-7668_SGD_PWY3O-4031>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/4778ae1f-a4fe-41f8-a597-44b0293fbecc_RXN-7668>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller>
         a       <http://identifiers.org/sgd/S000001004> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -943,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -956,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -964,11 +1003,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669_SGD_PWY3O-4031> ;
+          <http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_93c19173-06d0-4fc1-8a15-6b85e7a2036b_RXN-7669_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -976,7 +1015,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-7669> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669>
+          <http://model.geneontology.org/93c19173-06d0-4fc1-8a15-6b85e7a2036b_RXN-7669>
 ] .
 
 <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_RXN-7667>
@@ -986,7 +1025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,30 +1050,13 @@
           <http://model.geneontology.org/PWY3O-4031/PWY3O-4031>
 ] .
 
-<http://model.geneontology.org/5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002333_YHL012W-MONOMER_GLUC1PURIDYLTRANS-RXN_controller_SGD_PWY3O-4031> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,7 +1076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1082,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1102,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1155,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1169,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1186,7 +1208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1224,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,12 +1260,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_RXN-7667_SGD_PWY3O-4031> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-7667> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_RXN-7667>
+] .
+
 <http://model.geneontology.org/ev_w_id_GLUC1PURIDYLTRANS-RXN_RO_0002413_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_null_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1268,34 +1307,6 @@
           <http://model.geneontology.org/GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-7667_RO_0002233_GLUCOSYL-GLYCOGENIN_RXN-7667_SGD_PWY3O-4031> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-7667> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/GLUCOSYL-GLYCOGENIN_RXN-7667>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002234_5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668_SGD_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CPD-7010_RXN-7667>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_33695> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1305,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1318,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1333,24 +1344,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51306> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7668_RO_0002233_2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668_SGD_PWY3O-4031>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1360,7 +1360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1377,7 +1377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1398,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1415,7 +1415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1432,7 +1432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1460,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1488,7 +1488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1508,13 +1508,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51282> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.org/dc/elements/1.1/contributor>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15378_RXN-7667>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1525,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1533,8 +1536,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.org/dc/elements/1.1/contributor>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+<http://model.geneontology.org/93c19173-06d0-4fc1-8a15-6b85e7a2036b_RXN-7669>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000001518>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1546,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1559,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1574,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1602,7 +1619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,18 +1635,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/90591782-8ed6-438e-bb17-16f9616a6dd7_RXN-7668>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a glucosylated glycogenin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_RO_0002413_RXN-7667_null_PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1650,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1666,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1693,7 +1727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1710,7 +1744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1730,7 +1764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1743,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1754,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1766,7 +1800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1785,7 +1819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1801,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1816,7 +1850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1836,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1849,39 +1883,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669_SGD_PWY3O-4031>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4031" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/194b3f81-1dd9-4368-bc72-695c1ef9b806_RXN-7669>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1889,7 +1895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1906,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1942,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1955,7 +1961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1968,7 +1974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -1989,7 +1995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2009,9 +2015,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-7668_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668> , <http://model.geneontology.org/CHEBI_58885_RXN-7668> ;
+                <http://model.geneontology.org/CHEBI_58885_RXN-7668> , <http://model.geneontology.org/90591782-8ed6-438e-bb17-16f9616a6dd7_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_58223_RXN-7668> , <http://model.geneontology.org/5c73235b-179e-4c51-ab8c-5fe6ae0de253_RXN-7668> ;
+                <http://model.geneontology.org/4778ae1f-a4fe-41f8-a597-44b0293fbecc_RXN-7668> , <http://model.geneontology.org/CHEBI_58223_RXN-7668> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR258W-MONOMER_RXN-7668_controller> , <http://model.geneontology.org/YFR015C-MONOMER_RXN-7668_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2019,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2034,7 +2040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2051,7 +2057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,7 +2071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,7 +2091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2105,7 +2111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2123,7 +2129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,7 +2143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2170,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2183,7 +2189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2194,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2216,7 +2222,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4031" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-7669_RO_0002233_93c19173-06d0-4fc1-8a15-6b85e7a2036b_RXN-7669_SGD_PWY3O-4031>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2228,7 +2245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2244,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2262,7 +2279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2273,23 +2290,6 @@
           <http://model.geneontology.org/MONOMER3O-4054_GLYCOGENIN-GLUCOSYLTRANSFERASE-RXN_controller>
 ] .
 
-<http://model.geneontology.org/2fed7535-b0e7-421c-bee5-eb15d3c7d03e_RXN-7668>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a glucosylated glycogenin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4031SmallMolecule51367> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/PWY3O-4031>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2299,7 +2299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycogen biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2314,7 +2314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2327,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>
@@ -2341,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4031" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4031" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4105-PWY3O-4105.ttl
+++ b/models/PWY3O-4105-PWY3O-4105.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -237,7 +237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -319,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -389,7 +389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -511,7 +511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "valine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -680,7 +680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -695,7 +695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -874,7 +874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -890,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -994,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1105,13 +1105,16 @@
 <http://purl.obolibrary.org/obo/CHEBI_46645>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_48943>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-4133_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1122,15 +1125,12 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_48943>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-4133_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-4105>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1261,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1310,7 +1310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1327,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1397,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1437,7 +1437,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4105" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_null_PWY3O-4105>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1448,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1471,24 +1482,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002413_RXN3O-4133_null_PWY3O-4105>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4105" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-4133_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-4105> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1504,7 +1504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1535,7 +1535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4105" ;
         <http://purl.org/pav/providedBy>
@@ -1566,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4105" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-4106-PWY3O-4106.ttl
+++ b/models/PWY3O-4106-PWY3O-4106.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway IV (from nicotinamide riboside) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -283,7 +283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -432,7 +432,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -449,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -717,7 +717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -833,7 +833,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,30 +858,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106BiochemicalReaction69520> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69466> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_456216_RIBOSYLNICOTINAMIDE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_456216> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -892,11 +875,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69509> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_30616_2.7.7.1-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4106SmallMolecule69466> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4106" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4106" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4107-PWY3O-4107.ttl
+++ b/models/PWY3O-4107-PWY3O-4107.ttl
@@ -1,10 +1,10 @@
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025_SGD_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_cf75acb1-9654-45ad-aeb3-430b2a9233ce_RXN-15025_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -12,7 +12,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025>
+          <http://model.geneontology.org/cf75acb1-9654-45ad-aeb3-430b2a9233ce_RXN-15025>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_29985>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -78,7 +78,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -383,11 +383,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025_SGD_PWY3O-4107> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_99e214c2-3668-410d-8c04-28a275755a6e_RXN-15025_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025>
+          <http://model.geneontology.org/99e214c2-3668-410d-8c04-28a275755a6e_RXN-15025>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -404,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,9 +424,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> , <http://model.geneontology.org/cf75acb1-9654-45ad-aeb3-430b2a9233ce_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/99e214c2-3668-410d-8c04-28a275755a6e_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -538,7 +538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -613,7 +613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,30 +646,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107BiochemicalReaction70037> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4107> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_32544_NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_32544> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -680,11 +663,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule70027> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_58359_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4107> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/NAD-SYNTH-GLN-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
+] .
+
+<http://model.geneontology.org/99e214c2-3668-410d-8c04-28a275755a6e_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -696,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -751,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -814,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -854,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -884,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -896,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,7 +952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -949,26 +966,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller>
-        a       <http://identifiers.org/sgd/S000002200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD-dependent histone deacetylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107Protein69996> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -976,7 +978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,22 +989,20 @@
           <http://model.geneontology.org/CHEBI_17154_RXN-15025>
 ] .
 
-<http://model.geneontology.org/60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller>
+        a       <http://identifiers.org/sgd/S000002200> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
+                "NAD-dependent histone deacetylase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69962> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107Protein69996> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1038,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1068,7 +1068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1080,7 +1080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1096,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1170,24 +1170,13 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_60b25195-87e8-4fec-92f4-b13a6cb61aba_RXN-15025_SGD_PWY3O-4107>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_PWY3O-4107/PWY3O-4107_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1206,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1234,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1268,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1280,7 +1269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1300,7 +1289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1316,7 +1305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1370,7 +1359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1386,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1404,7 +1393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1421,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1434,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1446,7 +1435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1462,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1474,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1506,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1552,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1569,7 +1558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1583,7 +1572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,7 +1608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1635,7 +1624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1650,7 +1639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1667,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1684,7 +1673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1700,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1711,7 +1700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1723,7 +1712,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1734,6 +1723,17 @@
           <http://model.geneontology.org/YGR010W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_cf75acb1-9654-45ad-aeb3-430b2a9233ce_RXN-15025_SGD_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57502_NICOTINATEPRIBOSYLTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57502> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1743,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1757,7 +1757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1788,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,13 +1796,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_99e214c2-3668-410d-8c04-28a275755a6e_RXN-15025_SGD_PWY3O-4107>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4107" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_CHEBI_83767_RXN-15025_SGD_PWY3O-4107> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,7 +1878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1881,7 +1892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1897,7 +1908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1925,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1938,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -1950,7 +1961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1970,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1984,7 +1995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2009,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2020,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +2046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "NAD salvage pathway V (PNC V cycle) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2091,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,7 +2119,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2128,7 +2139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2145,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2159,7 +2170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2209,13 +2220,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107BiochemicalReaction69999> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/cf75acb1-9654-45ad-aeb3-430b2a9233ce_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000003005>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2225,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2239,7 +2267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2255,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2267,7 +2295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2285,7 +2313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,7 +2327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2315,7 +2343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2326,7 +2354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2339,7 +2367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2352,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2364,7 +2392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2381,7 +2409,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2392,23 +2420,12 @@
           <http://model.geneontology.org/CHEBI_29888_NICONUCADENYLYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025_SGD_PWY3O-4107>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4107" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_RO_0002233_CHEBI_32544_NICOTINATEPRIBOSYLTRANS-RXN_SGD_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2425,35 +2442,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/fe70721b-1604-48e0-ae5e-f7c9c18e5ef1_RXN-15025>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4107SmallMolecule69955> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002413_NICOTINAMID-RXN_null_PWY3O-4107>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>
@@ -2464,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4107" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4107" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4108-PWY3O-4108.ttl
+++ b/models/PWY3O-4108-PWY3O-4108.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -36,7 +36,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -50,7 +50,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -241,7 +241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -453,7 +453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tyrosine degradation III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -485,7 +485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -578,7 +578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -592,7 +592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -609,7 +609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,7 +625,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -781,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,7 +876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -955,7 +955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +1004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1086,7 +1086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1119,7 +1119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1130,7 +1130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1142,7 +1142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,7 +1159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1195,7 +1195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1319,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,7 +1352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1363,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1385,7 +1385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1402,7 +1402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,7 +1433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1461,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1497,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1509,7 +1509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1531,7 +1531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1548,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1559,7 +1559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>
@@ -1571,7 +1571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1588,7 +1588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1604,7 +1604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1617,7 +1617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1634,7 +1634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1669,7 +1669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1705,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4108" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4108" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4109-PWY3O-4109.ttl
+++ b/models/PWY3O-4109-PWY3O-4109.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -155,7 +155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -228,7 +228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -258,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -360,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -376,7 +376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -453,7 +453,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +599,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -690,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -722,7 +722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,7 +785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -805,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -835,7 +835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -883,7 +883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -934,7 +934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -970,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -993,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "isoleucine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1167,7 +1167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1196,7 +1196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1222,7 +1222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1332,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1345,7 +1345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1449,7 +1449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1462,7 +1462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1474,7 +1474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/4.1.1.72-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0047433> ;
+        a       <http://purl.obolibrary.org/obo/GO_0047433> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
                 "(<i>S</i>)-3-methyl-2-oxopentanoate + H<SUP>+</SUP> &rarr; 2-methylbutanal + CO<SUB>2</SUB>" ;
         <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -1535,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1548,7 +1548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1560,7 +1560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1593,7 +1593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1603,7 +1603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1636,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1666,7 +1666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1702,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1714,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>
@@ -1756,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4109" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4109" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4112-PWY3O-4112.ttl
+++ b/models/PWY3O-4112-PWY3O-4112.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -125,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -389,7 +389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,7 +505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -541,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -558,7 +558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -669,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "leucine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -711,24 +711,13 @@
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4109_SGD_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002333_CPLX3O-71_RXN3O-4108_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -739,13 +728,24 @@
           <http://model.geneontology.org/CPLX3O-71_RXN3O-4108_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4109_RO_0002233_CHEBI_16638_RXN3O-4109_SGD_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002333_YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -785,7 +785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -819,7 +819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -866,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -902,7 +902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -914,7 +914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -925,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1012,7 +1012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1030,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1044,7 +1044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1072,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1172,30 +1172,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY3O-4112>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4112" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_RO_0002234_CHEBI_29985_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_SGD_PWY3O-4112>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-4108_RO_0002234_CHEBI_16526_RXN3O-4108_SGD_PWY3O-4112>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1250,7 +1250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1298,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1329,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1346,7 +1346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,17 +1366,6 @@
 <http://identifiers.org/sgd/S000001251>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_null_PWY3O-4112>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4112" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YJR148W-MONOMER_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003909> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1384,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1392,13 +1381,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_BFO_0000066_reaction_BRANCHED-CHAINAMINOTRANSFERLEU-RXN_location_lociGO_0005829_null_PWY3O-4112>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4112" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-110_RXN3O-4108_controller_BFO_0000051_SGD_S000002238_CPLX3O-110_component_SGD_PWY3O-4112> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4112" ;
         <http://purl.org/pav/providedBy>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4112" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-4115-PWY3O-4115.ttl
+++ b/models/PWY3O-4115-PWY3O-4115.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -47,7 +47,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -168,7 +168,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -337,7 +337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -364,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -650,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -766,7 +766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,7 +928,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1038,7 +1038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1072,7 +1072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1133,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1174,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1199,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,7 +1219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1264,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,7 +1283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1319,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1330,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1342,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1370,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1408,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,7 +1455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1464,7 +1464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1491,7 +1491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1539,7 +1539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1555,7 +1555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1567,7 +1567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1604,7 +1604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1633,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1647,7 +1647,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1664,7 +1664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1707,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1721,7 +1721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1761,7 +1761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1825,7 +1825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,7 +1841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -1853,7 +1853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1892,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1906,7 +1906,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1922,7 +1922,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1938,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1952,7 +1952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +2013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2024,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2039,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2056,7 +2056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2075,7 +2075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4115" ;
         <http://purl.org/pav/providedBy>
@@ -2088,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4115" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-4120-PWY3O-4120.ttl
+++ b/models/PWY3O-4120-PWY3O-4120.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -26,7 +26,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -301,7 +301,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -341,7 +341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -535,7 +535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -551,7 +551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -597,7 +597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tyrosine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -631,7 +631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -697,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -722,7 +722,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -740,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -753,7 +753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -781,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -932,7 +932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -967,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1029,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1111,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1152,7 +1152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1215,7 +1215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1311,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1323,7 +1323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,7 +1342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1358,14 +1358,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0004665>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1373,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,6 +1380,9 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_36242_PREPHENATE-DEHYDROGENASE-NADP+-RXN>
 ] .
+
+<http://purl.obolibrary.org/obo/GO_0004665>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://purl.obolibrary.org/obo/CHEBI_16810>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1396,7 +1396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1460,7 +1460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1487,7 +1487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4120" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4120" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-4153-PWY3O-4153.ttl
+++ b/models/PWY3O-4153-PWY3O-4153.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -25,7 +25,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -38,7 +38,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -51,7 +51,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -210,7 +210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -289,7 +289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -452,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -475,7 +475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -503,7 +503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -603,7 +603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -651,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -690,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -754,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -765,7 +765,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phenylalanine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -873,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -942,7 +942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -961,7 +961,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -981,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -995,7 +995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1011,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1028,7 +1028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1042,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1057,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1103,7 +1103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1154,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1184,7 +1184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1196,8 +1196,22 @@
 <http://identifiers.org/sgd/S000001378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000050> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CHORISMATEMUT-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
+] .
 
 <http://model.geneontology.org/CPLX-9432_RXN-10814_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1208,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1222,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1238,28 +1252,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORISMATEMUT-RXN_BFO_0000050_PWY3O-4153/PWY3O-4153_SGD_PWY3O-4153> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000050> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CHORISMATEMUT-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/PWY3O-4153/PWY3O-4153>
-] .
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/RXN-10814>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004400> ;
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4153" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1385,7 +1385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1402,7 +1402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1445,7 +1445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1482,7 +1482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1519,7 +1519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4153" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-4158-PWY3O-4158.ttl
+++ b/models/PWY3O-4158-PWY3O-4158.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -68,7 +68,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -82,7 +82,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -135,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -203,7 +203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of NAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -287,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,41 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "formate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35838> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/GO_0008936>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -346,7 +380,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -356,40 +390,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-4158/PWY3O-4158>
 ] .
-
-<http://purl.obolibrary.org/obo/GO_0008936>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_15740_ARYLFORMAMIDASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15740> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "formate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35838> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_2.7.7.1-RXN_RO_0002333_YLR328W-MONOMER_2.7.7.1-RXN_controller_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -403,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,28 +413,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,23 +426,6 @@
           <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-4158/PWY3O-4158>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-8443> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57502_RXN-8443>
 ] .
 
 <http://model.geneontology.org/CHEBI_58359_NAD-SYNTH-GLN-RXN>
@@ -471,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -479,16 +445,50 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002234_CHEBI_57502_RXN-8443_SGD_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-8443> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57502_RXN-8443>
+] .
+
 <http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002233_CHEBI_30616_NAD-SYNTH-GLN-RXN_SGD_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_57540_RXN-15025>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
@@ -499,7 +499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,35 +516,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35799> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_null_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_2.7.7.1-RXN_null_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -554,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,13 +543,35 @@
           <http://model.geneontology.org/NICONUCADENYLYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002413_2.7.7.1-RXN_null_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_NICOTINAMID-RXN_RO_0002413_NICOTINATEPRIBOSYLTRANS-RXN_null_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002233_CHEBI_58527_RXN3O-214_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -648,7 +648,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_8491236c-e29b-43e6-9876-c9fde6e10857_RXN-15025_SGD_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -662,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -699,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -729,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -775,7 +786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -786,7 +797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -811,7 +822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -873,7 +884,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -903,7 +914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -949,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -960,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1059,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1128,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1145,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,7 +1170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1203,7 +1214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1218,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1240,7 +1251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1260,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1274,7 +1285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1307,7 +1318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1344,17 +1355,6 @@
           <http://model.geneontology.org/CHEBI_16675_QUINOPRIBOTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_36559_3-HYDROXY-KYNURENINASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_36559> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1381,7 +1381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1395,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1432,7 +1432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1445,7 +1445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1468,7 +1468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1484,7 +1484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1542,7 +1542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1561,7 +1561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1578,13 +1578,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_NICOTINATEPRIBOSYLTRANS-RXN_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,23 +1606,12 @@
           <http://model.geneontology.org/PWY3O-4158/PWY3O-4158>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_57502_NICONUCADENYLYLTRAN-RXN_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002234_CHEBI_57972_3-HYDROXY-KYNURENINASE-RXN_SGD_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1627,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1668,7 +1668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1683,6 +1683,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_null_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YOR209C-MONOMER_NICOTINATEPRIBOSYLTRANS-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005735> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1690,24 +1701,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35528> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/ev_w_id_NAD-SYNTH-GLN-RXN_RO_0002413_2.7.7.1-RXN_null_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1717,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1734,7 +1734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1773,7 +1773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1787,7 +1787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1804,7 +1804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1845,7 +1845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1856,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1868,7 +1868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1887,7 +1887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1903,18 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1925,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1938,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1951,7 +1940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1962,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -1977,7 +1966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1993,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +1997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2054,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2067,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2082,7 +2071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2115,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2126,7 +2115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2138,7 +2127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2154,7 +2143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2168,7 +2157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2185,7 +2174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2203,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2216,7 +2205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2227,7 +2216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2238,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2249,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2264,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2278,7 +2267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2298,7 +2287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2321,7 +2310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,29 +2321,12 @@
 <http://identifiers.org/sgd/S000005073>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002333> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
-] .
-
 <http://model.geneontology.org/ev_w_id_RXN-8443_RO_0002233_CHEBI_30616_RXN-8443_SGD_PWY3O-4158>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2365,11 +2337,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_KYNURENINE-3-MONOOXYGENASE-RXN_RO_0002333_YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller_SGD_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002333> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/KYNURENINE-3-MONOOXYGENASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/YBL098W-MONOMER_KYNURENINE-3-MONOOXYGENASE-RXN_controller>
+] .
 
 <http://model.geneontology.org/CHEBI_29888_2.7.7.1-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29888> ;
@@ -2380,45 +2369,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35400> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/CHEBI_57540_2.7.7.1-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NAD<sup>+</sup>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35385> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2428,7 +2383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2439,6 +2394,23 @@
           <http://model.geneontology.org/RXN3O-214>
 ] .
 
+<http://model.geneontology.org/CHEBI_57540_2.7.7.1-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57540> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NAD<sup>+</sup>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35385> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_16988>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2447,28 +2419,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [histone]-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2476,7 +2431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2493,7 +2448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2509,7 +2464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2547,7 +2502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2562,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2576,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2596,7 +2551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2616,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2633,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2650,7 +2605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2667,7 +2622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2683,7 +2638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2694,7 +2649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2709,7 +2664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2729,7 +2684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2748,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2763,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,12 +2729,23 @@
           <http://model.geneontology.org/CHEBI_58017_QUINOPRIBOTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_4547783f-87c6-4836-adf7-f91525cf4828_RXN-15025_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002333_YLR328W-MONOMER_NICONUCADENYLYLTRAN-RXN_controller_SGD_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2794,7 +2760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2813,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2825,7 +2791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,7 +2808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2858,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2870,7 +2836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2889,7 +2855,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2912,7 +2878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2925,7 +2891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2936,7 +2902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -2952,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2966,7 +2932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2983,7 +2949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3000,7 +2966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3016,7 +2982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3030,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3041,7 +3007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3052,7 +3018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3066,7 +3032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3083,7 +3049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3099,7 +3065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3113,7 +3079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3130,7 +3096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3162,16 +3128,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158BiochemicalReaction35589> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://purl.obolibrary.org/obo/RO_0002234>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_17154_NICOTINAMID-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_17154> ;
@@ -3182,13 +3145,16 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35433> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://purl.obolibrary.org/obo/RO_0002234>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_30616_RXN-8443>
         a       <http://purl.obolibrary.org/obo/CHEBI_30616> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3199,7 +3165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3213,7 +3179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3230,7 +3196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3269,7 +3235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3280,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3295,7 +3261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3308,30 +3274,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
-] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-7092>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3342,7 +3289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3351,12 +3298,31 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_QUINOPRIBOTRANS-RXN_BFO_0000066_reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829_null_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/QUINOPRIBOTRANS-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_QUINOPRIBOTRANS-RXN_location_lociGO_0005829>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-214_RO_0002234_CHEBI_32544_RXN3O-214_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3376,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3389,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3400,7 +3366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3415,7 +3381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3428,7 +3394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3443,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3456,7 +3422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3471,7 +3437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3484,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3495,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3509,7 +3475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3526,7 +3492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3542,7 +3508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3556,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3571,7 +3537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3589,26 +3555,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35335> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
-<http://model.geneontology.org/YLR209C-MONOMER_RXN0-7092_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004199> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "purine nucleoside phosphorylase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35302> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
@@ -3617,11 +3568,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YLR209C-MONOMER_RXN0-7092_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000004199> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "purine nucleoside phosphorylase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158Protein35302> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_32544_RXN3O-205>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_32544> ;
@@ -3632,7 +3598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3645,7 +3611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3662,7 +3628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3678,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3689,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3700,7 +3666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3715,7 +3681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3733,7 +3699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3741,12 +3707,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_PWY3O-4158>
+<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3761,7 +3727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3769,24 +3735,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-15025_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RIBOSYLNICOTINAMIDE-KINASE-RXN_RO_0002234_CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3797,13 +3752,24 @@
           <http://model.geneontology.org/CHEBI_14649_RIBOSYLNICOTINAMIDE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002333_MONOMER3O-4152_RXN-15025_controller_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-8441_RO_0002233_CHEBI_15377_RXN-8441_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3819,20 +3785,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3845,13 +3800,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35560> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_BFO_0000050_PWY3O-4158/PWY3O-4158_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_58527_RXN3O-214>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58527> ;
@@ -3862,7 +3828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3887,7 +3853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3900,7 +3866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3915,7 +3881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3931,7 +3897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3945,7 +3911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3961,7 +3927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3978,7 +3944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -3989,7 +3955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4000,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4014,7 +3980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4033,7 +3999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4053,7 +4019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4066,7 +4032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4081,7 +4047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4094,11 +4060,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025_SGD_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002234_4547783f-87c6-4836-adf7-f91525cf4828_RXN-15025_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4106,7 +4072,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025>
+          <http://model.geneontology.org/4547783f-87c6-4836-adf7-f91525cf4828_RXN-15025>
 ] .
 
 <http://purl.obolibrary.org/obo/GO_0004502>
@@ -4118,7 +4084,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4135,7 +4101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4173,7 +4139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4186,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4197,7 +4163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4209,7 +4175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4225,7 +4191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4237,7 +4203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4257,7 +4223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4275,7 +4241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4295,7 +4261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4312,7 +4278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4328,7 +4294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4348,7 +4314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4378,7 +4344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4391,7 +4357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4402,7 +4368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4417,7 +4383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4431,7 +4397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4450,7 +4416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4462,7 +4428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4478,7 +4444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4493,7 +4459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4506,7 +4472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4521,7 +4487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4534,7 +4500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4546,7 +4512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4566,7 +4532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4579,7 +4545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4590,7 +4556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4601,7 +4567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4621,7 +4587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4638,7 +4604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4654,7 +4620,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4669,7 +4635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4682,7 +4648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4694,7 +4660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4710,7 +4676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4722,7 +4688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4742,7 +4708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4762,7 +4728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4775,7 +4741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4786,7 +4752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4798,7 +4764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4817,7 +4783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4837,7 +4803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4854,11 +4820,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35318> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/8491236c-e29b-43e6-9876-c9fde6e10857_RXN-15025>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-N<sup>6</sup>-acetyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35457> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -4867,7 +4850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -4878,30 +4861,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1.13.11.6-RXN>
-] .
+<http://model.geneontology.org/4547783f-87c6-4836-adf7-f91525cf4828_RXN-15025>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [histone]-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35464> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY3O-4158>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4909,7 +4901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4920,16 +4912,24 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-5721>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002234_CHEBI_58437_NICONUCADENYLYLTRAN-RXN_SGD_PWY3O-4158>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation '3-hydroxy-L-kynurenine + H<sub>2</sub>O &rarr; 3-hydroxyanthranilate + L-alanine + H<SUP>+</SUP>' 'null' '3-hydroxyanthranilate + oxygen &rarr; 2-amino-3-carboxymuconate-6-semialdehyde + H<SUP>+</SUP>' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_3-HYDROXY-KYNURENINASE-RXN_RO_0002413_1.13.11.6-RXN_null_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/3-HYDROXY-KYNURENINASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/1.13.11.6-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57502>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -4940,7 +4940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4960,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4987,7 +4987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5004,7 +5004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5020,7 +5020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5031,7 +5031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5042,7 +5042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5057,7 +5057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5071,7 +5071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5091,7 +5091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5108,7 +5108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5127,7 +5127,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5147,7 +5147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5160,7 +5160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5171,7 +5171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5182,7 +5182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5194,7 +5194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5214,7 +5214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5231,7 +5231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5251,7 +5251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5265,7 +5265,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5281,7 +5281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5292,7 +5292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5306,7 +5306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5326,7 +5326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5342,7 +5342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5353,7 +5353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5364,7 +5364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5376,7 +5376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5393,7 +5393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5412,7 +5412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5430,7 +5430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5447,7 +5447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5468,7 +5468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5483,7 +5483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5497,7 +5497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5514,7 +5514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5533,7 +5533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5544,7 +5544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5555,7 +5555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5570,7 +5570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5587,7 +5587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5603,7 +5603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5619,7 +5619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5636,7 +5636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5663,7 +5663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5690,7 +5690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5704,7 +5704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5727,7 +5727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5743,7 +5743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5755,7 +5755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5771,7 +5771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5783,7 +5783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5809,7 +5809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5822,7 +5822,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5840,7 +5840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5860,7 +5860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5877,7 +5877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5904,7 +5904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5924,7 +5924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5940,7 +5940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5954,7 +5954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -5968,7 +5968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5985,7 +5985,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6005,7 +6005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6022,7 +6022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6038,7 +6038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6058,7 +6058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6075,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6091,7 +6091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6111,7 +6111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6124,7 +6124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6135,7 +6135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6147,7 +6147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6164,7 +6164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6194,7 +6194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6211,7 +6211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6229,7 +6229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6249,7 +6249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6263,7 +6263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6280,7 +6280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6296,7 +6296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6311,7 +6311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6328,7 +6328,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6345,7 +6345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6358,7 +6358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6370,7 +6370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6387,7 +6387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6407,7 +6407,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6420,7 +6420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6435,7 +6435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6443,16 +6443,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_PWY3O-4158>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<SUP>+</SUP>" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4158" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -6462,7 +6468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6479,7 +6485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6495,28 +6501,22 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/CHEBI_15378_KYNURENINE-3-MONOOXYGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<SUP>+</SUP>" ;
+<http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002233_CHEBI_58629_ARYLFORMAMIDASE-RXN_SGD_PWY3O-4158>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35211> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_994_RXN-5721>
         a       <http://purl.obolibrary.org/obo/CHEBI_994> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -6527,30 +6527,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-4158SmallMolecule35543> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY3O-4158> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
-] .
 
 <http://model.geneontology.org/reaction_RXN3O-205_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
@@ -6564,7 +6547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6572,12 +6555,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ARYLFORMAMIDASE-RXN_RO_0002234_CHEBI_15378_ARYLFORMAMIDASE-RXN_SGD_PWY3O-4158> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ARYLFORMAMIDASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_ARYLFORMAMIDASE-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_NICONUCADENYLYLTRAN-RXN_RO_0002233_CHEBI_15378_NICONUCADENYLYLTRAN-RXN_SGD_PWY3O-4158>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6588,7 +6588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6603,7 +6603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6616,7 +6616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6633,7 +6633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6653,7 +6653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6670,7 +6670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6685,7 +6685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6702,7 +6702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6716,7 +6716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6739,7 +6739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6758,7 +6758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6769,7 +6769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6781,7 +6781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6798,7 +6798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6824,7 +6824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6838,7 +6838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6854,7 +6854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6869,7 +6869,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6889,7 +6889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6903,7 +6903,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6920,7 +6920,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6936,7 +6936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6951,7 +6951,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6968,7 +6968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6984,7 +6984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -6995,7 +6995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7009,7 +7009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7028,7 +7028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7044,7 +7044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7055,7 +7055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7069,7 +7069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7081,7 +7081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7100,7 +7100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7123,7 +7123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7138,7 +7138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7151,7 +7151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7163,7 +7163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7196,7 +7196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7212,7 +7212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7228,7 +7228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7246,9 +7246,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-15025_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> ;
+                <http://model.geneontology.org/CHEBI_15377_RXN-15025> , <http://model.geneontology.org/CHEBI_57540_RXN-15025> , <http://model.geneontology.org/8491236c-e29b-43e6-9876-c9fde6e10857_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/d937c608-6ac1-488f-89bb-4241df948e30_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
+                <http://model.geneontology.org/4547783f-87c6-4836-adf7-f91525cf4828_RXN-15025> , <http://model.geneontology.org/CHEBI_17154_RXN-15025> , <http://model.geneontology.org/CHEBI_83767_RXN-15025> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4152_RXN-15025_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -7256,7 +7256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7289,7 +7289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7302,7 +7302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7320,7 +7320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7334,7 +7334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7350,7 +7350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7365,7 +7365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7382,7 +7382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7401,7 +7401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7416,7 +7416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7433,7 +7433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7456,7 +7456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7469,7 +7469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7481,7 +7481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7498,7 +7498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7518,7 +7518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7535,7 +7535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7548,7 +7548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7560,7 +7560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7592,7 +7592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7606,7 +7606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7622,7 +7622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7633,7 +7633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7645,7 +7645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7663,7 +7663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7677,7 +7677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7693,7 +7693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7707,7 +7707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7725,7 +7725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7738,7 +7738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7750,7 +7750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7767,7 +7767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7780,11 +7780,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025_SGD_PWY3O-4158> ;
+          <http://model.geneontology.org/ev_w_id_RXN-15025_RO_0002233_8491236c-e29b-43e6-9876-c9fde6e10857_RXN-15025_SGD_PWY3O-4158> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7792,7 +7792,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-15025> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/67b64d91-ead9-40cd-ab60-5bc1345d57ee_RXN-15025>
+          <http://model.geneontology.org/8491236c-e29b-43e6-9876-c9fde6e10857_RXN-15025>
 ] .
 
 <http://model.geneontology.org/CHEBI_15379_KYNURENINE-3-MONOOXYGENASE-RXN>
@@ -7804,7 +7804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7831,7 +7831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7848,7 +7848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7861,7 +7861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7873,7 +7873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7891,7 +7891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7908,7 +7908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7938,7 +7938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7952,7 +7952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7969,7 +7969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7985,7 +7985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -7997,7 +7997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8013,7 +8013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>
@@ -8028,7 +8028,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8043,7 +8043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8056,7 +8056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4158" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4158" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-4300-PWY3O-4300.ttl
+++ b/models/PWY3O-4300-PWY3O-4300.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -67,7 +67,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -117,7 +117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -134,7 +134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "ethanol degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -559,7 +559,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -734,7 +734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -837,7 +837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -854,7 +854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -889,7 +889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -905,7 +905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -927,7 +927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -968,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1024,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1044,7 +1044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1120,7 +1120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1138,7 +1138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1151,7 +1151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1172,7 +1172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1214,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1293,18 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_57540_RXN66-3_SGD_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1312,6 +1301,17 @@
 
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002233_CHEBI_57540_RXN66-3_SGD_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1379,7 +1379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,24 +1407,13 @@
           <http://model.geneontology.org/CHEBI_29888_ACETATE--COA-LIGASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY3O-4300>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-4300" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN66-3_RO_0002234_CHEBI_15378_RXN66-3_SGD_PWY3O-4300> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1435,6 +1424,17 @@
           <http://model.geneontology.org/CHEBI_15378_RXN66-3>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ALCOHOL-DEHYDROG-RXN_RO_0002333_YMR303C-MONOMER_ALCOHOL-DEHYDROG-RXN_controller_SGD_PWY3O-4300>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-4300" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_ACETATE--COA-LIGASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1486,7 +1486,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>
@@ -1519,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1541,7 +1541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-4300" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-4300" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-440-PWY3O-440.ttl
+++ b/models/PWY3O-440-PWY3O-440.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,13 +37,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022> ;
+                <http://model.geneontology.org/ee055293-f8b7-4f05-a93b-4cb1832a84f9_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -54,29 +54,12 @@
 <http://identifiers.org/sgd/S000004034>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_CHEBI_16526_RXN0-2022_SGD_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -186,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -206,24 +189,13 @@
 <http://purl.obolibrary.org/obo/BFO_0000051>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002233_CHEBI_15343_RXN0-2022_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -234,6 +206,17 @@
           <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN3O-470_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -243,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -257,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -288,7 +271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -365,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -377,7 +360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -405,6 +388,17 @@
           <http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_0d11f79a-e86f-44b6-9540-7c2ee285a7ee_RXN3O-470_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-118_RXN-6161_controller>
         a       <http://purl.obolibrary.org/obo/GO_0032991> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -414,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,7 +422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -438,6 +432,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
 ] .
+
+<http://model.geneontology.org/ee055293-f8b7-4f05-a93b-4cb1832a84f9_RXN0-2022>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37543> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -453,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -462,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -476,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -537,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -613,7 +624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -629,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -661,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -672,13 +683,24 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-6161>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_ee055293-f8b7-4f05-a93b-4cb1832a84f9_RXN0-2022_SGD_PWY3O-440>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-440" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-118_RXN3O-470_controller_BFO_0000051_SGD_S000004034_CPLX3O-118_component_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -711,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -719,11 +741,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_ee055293-f8b7-4f05-a93b-4cb1832a84f9_RXN0-2022_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -731,7 +753,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022>
+          <http://model.geneontology.org/ee055293-f8b7-4f05-a93b-4cb1832a84f9_RXN0-2022>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002233>
@@ -742,7 +764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -757,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyruvate fermentation to acetoin III - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -776,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -788,7 +810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,11 +823,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470_SGD_PWY3O-440> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_0d11f79a-e86f-44b6-9540-7c2ee285a7ee_RXN3O-470_SGD_PWY3O-440> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +835,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470>
+          <http://model.geneontology.org/0d11f79a-e86f-44b6-9540-7c2ee285a7ee_RXN3O-470>
 ] .
 
 <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
@@ -825,7 +847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -844,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -873,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -927,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,22 +957,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/CHEBI_15343_RXN-6161>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetaldehyde" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY3O-440> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN-6161> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
+] .
 
 <http://model.geneontology.org/RXN3O-470>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -963,7 +985,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470> ;
+                <http://model.geneontology.org/0d11f79a-e86f-44b6-9540-7c2ee285a7ee_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -971,7 +993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -979,22 +1001,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY3O-440> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN-6161> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15361_RXN-6161>
-] .
+<http://model.geneontology.org/CHEBI_15343_RXN-6161>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15343> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetaldehyde" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-440SmallMolecule37534> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1002,7 +1024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1045,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1057,7 +1079,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1149,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1164,7 +1186,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1191,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1203,7 +1225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,17 +1245,6 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_055d88af-02a5-4df6-8370-18a13db90f13_RXN3O-470_SGD_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_15343_RXN0-2022>
         a       <http://purl.obolibrary.org/obo/CHEBI_15343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1243,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,15 +1262,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/CHEBI_15361>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1274,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,11 +1314,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_15361>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1318,7 +1329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1329,7 +1340,7 @@
           <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
 ] .
 
-<http://model.geneontology.org/5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022>
+<http://model.geneontology.org/0d11f79a-e86f-44b6-9540-7c2ee285a7ee_RXN3O-470>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
@@ -1338,7 +1349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1352,7 +1363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1372,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1397,23 +1408,12 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_5e9aa04c-27de-4334-8916-7d92d93f6834_RXN0-2022_SGD_PWY3O-440>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-440" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-470_BFO_0000066_reaction_RXN3O-470_location_lociGO_0005829_null_PWY3O-440>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1452,7 +1452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1475,7 +1475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1492,7 +1492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1549,7 +1549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1583,7 +1583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1610,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-440" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-440" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-45-PWY3O-45.ttl
+++ b/models/PWY3O-45-PWY3O-45.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -89,7 +89,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -207,7 +207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -224,7 +224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -240,7 +240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -377,7 +377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -444,7 +444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -564,7 +564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -578,7 +578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -724,12 +724,40 @@
 <http://purl.obolibrary.org/obo/CHEBI_456215>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/0fd404cf-c302-44f0-8513-26443d7fe1f2_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_e1009616-1d7d-4304-9428-bf94e6107d43_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_H2PTERIDINEPYROPHOSPHOKIN-RXN_RO_0002413_H2PTEROATESYNTH-RXN_null_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -758,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -818,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -835,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -870,11 +898,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/e1009616-1d7d-4304-9428-bf94e6107d43_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -884,7 +929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -904,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -921,7 +966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,13 +997,30 @@
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65389> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ADCLY-RXN_RO_0002234_CHEBI_15378_ADCLY-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,23 +1031,6 @@
           <http://model.geneontology.org/CHEBI_15378_ADCLY-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15377_GTP-CYCLOHYDRO-I-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65389> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -995,7 +1040,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate biosynthesis II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1037,7 +1082,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1050,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1089,7 +1134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1103,7 +1148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1136,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1147,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1162,7 +1207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1175,11 +1220,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_e1009616-1d7d-4304-9428-bf94e6107d43_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1232,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/e1009616-1d7d-4304-9428-bf94e6107d43_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_H2NEOPTERINALDOL-RXN_BFO_0000050_PWY3O-45/PWY3O-45_SGD_PWY3O-45>
@@ -1195,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1206,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1221,7 +1266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1266,7 +1311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1282,7 +1327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1302,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1335,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1367,7 +1412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1383,7 +1428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1425,7 +1470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1436,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1451,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1467,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1479,7 +1524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1499,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1515,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1526,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1560,7 +1605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1588,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1601,7 +1646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1627,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1655,7 +1700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1672,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1691,7 +1736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1704,11 +1749,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0fd404cf-c302-44f0-8513-26443d7fe1f2_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1716,7 +1761,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/0fd404cf-c302-44f0-8513-26443d7fe1f2_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
@@ -1726,7 +1771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1751,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1767,7 +1812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1782,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1798,7 +1843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1835,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1850,7 +1895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1907,7 +1952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1921,7 +1966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1937,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -1953,7 +1998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1970,7 +2015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1985,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,7 +2047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2019,24 +2064,13 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_H2PTEROATESYNTH-RXN_RO_0002234_CHEBI_29888_H2PTEROATESYNTH-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2055,7 +2089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,30 +2100,13 @@
           <http://model.geneontology.org/reaction_H2NEOPTERINP3PYROPHOSPHOHYDRO-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65612> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_RO_0002233_CHEBI_58762_DIHYDRONEOPTERIN-MONO-P-DEPHOS-RXN_SGD_PWY3O-45> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2105,7 +2122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2119,7 +2136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2135,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2150,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2183,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2210,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2224,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2243,7 +2260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2257,7 +2274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2277,7 +2294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2288,6 +2305,17 @@
           <http://model.geneontology.org/CHEBI_15378_GTP-CYCLOHYDRO-I-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_0fd404cf-c302-44f0-8513-26443d7fe1f2_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-45" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2296,7 +2324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2312,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2329,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2353,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2370,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2384,7 +2412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2401,7 +2429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2418,7 +2446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,7 +2462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2446,7 +2474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2465,7 +2493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2486,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2516,7 +2544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2528,7 +2556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2548,7 +2576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2562,7 +2590,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2578,7 +2606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2593,7 +2621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2608,7 +2636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2624,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2644,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2658,7 +2686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2678,7 +2706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2701,7 +2729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2715,7 +2743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2731,7 +2759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2743,7 +2771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2763,7 +2791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2777,7 +2805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2795,7 +2823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2812,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2826,7 +2854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2842,7 +2870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2857,7 +2885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2870,7 +2898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2885,7 +2913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2905,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2918,7 +2946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2933,7 +2961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2946,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -2960,7 +2988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2993,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3009,7 +3037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3025,7 +3053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3048,7 +3076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3064,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3076,7 +3104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3098,7 +3126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3118,7 +3146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3135,7 +3163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3154,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3168,7 +3196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3193,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3213,7 +3241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3227,7 +3255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3249,7 +3277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3266,7 +3294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3282,7 +3310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3294,7 +3322,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3313,7 +3341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3326,7 +3354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3337,29 +3365,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_17836>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-45SmallMolecule65591> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATESYNTH-RXN_RO_0002333_YMR113W-MONOMER_DIHYDROFOLATESYNTH-RXN_controller_SGD_PWY3O-45>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3374,7 +3385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3390,20 +3401,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-45>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3416,7 +3416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3432,7 +3432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3444,7 +3444,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,7 +3461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3477,7 +3477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3489,7 +3489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3509,7 +3509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3522,7 +3522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3537,7 +3537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3550,7 +3550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3565,15 +3565,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c4c61aeb-8d0e-4e90-a96c-65faae5eb991_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/e1009616-1d7d-4304-9428-bf94e6107d43_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/d1537e53-91c7-4dcc-a3ff-7bd697aa9833_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/0fd404cf-c302-44f0-8513-26443d7fe1f2_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3586,7 +3586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3598,7 +3598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3614,7 +3614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3626,7 +3626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3642,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3654,7 +3654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3671,7 +3671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3694,7 +3694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3711,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3727,7 +3727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3741,7 +3741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3752,7 +3752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-45" ;
         <http://purl.org/pav/providedBy>
@@ -3766,7 +3766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-45" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-450-PWY3O-450.ttl
+++ b/models/PWY3O-450-PWY3O-450.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidylcholine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -167,23 +167,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_29888>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/CHEBI_295975_2.7.7.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "phosphocholine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450SmallMolecule21848> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHOLINE-KINASE-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004103> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -204,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,12 +195,29 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/CHEBI_295975_2.7.7.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_295975> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "phosphocholine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-450SmallMolecule21848> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_58779_RXN-5781_SGD_PWY3O-450>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -232,7 +232,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -416,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -495,7 +495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -513,7 +513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,7 +546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -593,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -621,7 +621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -650,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -745,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -826,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,24 +834,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY3O-450>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-450" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-5781_RO_0002233_CHEBI_17815_RXN-5781_SGD_PWY3O-450> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,6 +850,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17815_RXN-5781>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CHOLINE-KINASE-RXN_RO_0002234_CHEBI_15378_CHOLINE-KINASE-RXN_SGD_PWY3O-450>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-450" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN-5781>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004142> ;
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -928,7 +928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -992,7 +992,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1012,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1088,7 +1088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1139,7 +1139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1182,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1205,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-450" ;
         <http://purl.org/pav/providedBy>
@@ -1245,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1259,7 +1259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-450" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-48-PWY3O-48.ttl
+++ b/models/PWY3O-48-PWY3O-48.ttl
@@ -10,7 +10,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -187,7 +187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -224,7 +224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -244,7 +244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -286,7 +286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,24 +300,13 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY3O-48>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-48" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_15378_1.1.1.8-RXN_SGD_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -328,13 +317,24 @@
           <http://model.geneontology.org/CHEBI_15378_1.1.1.8-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002411_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY3O-48>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-48" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYCEROL-1-PHOSPHATASE-RXN_RO_0002233_CHEBI_15377_GLYCEROL-1-PHOSPHATASE-RXN_SGD_PWY3O-48> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -407,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -484,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -514,7 +514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -533,7 +533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -559,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -610,7 +610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -627,7 +627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -678,7 +678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -713,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -762,7 +762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -817,7 +817,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -856,7 +856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-48" ;
         <http://purl.org/pav/providedBy>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-48" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-5-PWY3O-5.ttl
+++ b/models/PWY3O-5-PWY3O-5.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylulose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -83,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -94,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -262,7 +262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -302,7 +302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>
@@ -439,7 +439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,7 +458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-50-PWY3O-50.ttl
+++ b/models/PWY3O-50-PWY3O-50.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -100,7 +100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -114,7 +114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,7 +340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -461,7 +461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -498,7 +498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -672,7 +672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -688,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -784,7 +784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -834,7 +834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -864,7 +864,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -929,20 +929,20 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/CHEBI_58126_PORPHOBILSYNTH-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58126> ;
+<http://model.geneontology.org/CHEBI_57845_UROGENIIISYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57845> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "porphobilinogen" ;
+                "preuroporphyrinogen" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52225> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52170> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -955,7 +955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -963,20 +963,20 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/CHEBI_57845_UROGENIIISYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57845> ;
+<http://model.geneontology.org/CHEBI_58126_PORPHOBILSYNTH-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58126> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "preuroporphyrinogen" ;
+                "porphobilinogen" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52170> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-50SmallMolecule52225> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -988,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1050,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1094,7 +1094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1108,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1136,7 +1136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,7 +1177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "tetrapyrrole biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1270,7 +1270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1287,7 +1287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1303,7 +1303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,18 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_PWY3O-50/PWY3O-50_SGD_PWY3O-50>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1359,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,6 +1358,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_57845_OHMETHYLBILANESYN-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_OHMETHYLBILANESYN-RXN_BFO_0000050_PWY3O-50/PWY3O-50_SGD_PWY3O-50>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/UROGENIIISYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004852> ;
@@ -1387,7 +1387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1401,7 +1401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
@@ -1462,9 +1462,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_null_PWY3O-50>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-50" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1476,7 +1487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,17 +1498,6 @@
           <http://model.geneontology.org/reaction_PORPHOBILSYNTH-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PORPHOBILSYNTH-RXN_RO_0002413_OHMETHYLBILANESYN-RXN_null_PWY3O-50>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-50" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1523,7 +1523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-50" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-50" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-5268-PWY3O-5268.ttl
+++ b/models/PWY3O-5268-PWY3O-5268.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -14,7 +14,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "oleate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -77,7 +77,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,7 +244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -298,7 +298,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -378,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -435,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -549,7 +549,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +657,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -702,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -779,7 +779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -837,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -854,7 +854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5268" ;
         <http://purl.org/pav/providedBy>
@@ -905,7 +905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5268" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-592-PWY3O-592.ttl
+++ b/models/PWY3O-592-PWY3O-592.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,7 +80,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -197,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -335,7 +335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -363,7 +363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -379,7 +379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -399,7 +399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -480,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -492,7 +492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -508,7 +508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -604,7 +604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,7 +661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -674,7 +674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -734,7 +734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -762,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -798,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione-glutaredoxin system - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,7 +878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +940,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -957,7 +957,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1021,7 +1021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1041,7 +1041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1054,7 +1054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-592" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-592" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-5962-PWY3O-5962.ttl
+++ b/models/PWY3O-5962-PWY3O-5962.ttl
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -40,7 +40,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,7 +122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -135,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -206,7 +206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -299,7 +299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -319,7 +319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -333,7 +333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -367,7 +367,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -398,7 +398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -412,7 +412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,7 +501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -517,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -529,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -566,7 +566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -594,7 +594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -675,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -726,7 +726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -763,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -824,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -850,7 +850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -877,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -949,7 +949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -986,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1117,7 +1117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1185,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1238,7 +1238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1258,7 +1258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1296,7 +1296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1313,7 +1313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1346,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1360,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1375,7 +1375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1423,7 +1423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1439,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1467,7 +1467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1482,7 +1482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,7 +1496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1530,7 +1530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1550,7 +1550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1564,7 +1564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1609,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1626,7 +1626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1670,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1681,7 +1681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1693,7 +1693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1711,7 +1711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1725,7 +1725,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1755,7 +1755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1807,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1848,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1866,7 +1866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1883,7 +1883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1911,7 +1911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,7 +1927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1938,7 +1938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1950,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1967,7 +1967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1983,7 +1983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -1995,7 +1995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2012,7 +2012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2029,7 +2029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2048,7 +2048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2064,7 +2064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2079,7 +2079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,7 +2092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2107,7 +2107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2124,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2137,7 +2137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2159,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2188,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2208,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2222,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2233,17 +2233,6 @@
           <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2252,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2263,12 +2252,23 @@
           <http://model.geneontology.org/reaction_RXN-9514_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.14.19.1-RXN_RO_0002234_CHEBI_57387_1.14.19.1-RXN_SGD_PWY3O-5962>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2283,7 +2283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2303,7 +2303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2330,7 +2330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2341,7 +2341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2353,7 +2353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2370,7 +2370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,7 +2387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2413,7 +2413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2463,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2488,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2501,7 +2501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2512,7 +2512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2525,7 +2525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2542,7 +2542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2555,7 +2555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2566,7 +2566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2577,7 +2577,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2602,7 +2602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2616,7 +2616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2632,7 +2632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2643,7 +2643,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2668,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2682,7 +2682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2699,7 +2699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2729,7 +2729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2743,7 +2743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2759,7 +2759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2787,7 +2787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2798,7 +2798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2827,7 +2827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2847,7 +2847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2860,7 +2860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2874,7 +2874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2891,7 +2891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2907,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -2932,7 +2932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2952,7 +2952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2972,7 +2972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2989,7 +2989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3006,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3019,7 +3019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3040,7 +3040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3056,7 +3056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3068,7 +3068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3085,7 +3085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3102,7 +3102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3121,7 +3121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3140,7 +3140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3151,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3164,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3178,7 +3178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3194,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3209,7 +3209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3225,7 +3225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3237,7 +3237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3253,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3268,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3282,7 +3282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3302,7 +3302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3329,7 +3329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3342,7 +3342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3367,7 +3367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3388,7 +3388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3402,7 +3402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3420,7 +3420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3434,7 +3434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3450,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3461,7 +3461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3473,7 +3473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3495,7 +3495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3511,7 +3511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3525,7 +3525,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3545,7 +3545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3561,7 +3561,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3579,7 +3579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3592,7 +3592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3606,7 +3606,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3623,7 +3623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3640,7 +3640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3656,7 +3656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3667,7 +3667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3689,7 +3689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3704,7 +3704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3720,7 +3720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3731,7 +3731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3742,7 +3742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3757,7 +3757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3774,7 +3774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3789,7 +3789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3802,7 +3802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3814,7 +3814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3830,7 +3830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3841,7 +3841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3850,7 +3850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3861,7 +3861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -3877,7 +3877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3894,7 +3894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3908,7 +3908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3925,7 +3925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3945,7 +3945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3962,7 +3962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3982,7 +3982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3995,7 +3995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4007,7 +4007,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4024,7 +4024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4041,7 +4041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4057,7 +4057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4074,7 +4074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4091,7 +4091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4107,7 +4107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4118,7 +4118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4129,7 +4129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4140,7 +4140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4152,7 +4152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4172,7 +4172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4185,7 +4185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4196,7 +4196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4207,7 +4207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4222,7 +4222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4239,7 +4239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4256,7 +4256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4272,7 +4272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4289,7 +4289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4300,7 +4300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4312,7 +4312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4329,7 +4329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4346,7 +4346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4369,7 +4369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4383,7 +4383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4400,7 +4400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4417,7 +4417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4437,7 +4437,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4454,7 +4454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4474,7 +4474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4487,7 +4487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4500,7 +4500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4517,7 +4517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4534,7 +4534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4550,7 +4550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4565,7 +4565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4578,7 +4578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4593,7 +4593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4606,7 +4606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4621,7 +4621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4634,7 +4634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4659,7 +4659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4679,7 +4679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4695,7 +4695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4711,7 +4711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4723,7 +4723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4740,7 +4740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4759,7 +4759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4771,7 +4771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4787,7 +4787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4802,7 +4802,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4816,7 +4816,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4836,7 +4836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4850,7 +4850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4870,7 +4870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4886,7 +4886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4897,7 +4897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4909,7 +4909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4928,7 +4928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4943,7 +4943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4960,7 +4960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4973,7 +4973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -4998,7 +4998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5011,7 +5011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5025,7 +5025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5036,7 +5036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5047,7 +5047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5058,7 +5058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5069,7 +5069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5081,7 +5081,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5101,7 +5101,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5121,7 +5121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5138,7 +5138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5152,7 +5152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5172,7 +5172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5189,7 +5189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5203,7 +5203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5220,7 +5220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5237,7 +5237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5257,7 +5257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5276,7 +5276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5295,7 +5295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5314,7 +5314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5325,7 +5325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5340,7 +5340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5357,7 +5357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5370,7 +5370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5381,7 +5381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5396,7 +5396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5412,7 +5412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5429,7 +5429,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5446,7 +5446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5476,7 +5476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5492,7 +5492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5509,7 +5509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5531,7 +5531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5548,7 +5548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5568,7 +5568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5584,7 +5584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5596,7 +5596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5616,7 +5616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5630,7 +5630,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5650,7 +5650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5663,7 +5663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5674,7 +5674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5689,7 +5689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5702,7 +5702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5717,7 +5717,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5733,7 +5733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5744,7 +5744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5756,7 +5756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5773,7 +5773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5791,7 +5791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5808,7 +5808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5822,7 +5822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5838,7 +5838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5850,7 +5850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5873,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5886,7 +5886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5898,7 +5898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5915,7 +5915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5932,7 +5932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5948,7 +5948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5959,7 +5959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5970,7 +5970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -5982,7 +5982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5999,7 +5999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6015,7 +6015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6030,7 +6030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6047,7 +6047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6060,7 +6060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6075,7 +6075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6091,7 +6091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6111,7 +6111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6136,7 +6136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6149,7 +6149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6163,7 +6163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6177,7 +6177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6192,7 +6192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6208,7 +6208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6225,7 +6225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6245,7 +6245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6259,7 +6259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6275,7 +6275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6287,7 +6287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6303,7 +6303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6315,7 +6315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6337,7 +6337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6354,7 +6354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6371,7 +6371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6401,7 +6401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6415,7 +6415,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6431,7 +6431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6446,7 +6446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6459,7 +6459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6474,7 +6474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6487,7 +6487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6498,7 +6498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6514,7 +6514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6531,7 +6531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6548,7 +6548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6561,7 +6561,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6572,7 +6572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6587,7 +6587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6601,7 +6601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6618,7 +6618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6635,7 +6635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6654,7 +6654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6671,7 +6671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6687,7 +6687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6701,7 +6701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6715,7 +6715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6734,7 +6734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6756,7 +6756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6768,7 +6768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6785,7 +6785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6801,7 +6801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6812,7 +6812,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6823,7 +6823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6838,7 +6838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6853,7 +6853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6870,7 +6870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6883,7 +6883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6894,7 +6894,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6909,7 +6909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6926,7 +6926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6943,7 +6943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6960,7 +6960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6973,7 +6973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -6986,7 +6986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6999,7 +6999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7014,7 +7014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated and unsaturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -7028,7 +7028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7045,7 +7045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7075,7 +7075,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7089,7 +7089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7109,7 +7109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7126,7 +7126,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7146,7 +7146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7159,7 +7159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7171,7 +7171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7191,7 +7191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7208,7 +7208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7224,7 +7224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7236,7 +7236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7252,7 +7252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7267,7 +7267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7280,7 +7280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7294,7 +7294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7305,7 +7305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7325,7 +7325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7336,7 +7336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7352,7 +7352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7365,7 +7365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7380,7 +7380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7400,7 +7400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7416,7 +7416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7431,7 +7431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7448,7 +7448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7468,7 +7468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7484,7 +7484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7496,7 +7496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7513,7 +7513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7533,7 +7533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7547,7 +7547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7569,7 +7569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7585,7 +7585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7600,7 +7600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7614,7 +7614,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7637,7 +7637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7651,7 +7651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7671,7 +7671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7688,7 +7688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7701,7 +7701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7722,7 +7722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7735,7 +7735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7747,7 +7747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7763,7 +7763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7774,7 +7774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7789,7 +7789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7811,7 +7811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7825,7 +7825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7850,7 +7850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7877,7 +7877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7890,7 +7890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7902,7 +7902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7918,7 +7918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7932,7 +7932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7952,7 +7952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7969,7 +7969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7985,7 +7985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -7997,7 +7997,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8013,7 +8013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8025,7 +8025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8042,7 +8042,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8058,7 +8058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8072,7 +8072,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8089,7 +8089,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8105,7 +8105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8116,7 +8116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8127,7 +8127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8138,7 +8138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8149,7 +8149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8160,7 +8160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8171,7 +8171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8182,7 +8182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8193,7 +8193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8206,7 +8206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8219,7 +8219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8230,7 +8230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -8240,7 +8240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8259,7 +8259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8275,7 +8275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8287,7 +8287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8304,7 +8304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8320,7 +8320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8332,7 +8332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8348,7 +8348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8360,7 +8360,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8377,7 +8377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8395,7 +8395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8411,7 +8411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8430,7 +8430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8441,7 +8441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8454,7 +8454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8471,7 +8471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8484,7 +8484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8505,7 +8505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8518,7 +8518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8536,7 +8536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8553,7 +8553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8566,7 +8566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8581,7 +8581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8594,7 +8594,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8608,7 +8608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8625,7 +8625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8644,7 +8644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8656,7 +8656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8673,7 +8673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8693,7 +8693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8713,7 +8713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -8727,7 +8727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8738,23 +8738,23 @@
           <http://model.geneontology.org/ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY3O-5962>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-5962" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-REDUCT-RXN_RO_0002234_CHEBI_57783_3-OXOACYL-ACP-REDUCT-RXN_SGD_PWY3O-5962>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-5962" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002233_CHEBI_15378_RXN3O-1803_SGD_PWY3O-5962>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8766,7 +8766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8783,7 +8783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8800,7 +8800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -8816,7 +8816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-5962" ;
         <http://purl.org/pav/providedBy>
@@ -8831,7 +8831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-5962" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-6-1-PWY3O-6-1.ttl
+++ b/models/PWY3O-6-1-PWY3O-6-1.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -66,7 +66,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,7 +244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -311,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -328,7 +328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -348,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -385,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "dehydro-D-arabinono-1,4-lactone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -491,7 +491,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -647,7 +647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -660,7 +660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -703,7 +703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -719,7 +719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -730,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -761,7 +761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -852,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -879,7 +879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -891,7 +891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +908,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -937,7 +937,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -954,7 +954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1001,7 +1001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1019,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1096,7 +1096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1124,7 +1124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1143,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1158,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1171,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1199,7 +1199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6-1" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1233,7 +1233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1261,7 +1261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-6336-PWY3O-6336.ttl
+++ b/models/PWY3O-6336-PWY3O-6336.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -98,7 +98,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -182,7 +182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -199,7 +199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -255,7 +255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -285,7 +285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -296,7 +296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -349,7 +349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -428,7 +428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -485,16 +485,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACETYL-COA-CARBOXYLTRANSFER-RXN_BFO_0000050_PWY3O-6336/PWY3O-6336_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -505,6 +502,9 @@
           <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-REDUCT-RXN_controller>
         a       <http://identifiers.org/sgd/S000006152> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -512,7 +512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -564,7 +564,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -601,7 +601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -676,7 +676,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -695,7 +695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -706,7 +706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -735,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -752,7 +752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -777,25 +777,25 @@
 <http://model.geneontology.org/reaction_4.2.1.58-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-BASE-RXN_RO_0002413_RXN-9514_null_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACP-S-ACETYLTRANSFER-RXN_RO_0002234_ACP_ACP-S-ACETYLTRANSFER-RXN_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -805,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -824,7 +824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -840,7 +840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +882,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -936,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -970,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -994,7 +994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1009,7 +1009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of fatty acid biosynthesis, saturated - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1040,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1074,7 +1074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1124,7 +1124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1200,7 +1200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1214,7 +1214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1234,7 +1234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1291,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1304,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1339,7 +1339,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1376,7 +1376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1439,7 +1439,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1459,7 +1459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1473,7 +1473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1489,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1500,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1515,7 +1515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1543,7 +1543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1557,7 +1557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1579,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1632,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1648,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1659,7 +1659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1704,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1716,7 +1716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,7 +1735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1751,7 +1751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1762,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1777,7 +1777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1794,7 +1794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1807,7 +1807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1821,7 +1821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1840,7 +1840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1864,7 +1864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1878,7 +1878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1895,7 +1895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1912,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,7 +1962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1973,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -1993,7 +1993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2043,7 +2043,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2061,7 +2072,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2074,20 +2085,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-1803_RO_0002333_YPL231W-MONOMER_RXN3O-1803_controller_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2096,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2108,7 +2108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2125,7 +2125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2142,7 +2142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2158,7 +2158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2170,7 +2170,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2208,7 +2208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2222,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2239,7 +2239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,7 +2257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2283,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,7 +2316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2332,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2358,7 +2358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2370,7 +2370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2402,7 +2402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2418,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2433,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2466,7 +2466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2481,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2494,7 +2494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2506,7 +2506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2522,7 +2522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2533,7 +2533,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2547,7 +2547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2563,7 +2563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2574,7 +2574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2585,7 +2585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2596,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2608,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2624,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2638,7 +2638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,7 +2658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2678,7 +2678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2691,7 +2691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2702,7 +2702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2719,7 +2719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2744,7 +2744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2757,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2788,7 +2788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2807,7 +2807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2821,7 +2821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2838,7 +2838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2854,7 +2854,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2866,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2883,7 +2883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2899,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2910,7 +2910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2921,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -2936,7 +2936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2951,7 +2951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2968,7 +2968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2985,7 +2985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3011,7 +3011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3024,7 +3024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3036,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3053,7 +3053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3076,7 +3076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3090,7 +3090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3101,41 +3101,13 @@
           <http://model.geneontology.org/CHEBI_15377_RXN-9624>
 ] .
 
-<http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "NADPH" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68388> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-6336>
-        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002233_ACP_3-OXOACYL-ACP-SYNTH-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3146,6 +3118,34 @@
           <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALONYL-COA-ACP-TRANSACYL-RXN_RO_0002413_3-OXOACYL-ACP-SYNTH-BASE-RXN_null_PWY3O-6336>
+        a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57783_RXN3O-5293>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57783> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "NADPH" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68388> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YKL182W-MONOMER_RXN3O-5293_controller>
         a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3153,7 +3153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3166,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3178,7 +3178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3195,7 +3195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3211,7 +3211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3229,7 +3229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3246,7 +3246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3262,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3274,7 +3274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3290,7 +3290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3301,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3312,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3323,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3335,7 +3335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3355,7 +3355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3372,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3385,7 +3385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3397,7 +3397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3414,7 +3414,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3430,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3441,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3456,7 +3456,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68524> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57384> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "malonyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3469,28 +3486,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_57384_MALONYL-COA-ACP-TRANSACYL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_57384> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "malonyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68524> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3498,7 +3498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3528,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3541,7 +3541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3552,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3567,7 +3567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3584,7 +3584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3598,7 +3598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3615,7 +3615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3635,7 +3635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3648,7 +3648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3662,7 +3662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3673,7 +3673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3685,7 +3685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3702,7 +3702,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3718,7 +3718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3729,7 +3729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3741,7 +3741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3764,7 +3764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3780,7 +3780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3791,7 +3791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3805,7 +3805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3825,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3839,7 +3839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3863,7 +3863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3877,7 +3877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3893,7 +3893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3908,7 +3908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3922,7 +3922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3942,7 +3942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3956,7 +3956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3972,7 +3972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3983,7 +3983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -3994,7 +3994,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4003,7 +4003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4014,7 +4014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4026,7 +4026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4046,7 +4046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4063,7 +4063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4076,7 +4076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4094,7 +4094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4111,7 +4111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4124,7 +4124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4136,7 +4136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4152,7 +4152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4163,7 +4163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4174,7 +4174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4190,7 +4190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4204,7 +4204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4221,7 +4221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4239,7 +4239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4252,7 +4252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4263,7 +4263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4274,7 +4274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4286,7 +4286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4303,7 +4303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4319,7 +4319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4330,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4341,7 +4341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4356,7 +4356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4383,7 +4383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4400,7 +4400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4417,7 +4417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4433,7 +4433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4445,7 +4445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4462,7 +4462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4478,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4491,7 +4491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4505,7 +4505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4524,7 +4524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4544,7 +4544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4558,7 +4558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4578,7 +4578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4600,7 +4600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4617,7 +4617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4633,7 +4633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4648,7 +4648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4665,7 +4665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4679,7 +4679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4695,7 +4695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4707,7 +4707,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4727,13 +4727,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68655> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_7896> ;
@@ -4744,24 +4755,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336SmallMolecule68815> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002233_CHEBI_58349_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN3O-1803>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -4772,7 +4772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4786,7 +4786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4805,7 +4805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4824,7 +4824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4835,7 +4835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4853,7 +4853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4867,7 +4867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4900,7 +4900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4913,7 +4913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4924,7 +4924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4935,7 +4935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4947,7 +4947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4967,7 +4967,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4986,7 +4986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -4997,7 +4997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5011,7 +5011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5028,7 +5028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5044,7 +5044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5058,7 +5058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5071,7 +5071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5085,7 +5085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5105,7 +5105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5118,7 +5118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5130,7 +5130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5147,7 +5147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5164,7 +5164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5187,7 +5187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5200,7 +5200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5211,7 +5211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5226,7 +5226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5249,7 +5249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5263,7 +5263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5280,7 +5280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5296,7 +5296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5308,7 +5308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5325,7 +5325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5345,7 +5345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5364,7 +5364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5383,7 +5383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5397,7 +5397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5408,7 +5408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5419,7 +5419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5431,7 +5431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5450,7 +5450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5464,7 +5464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5483,7 +5483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5499,7 +5499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5510,7 +5510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5525,7 +5525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5552,7 +5552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5565,7 +5565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5577,7 +5577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5594,7 +5594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5614,7 +5614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5631,7 +5631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5644,7 +5644,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5656,7 +5667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5667,23 +5678,12 @@
           <http://model.geneontology.org/CHEBI_57288_ACETYL-COA-CARBOXYLTRANSFER-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-OXOACYL-ACP-SYNTH-RXN_RO_0002333_YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-RXN_controller_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_4.2.1.58-RXN_RO_0002233_ACP_4.2.1.58-RXN_SGD_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5698,7 +5698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5711,7 +5711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5724,7 +5724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5737,7 +5737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5752,7 +5752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5772,7 +5772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5792,7 +5792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5805,7 +5805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5817,32 +5817,22 @@
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
-        a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
+        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>" ;
-        <http://purl.obolibrary.org/obo/BFO_0000050>
-                <http://model.geneontology.org/PWY3O-6336/PWY3O-6336> ;
-        <http://purl.obolibrary.org/obo/BFO_0000066>
-                <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829> ;
-        <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN> , <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN> , <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
-        <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller> , <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller> ;
-        <http://purl.obolibrary.org/obo/RO_0002413>
-                <http://model.geneontology.org/RXN-9514> ;
+                "a palmitoyl-[acp]" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336BiochemicalReaction68641> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68737> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/MALONYL-COA-ACP-TRANSACYL-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004314> ;
@@ -5863,7 +5853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5871,22 +5861,32 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/Palmitoyl-ACPs_RXN3O-1803>
-        a       <http://purl.obolibrary.org/obo/CHEBI_33695> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://model.geneontology.org/3-OXOACYL-ACP-SYNTH-BASE-RXN>
+        a       <http://purl.obolibrary.org/obo/GO_0004315> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a palmitoyl-[acp]" ;
+                "an acetyl-[acp] + a malonyl-[acp] + H<SUP>+</SUP> &rarr; an acetoacetyl-[acp] + acyl-carrier protein + CO<SUB>2</SUB>" ;
+        <http://purl.obolibrary.org/obo/BFO_0000050>
+                <http://model.geneontology.org/PWY3O-6336/PWY3O-6336> ;
+        <http://purl.obolibrary.org/obo/BFO_0000066>
+                <http://model.geneontology.org/reaction_3-OXOACYL-ACP-SYNTH-BASE-RXN_location_lociGO_0005829> ;
+        <http://purl.obolibrary.org/obo/RO_0002233>
+                <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN> , <http://model.geneontology.org/CHEBI_15378_3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002234>
+                <http://model.geneontology.org/ACP_3-OXOACYL-ACP-SYNTH-BASE-RXN> , <http://model.geneontology.org/CHEBI_16526_3-OXOACYL-ACP-SYNTH-BASE-RXN> ;
+        <http://purl.obolibrary.org/obo/RO_0002333>
+                <http://model.geneontology.org/YER061C-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller> , <http://model.geneontology.org/YPL231W-MONOMER_3-OXOACYL-ACP-SYNTH-BASE-RXN_controller> ;
+        <http://purl.obolibrary.org/obo/RO_0002413>
+                <http://model.geneontology.org/RXN-9514> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336Protein68737> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6336BiochemicalReaction68641> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 <http://model.geneontology.org/RXN3O-5293>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003674> ;
@@ -5907,7 +5907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5921,7 +5921,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5937,7 +5937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5952,7 +5952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5966,7 +5966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5982,7 +5982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -5996,7 +5996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6012,7 +6012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6033,7 +6033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6046,7 +6046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6058,7 +6058,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6074,7 +6074,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6086,7 +6086,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6106,7 +6106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6120,7 +6120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6137,7 +6137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6157,7 +6157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6170,7 +6170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6188,7 +6188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6201,7 +6201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6212,7 +6212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6224,7 +6224,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6241,7 +6241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6257,7 +6257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6269,7 +6269,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6285,7 +6285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6297,7 +6297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6314,7 +6314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6334,7 +6334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6354,7 +6354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6369,7 +6369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6383,7 +6383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6403,7 +6403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6426,7 +6426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6440,7 +6440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6459,7 +6459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6475,7 +6475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6488,7 +6488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6501,7 +6501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6512,7 +6512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6526,7 +6526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6541,7 +6541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6549,24 +6549,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6336" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PALMITOYL-COA-HYDROLASE-RXN_RO_0002234_CHEBI_7896_PALMITOYL-COA-HYDROLASE-RXN_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6583,7 +6572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6594,12 +6583,23 @@
           <http://model.geneontology.org/PWY3O-6336/PWY3O-6336>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-ACP-REDUCT-NADPH-RXN_RO_0002234_CHEBI_15378_ENOYL-ACP-REDUCT-NADPH-RXN_SGD_PWY3O-6336>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6336" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-5293_RO_0002234_CHEBI_15378_RXN3O-5293_SGD_PWY3O-6336>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6611,7 +6611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6628,7 +6628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6648,7 +6648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6664,7 +6664,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6680,7 +6680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6693,7 +6693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6706,7 +6706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6721,7 +6721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6735,7 +6735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6752,7 +6752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6772,7 +6772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6785,14 +6785,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_7896>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6800,7 +6797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6811,13 +6808,16 @@
           <http://model.geneontology.org/TRANS-D2-ENOYL-ACP_ENOYL-ACP-REDUCT-NADPH-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/CHEBI_7896>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-5304_RO_0002234_CHEBI_57394_RXN3O-5304_SGD_PWY3O-6336> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6834,7 +6834,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6852,7 +6852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6867,7 +6867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6884,7 +6884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6897,7 +6897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6908,7 +6908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6919,7 +6919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -6931,7 +6931,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6964,7 +6964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6978,7 +6978,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6998,7 +6998,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7015,7 +7015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7032,7 +7032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7048,7 +7048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7063,7 +7063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7076,7 +7076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7090,7 +7090,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7110,7 +7110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7125,7 +7125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7138,7 +7138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6336" ;
         <http://purl.org/pav/providedBy>
@@ -7163,7 +7163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7180,7 +7180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6336" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-64-PWY3O-64.ttl
+++ b/models/PWY3O-64-PWY3O-64.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -296,7 +296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -447,7 +447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -489,7 +489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -548,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -752,7 +752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -763,7 +763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -774,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -827,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -871,7 +871,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -906,7 +906,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -965,7 +965,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,7 +1028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1062,7 +1062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "methionine salvage pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1076,7 +1076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1194,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1228,7 +1228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1287,7 +1287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1303,7 +1303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1331,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1406,7 +1406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1428,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,7 +1468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1493,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1529,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1551,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1566,7 +1566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1582,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1614,7 +1614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1627,7 +1627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1653,7 +1653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1670,7 +1670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1687,7 +1687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1705,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1718,7 +1718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1733,7 +1733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1746,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1775,7 +1775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1789,7 +1789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1809,7 +1809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1823,7 +1823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1842,7 +1842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1858,7 +1858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1965,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -1986,7 +1986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2024,7 +2024,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,7 +2041,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,7 +2061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2092,7 +2092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2117,7 +2117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2142,7 +2142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2159,7 +2159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2198,7 +2198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2211,7 +2211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2224,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2237,7 +2237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2262,7 +2262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2276,7 +2276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,7 +2296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,7 +2332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-64" ;
         <http://purl.org/pav/providedBy>
@@ -2357,7 +2357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-64" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-6407-PWY3O-6407.ttl
+++ b/models/PWY3O-6407-PWY3O-6407.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -175,7 +175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -192,12 +192,15 @@
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_57642>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002234_CHEBI_58349_RXN3O-9800_SGD_PWY3O-6407>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -209,7 +212,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,15 +223,12 @@
           <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_57642>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279_SGD_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_3aef7d6b-2efc-462c-95dc-a89d95a47ae4_RXN3O-5279_SGD_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -240,7 +240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -278,7 +278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,13 +301,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20825> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_2be0d505-2b6b-45b2-94e3-40db41efe6b9_RXN3O-9800_SGD_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_RXN-1623_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -318,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -337,7 +348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -384,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -395,11 +406,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279_SGD_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_3aef7d6b-2efc-462c-95dc-a89d95a47ae4_RXN3O-5279_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +418,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279>
+          <http://model.geneontology.org/3aef7d6b-2efc-462c-95dc-a89d95a47ae4_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN3O-9800>
@@ -419,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -436,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -450,7 +461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,11 +480,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800_SGD_PWY3O-6407> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_2be0d505-2b6b-45b2-94e3-40db41efe6b9_RXN3O-9800_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +492,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800>
+          <http://model.geneontology.org/2be0d505-2b6b-45b2-94e3-40db41efe6b9_RXN3O-9800>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002413_RXN3O-9800_null_PWY3O-6407>
@@ -489,31 +500,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_PWY3O-6407/PWY3O-6407_SGD_PWY3O-6407>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800_SGD_PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -522,11 +511,39 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_BFO_0000050_PWY3O-6407/PWY3O-6407_SGD_PWY3O-6407>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6407" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/3aef7d6b-2efc-462c-95dc-a89d95a47ae4_RXN3O-5279>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -539,7 +556,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,13 +570,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_33184>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/2be0d505-2b6b-45b2-94e3-40db41efe6b9_RXN3O-9800>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-5279_BFO_0000050_PWY3O-6407/PWY3O-6407_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -581,7 +615,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/3aef7d6b-2efc-462c-95dc-a89d95a47ae4_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -589,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -628,7 +662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +739,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,23 +750,6 @@
           <http://model.geneontology.org/RXN-1623>
 ] .
 
-<http://model.geneontology.org/dc981b24-ba7c-4d7d-9a5b-477946215ad3_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0016287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -741,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +772,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -773,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -789,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -804,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,30 +875,13 @@
 <http://purl.obolibrary.org/obo/GO_0003674>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/PWY3O-6407>
-        a       <http://www.w3.org/2002/07/owl#Ontology> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
-        <http://geneontology.org/lego/modelstate>
-                "development" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/title>
-                "phosphatidate biosynthesis I (the dihydroxyacetone pathway) - imported from: Saccharomyces Genome Database" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <https://w3id.org/biolink/vocab/in_taxon>
-                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002233_CHEBI_57642_RXN3O-5279_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -892,13 +892,30 @@
           <http://model.geneontology.org/CHEBI_57642_RXN3O-5279>
 ] .
 
+<http://model.geneontology.org/PWY3O-6407>
+        a       <http://www.w3.org/2002/07/owl#Ontology> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "For logical inference, import the integrated tbox ontology http://purl.obolibrary.org/obo/go/extensions/go-lego-reacto.owl" ;
+        <http://geneontology.org/lego/modelstate>
+                "development" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/title>
+                "phosphatidate biosynthesis I (the dihydroxyacetone pathway) - imported from: Saccharomyces Genome Database" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <https://w3id.org/biolink/vocab/in_taxon>
+                <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-1623_BFO_0000050_PWY3O-6407/PWY3O-6407_SGD_PWY3O-6407> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -914,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,7 +985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -976,23 +993,6 @@
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6407SmallMolecule20750> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17984_RXN-1623>
         a       <http://purl.obolibrary.org/obo/CHEBI_17984> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,7 +1022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1039,7 +1039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1059,7 +1059,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/32a5ce0c-7fd2-47a2-b805-be96fcbba728_RXN3O-9800> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
+                <http://model.geneontology.org/2be0d505-2b6b-45b2-94e3-40db41efe6b9_RXN3O-9800> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1087,7 +1087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6407" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6407" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-6499-PWY3O-6499.ttl
+++ b/models/PWY3O-6499-PWY3O-6499.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -216,7 +216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -231,7 +231,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -254,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -355,7 +355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "phosphatidate biosynthesis II (the glycerol-3-phosphate pathway) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -372,7 +372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -544,7 +544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -571,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -588,7 +588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -673,7 +673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -846,7 +846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -862,11 +862,26 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6499Protein21431> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://model.geneontology.org/CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57287> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -877,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,28 +900,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/YOL059W-MONOMER_1.1.1.8-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000005420> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "glycerol-3-phosphate dehydrogenase (NAD+)" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6499Protein21431> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_PWY3O-6499/PWY3O-6499_SGD_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -953,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1003,7 +1003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1016,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1048,7 +1048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1070,24 +1070,13 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_15378_1.1.1.8-RXN_SGD_PWY3O-6499>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6499" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1098,13 +1087,24 @@
           <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002234_CHEBI_15378_1.1.1.8-RXN_SGD_PWY3O-6499>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6499" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_RO_0002234_CHEBI_57287_GLYCEROL-3-P-ACYLTRANSFER-RXN_SGD_PWY3O-6499> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1127,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1155,7 +1155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6499" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1206,7 +1206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1246,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6499" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-661-PWY3O-661.ttl
+++ b/models/PWY3O-661-PWY3O-661.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -58,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -132,7 +132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -200,7 +200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -254,7 +254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -288,7 +288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -337,7 +337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -364,7 +364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -447,7 +447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -460,7 +460,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-661" ;
         <http://purl.org/pav/providedBy>
@@ -478,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-661" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>

--- a/models/PWY3O-6635-PWY3O-6635.ttl
+++ b/models/PWY3O-6635-PWY3O-6635.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -33,7 +33,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -181,7 +181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -208,11 +208,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279_SGD_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_8dae031d-45f7-499d-abaf-ab5ca1bc987b_RXN3O-5279_SGD_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -220,7 +220,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-5279> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279>
+          <http://model.geneontology.org/8dae031d-45f7-499d-abaf-ab5ca1bc987b_RXN3O-5279>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.1.1.8-RXN_RO_0002233_CHEBI_57597_1.1.1.8-RXN_SGD_PWY3O-6635>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -294,7 +294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -327,7 +327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -394,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -496,17 +496,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_57642>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800_SGD_PWY3O-6635>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/RXN3O-5279>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0016287> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -518,7 +507,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57642_RXN3O-5279> , <http://model.geneontology.org/CHEBI_33184_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279> ;
+                <http://model.geneontology.org/CHEBI_57287_RXN3O-5279> , <http://model.geneontology.org/8dae031d-45f7-499d-abaf-ab5ca1bc987b_RXN3O-5279> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-4105_RXN3O-5279_controller> , <http://model.geneontology.org/MONOMER3O-4095_RXN3O-5279_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -526,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -539,18 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-6635" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279_SGD_PWY3O-6635>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -561,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -575,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -604,7 +582,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -645,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -673,7 +651,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -721,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +722,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-9800_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
+                <http://model.geneontology.org/002fb7f9-6893-47b5-99ea-762dc9fb040c_RXN3O-9800> , <http://model.geneontology.org/CHEBI_57783_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_58349_RXN3O-9800> , <http://model.geneontology.org/CHEBI_15378_RXN3O-9800> , <http://model.geneontology.org/CHEBI_16975_RXN3O-9800> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -754,7 +732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +749,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -855,7 +833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +850,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -888,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -914,7 +892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -929,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -949,7 +927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -972,7 +950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -988,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1002,7 +980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1013,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1024,7 +1002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1051,7 +1029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1068,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1125,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1138,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1150,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,13 +1185,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37727> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_002fb7f9-6893-47b5-99ea-762dc9fb040c_RXN3O-9800_SGD_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/MONOMER3O-4095_GLYCEROL-3-P-ACYLTRANSFER-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001775> ;
@@ -1222,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1231,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1255,7 +1244,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1287,7 +1276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1319,13 +1308,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635Protein37836> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/002fb7f9-6893-47b5-99ea-762dc9fb040c_RXN3O-9800>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_16975_RXN-1623>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16975> ;
@@ -1336,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1355,7 +1361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1372,7 +1378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1392,7 +1398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1405,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1420,7 +1426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1431,6 +1437,17 @@
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-5279_RO_0002234_8dae031d-45f7-499d-abaf-ab5ca1bc987b_RXN3O-5279_SGD_PWY3O-6635>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-6635" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000000107>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1440,7 +1457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1460,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1473,7 +1490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1485,7 +1502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1518,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1526,11 +1543,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800_SGD_PWY3O-6635> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-9800_RO_0002233_002fb7f9-6893-47b5-99ea-762dc9fb040c_RXN3O-9800_SGD_PWY3O-6635> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,8 +1555,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-9800> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800>
+          <http://model.geneontology.org/002fb7f9-6893-47b5-99ea-762dc9fb040c_RXN3O-9800>
 ] .
+
+<http://model.geneontology.org/8dae031d-45f7-499d-abaf-ab5ca1bc987b_RXN3O-5279>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "1-acyl-dihydroxyacetone-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1549,7 +1583,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1565,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1602,7 +1636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1652,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1633,7 +1667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1647,7 +1681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1668,7 +1702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1681,7 +1715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1697,7 +1731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1705,29 +1739,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/117ca543-6b65-49de-b54d-b3211e1c109b_RXN3O-9800>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_GLYCEROL-3-P-ACYLTRANSFER-RXN_BFO_0000050_PWY3O-6635/PWY3O-6635_SGD_PWY3O-6635>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1745,7 +1762,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1758,7 +1775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1783,7 +1800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1796,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1807,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1819,7 +1836,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1853,7 +1870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1869,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1884,7 +1901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1917,7 +1934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1931,7 +1948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1951,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of phosphatidate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -1976,7 +1993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1993,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2009,7 +2026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2020,7 +2037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2031,7 +2048,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-6635" ;
         <http://purl.org/pav/providedBy>
@@ -2039,20 +2056,3 @@
 
 <http://identifiers.org/sgd/S000005420>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/3433c69b-0f2b-4d3c-95c4-83adf6ce0803_RXN3O-5279>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "1-acyl-dihydroxyacetone-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-6635" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-6635SmallMolecule37625> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PWY3O-69-PWY3O-69.ttl
+++ b/models/PWY3O-69-PWY3O-69.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -45,7 +45,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -143,7 +143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -427,7 +427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -504,7 +504,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -520,7 +520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -545,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -560,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -613,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -624,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -682,7 +682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -760,7 +760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -790,7 +790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -827,7 +827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -846,7 +846,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -881,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -895,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -939,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -953,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -969,7 +969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1010,7 +1010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1091,7 +1091,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1107,7 +1107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1120,7 +1120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1181,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1196,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1210,7 +1210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1243,7 +1243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1289,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1309,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1333,7 +1333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1367,7 +1367,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1380,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1431,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1444,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1476,7 +1476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1493,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1507,7 +1507,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1527,7 +1527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1543,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of heme and siroheme biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1577,7 +1577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1662,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1692,7 +1692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1706,7 +1706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1736,7 +1736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1774,7 +1774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1791,7 +1791,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1820,7 +1820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1837,7 +1837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1851,7 +1851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1870,7 +1870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1881,7 +1881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1896,7 +1896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1916,7 +1916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -1964,7 +1964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1999,7 +1999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,7 +2015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,7 +2031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2043,7 +2043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2065,7 +2065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2076,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2094,7 +2094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2114,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2127,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2141,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2189,7 +2189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2200,7 +2200,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2214,7 +2214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2240,7 +2240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2329,7 +2329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2345,7 +2345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2361,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2373,7 +2373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2398,7 +2398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2409,7 +2409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2421,7 +2421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2441,7 +2441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2465,7 +2465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2480,7 +2480,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2496,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2511,7 +2511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2530,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2542,7 +2542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2560,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2584,7 +2584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2596,7 +2596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2616,7 +2616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2629,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2643,7 +2643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2660,7 +2660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2687,7 +2687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2699,7 +2699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2716,7 +2716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2732,7 +2732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2744,7 +2744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2774,7 +2774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2788,7 +2788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2811,7 +2811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2825,7 +2825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2841,7 +2841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2863,7 +2863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2877,7 +2877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2896,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2907,7 +2907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2920,7 +2920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2933,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2948,7 +2948,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2967,7 +2967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2978,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -2990,7 +2990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3022,7 +3022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3042,7 +3042,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3059,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3076,7 +3076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3089,7 +3089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3103,7 +3103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3119,7 +3119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3130,7 +3130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3141,7 +3141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3158,7 +3158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3181,7 +3181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3198,7 +3198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3218,7 +3218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3234,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3246,7 +3246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3263,7 +3263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3283,7 +3283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3300,7 +3300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3316,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3331,7 +3331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3347,7 +3347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3362,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3382,7 +3382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3395,7 +3395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3410,7 +3410,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3426,7 +3426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3441,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3455,7 +3455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3475,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3488,7 +3488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3505,7 +3505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3521,7 +3521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3533,7 +3533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3553,7 +3553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3569,7 +3569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3583,7 +3583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3595,7 +3595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3615,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3628,7 +3628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3653,7 +3653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3678,7 +3678,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3695,7 +3695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3708,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3720,7 +3720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3738,7 +3738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3755,7 +3755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3769,7 +3769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3795,7 +3795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3809,7 +3809,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3825,7 +3825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3837,7 +3837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,7 +3856,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3879,7 +3879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3895,7 +3895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3909,7 +3909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3920,7 +3920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -3934,7 +3934,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3954,7 +3954,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3987,7 +3987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4012,7 +4012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4026,7 +4026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4046,7 +4046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4062,7 +4062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4074,7 +4074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4093,7 +4093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4104,7 +4104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4132,7 +4132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4145,7 +4145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4156,7 +4156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>
@@ -4167,7 +4167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-69" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-69" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-697-PWY3O-697.ttl
+++ b/models/PWY3O-697-PWY3O-697.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,11 +23,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_6fb4bc0e-a7e9-43c7-876f-d5f85029fdbb_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/6fb4bc0e-a7e9-43c7-876f-d5f85029fdbb_GLYOHMETRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_57305>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -64,7 +64,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -80,35 +80,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_57945_GCVMULTI-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -117,13 +100,30 @@
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/6fb4bc0e-a7e9-43c7-876f-d5f85029fdbb_GLYOHMETRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002333_CPLX3O-317_1.5.1.15-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -170,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -178,11 +178,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_b13455ce-a57f-4725-bea7-6750f7ad2dd7_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -190,7 +190,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/b13455ce-a57f-4725-bea7-6750f7ad2dd7_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_57305_GLYOHMETRANS-RXN_SGD_PWY3O-697>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,11 +232,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_08d18870-3e8d-4044-997b-72e455b40a7f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -244,19 +244,30 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/08d18870-3e8d-4044-997b-72e455b40a7f_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_24431>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4210e02c-6a7b-479a-b588-73f6d97031fe_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_2e1815a0-d086-4601-bec1-23c41c3f34dc_GCVMULTI-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -264,33 +275,11 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN>
+          <http://model.geneontology.org/2e1815a0-d086-4601-bec1-23c41c3f34dc_GCVMULTI-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000004801>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -298,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -309,12 +298,29 @@
           <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
 
+<http://model.geneontology.org/08d18870-3e8d-4044-997b-72e455b40a7f_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +332,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,51 +342,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/1.5.1.20-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -393,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -436,7 +397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,18 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -526,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -538,7 +488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -568,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -582,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -598,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -607,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -618,7 +568,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/62cd2644-8031-4a11-b010-56b1124174bb_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_a894d7aa-10c8-44b9-97c3-c201bfc9a13d_FORMATETHFLIG-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -646,7 +624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -665,11 +643,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_d7f1769f-135c-4f29-bf6f-ba52f8447785_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -677,7 +655,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/d7f1769f-135c-4f29-bf6f-ba52f8447785_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_BFO_0000050_PWY3O-697/PWY3O-697_SGD_PWY3O-697>
@@ -685,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -694,22 +672,16 @@
 <http://identifiers.org/sgd/S000001876>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_4306907a-96df-4ee8-b623-174805e88efb_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66298> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -717,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -728,17 +700,6 @@
           <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_246422>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -747,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -755,11 +716,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_05aa216a-cb03-4619-b19d-d551b60db314_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,19 +728,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/05aa216a-cb03-4619-b19d-d551b60db314_DIHYDROFOLATEREDUCT-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004329> ;
@@ -790,9 +740,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_FORMATETHFLIG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN> , <http://model.geneontology.org/a894d7aa-10c8-44b9-97c3-c201bfc9a13d_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_30616_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/6034dc4d-b948-49a2-8622-012e7aecb0ea_FORMATETHFLIG-RXN> ;
+                <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN> , <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN> , <http://model.geneontology.org/b13455ce-a57f-4725-bea7-6750f7ad2dd7_FORMATETHFLIG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_FORMATETHFLIG-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -800,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -816,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -831,7 +781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -864,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -878,17 +828,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -897,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -905,11 +844,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_c557b249-0a59-4d74-9294-8137184e520d_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -917,7 +856,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/c557b249-0a59-4d74-9294-8137184e520d_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN>
@@ -929,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -960,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -986,7 +925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1014,7 +953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1028,6 +967,40 @@
 <http://purl.obolibrary.org/obo/CHEBI_57783>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/4210e02c-6a7b-479a-b588-73f6d97031fe_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/eee3c532-3229-48b7-9219-9f30f2a3c3e9_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003674> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1037,9 +1010,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/3ad2bd11-a3e1-4e8f-9a8a-2e6b63f53c83_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN> ;
+                <http://model.geneontology.org/08d18870-3e8d-4044-997b-72e455b40a7f_METHYLENETHFDEHYDROG-NADP-RXN> , <http://model.geneontology.org/CHEBI_57783_METHYLENETHFDEHYDROG-NADP-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHYLENETHFDEHYDROG-NADP-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1047,7 +1020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1061,7 +1034,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1072,6 +1045,17 @@
           <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002234_b13455ce-a57f-4725-bea7-6750f7ad2dd7_FORMATETHFLIG-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/THYMIDYLATESYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004799> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1081,9 +1065,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/d7f1769f-135c-4f29-bf6f-ba52f8447785_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/4210e02c-6a7b-479a-b588-73f6d97031fe_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1091,13 +1075,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697BiochemicalReaction66122> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_62cd2644-8031-4a11-b010-56b1124174bb_1.5.1.20-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
@@ -1108,7 +1103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1121,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1132,7 +1127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1162,7 +1157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1185,7 +1180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1201,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1207,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1224,7 +1230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,35 +1241,13 @@
           <http://model.geneontology.org/CHEBI_15740_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_CHEBI_57540_1.5.1.20-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,40 +1258,6 @@
           <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN>
 ] .
 
-<http://model.geneontology.org/6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Provides Input For Rule. The relation 'L-serine + a tetrahydrofolate &harr; glycine + a 5,10-methylenetetrahydrofolate + H<sub>2</sub>O' 'null' 'a 5,10-methylenetetrahydrofolate + dUMP &rarr; dTMP + a 7,8-dihydrofolate' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
@@ -1316,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1350,7 +1300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1364,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1388,11 +1338,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_a78fb7ed-7cb3-44db-973c-8da242e6b762_1.5.1.20-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1400,7 +1350,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN>
+          <http://model.geneontology.org/a78fb7ed-7cb3-44db-973c-8da242e6b762_1.5.1.20-RXN>
 ] .
 
 <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN>
@@ -1412,9 +1362,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/c557b249-0a59-4d74-9294-8137184e520d_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/CHEBI_15377_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN> ;
+                <http://model.geneontology.org/CHEBI_15378_METHENYLTHFCYCLOHYDRO-RXN> , <http://model.geneontology.org/1132b178-12dc-4d9a-a44d-c75e98422686_METHENYLTHFCYCLOHYDRO-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> , <http://model.geneontology.org/YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -1422,30 +1372,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697BiochemicalReaction66510> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1455,7 +1388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,6 +1418,17 @@
           <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_c557b249-0a59-4d74-9294-8137184e520d_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/reaction_METHYLENETHFDEHYDROG-NADP-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
@@ -1493,11 +1437,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_0e0f97d1-a42d-4fdb-9489-2080ac737bee_GCVMULTI-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1505,7 +1449,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GCVMULTI-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN>
+          <http://model.geneontology.org/0e0f97d1-a42d-4fdb-9489-2080ac737bee_GCVMULTI-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002411_GLYOHMETRANS-RXN_SGD_PWY3O-697>
@@ -1513,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1525,7 +1469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1536,23 +1480,6 @@
           <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/CHEBI_63528>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1562,7 +1489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1573,13 +1500,30 @@
           <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
 ] .
 
+<http://model.geneontology.org/b13455ce-a57f-4725-bea7-6750f7ad2dd7_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002333_YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1590,6 +1534,17 @@
           <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_d7f1769f-135c-4f29-bf6f-ba52f8447785_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1599,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1619,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1630,12 +1585,12 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN_SGD_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_08d18870-3e8d-4044-997b-72e455b40a7f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1647,7 +1602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1667,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1683,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1695,7 +1650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1705,6 +1660,23 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/YGR204W-MONOMER_FORMATETHFLIG-RXN_controller>
 ] .
+
+<http://model.geneontology.org/a894d7aa-10c8-44b9-97c3-c201bfc9a13d_FORMATETHFLIG-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004048>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1717,7 +1689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1729,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,7 +1732,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1772,7 +1744,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1788,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1802,7 +1774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "folate interconversions - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1833,13 +1805,30 @@
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
 
+<http://model.geneontology.org/3ad2bd11-a3e1-4e8f-9a8a-2e6b63f53c83_METHYLENETHFDEHYDROG-NADP-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_1ec3d55c-b39a-4fd4-af14-f22d36c98bb1_1.5.1.15-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1847,15 +1836,32 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN>
+          <http://model.geneontology.org/1ec3d55c-b39a-4fd4-af14-f22d36c98bb1_1.5.1.15-RXN>
 ] .
+
+<http://model.geneontology.org/1ec3d55c-b39a-4fd4-af14-f22d36c98bb1_1.5.1.15-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_CHEBI_28938_GCVMULTI-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1868,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1881,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1895,7 +1901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1915,7 +1921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1926,17 +1932,6 @@
 <http://identifiers.org/sgd/S000005762>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004477>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1945,11 +1940,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_FORMATETHFLIG-RXN_RO_0002233_a894d7aa-10c8-44b9-97c3-c201bfc9a13d_FORMATETHFLIG-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1952,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/FORMATETHFLIG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN>
+          <http://model.geneontology.org/a894d7aa-10c8-44b9-97c3-c201bfc9a13d_FORMATETHFLIG-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_CHEBI_57540_1.5.1.15-RXN_SGD_PWY3O-697>
@@ -1965,7 +1960,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002233_0e0f97d1-a42d-4fdb-9489-2080ac737bee_GCVMULTI-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -1976,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1989,9 +1995,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLYOHMETRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/d791c22b-87a5-4a26-ad4c-6c783e504442_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_33384_GLYOHMETRANS-RXN> , <http://model.geneontology.org/6fb4bc0e-a7e9-43c7-876f-d5f85029fdbb_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN> , <http://model.geneontology.org/CHEBI_15377_GLYOHMETRANS-RXN> , <http://model.geneontology.org/8a718581-2913-4105-8ed2-79c0b0db8897_GLYOHMETRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR058C-MONOMER_GLYOHMETRANS-RXN_controller> , <http://model.geneontology.org/YBR263W-MONOMER_GLYOHMETRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2001,7 +2007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,7 +2021,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,7 +2037,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002233_1ec3d55c-b39a-4fd4-af14-f22d36c98bb1_1.5.1.15-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2046,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2059,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2071,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2082,13 +2099,24 @@
           <http://model.geneontology.org/CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002234_a78fb7ed-7cb3-44db-973c-8da242e6b762_1.5.1.20-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_CHEBI_58349_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,7 +2136,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2119,30 +2147,47 @@
           <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN>
 ] .
 
+<http://model.geneontology.org/a78fb7ed-7cb3-44db-973c-8da242e6b762_1.5.1.20-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002233_6fb4bc0e-a7e9-43c7-876f-d5f85029fdbb_GLYOHMETRANS-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/ECO_0000313>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002234_ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_4210e02c-6a7b-479a-b588-73f6d97031fe_THYMIDYLATESYN-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2150,27 +2195,33 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/4210e02c-6a7b-479a-b588-73f6d97031fe_THYMIDYLATESYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002233_8b6572c0-f9f3-40e1-8f04-e213f3ea52cb_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/05aa216a-cb03-4619-b19d-d551b60db314_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_8a718581-2913-4105-8ed2-79c0b0db8897_GLYOHMETRANS-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2178,7 +2229,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLYOHMETRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN>
+          <http://model.geneontology.org/8a718581-2913-4105-8ed2-79c0b0db8897_GLYOHMETRANS-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2187,7 +2238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2223,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2237,7 +2288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2257,7 +2308,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2270,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2278,11 +2329,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_1132b178-12dc-4d9a-a44d-c75e98422686_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2290,8 +2341,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHENYLTHFCYCLOHYDRO-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN>
+          <http://model.geneontology.org/1132b178-12dc-4d9a-a44d-c75e98422686_METHENYLTHFCYCLOHYDRO-RXN>
 ] .
+
+<http://model.geneontology.org/1132b178-12dc-4d9a-a44d-c75e98422686_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 10-formyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000000467>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2301,7 +2369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2312,7 +2380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2325,7 +2393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2339,7 +2407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2355,7 +2423,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_8a718581-2913-4105-8ed2-79c0b0db8897_GLYOHMETRANS-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2374,9 +2453,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.15-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/6ad5f189-4ca5-4027-8c75-c7992bec5c3d_1.5.1.15-RXN> , <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.15-RXN> , <http://model.geneontology.org/1ec3d55c-b39a-4fd4-af14-f22d36c98bb1_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_1.5.1.15-RXN> , <http://model.geneontology.org/eee3c532-3229-48b7-9219-9f30f2a3c3e9_1.5.1.15-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-317_1.5.1.15-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2384,7 +2463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2392,24 +2471,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2428,7 +2496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2449,7 +2517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2463,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2479,7 +2547,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2490,7 +2558,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2502,7 +2570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2520,7 +2588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2533,7 +2601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2548,7 +2616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2561,7 +2629,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2575,7 +2643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2594,11 +2662,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_4306907a-96df-4ee8-b623-174805e88efb_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2606,7 +2674,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROFOLATEREDUCT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN>
+          <http://model.geneontology.org/4306907a-96df-4ee8-b623-174805e88efb_DIHYDROFOLATEREDUCT-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57305_GLYOHMETRANS-RXN>
@@ -2618,7 +2686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2632,7 +2700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2655,7 +2723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2665,23 +2733,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
-
-<http://model.geneontology.org/29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66168> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_16526>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -2695,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2712,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2723,23 +2774,6 @@
           <http://model.geneontology.org/CHEBI_43474_FORMATETHFLIG-RXN>
 ] .
 
-<http://model.geneontology.org/4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -2749,7 +2783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2763,29 +2797,12 @@
 <http://purl.obolibrary.org/obo/RO_0002411>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_CHEBI_58349_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2800,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2810,11 +2827,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_3ad2bd11-a3e1-4e8f-9a8a-2e6b63f53c83_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2822,25 +2839,8 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/METHYLENETHFDEHYDROG-NADP-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/74e8227c-0ccd-42cd-baf9-8a7c5e694c4f_METHYLENETHFDEHYDROG-NADP-RXN>
+          <http://model.geneontology.org/3ad2bd11-a3e1-4e8f-9a8a-2e6b63f53c83_METHYLENETHFDEHYDROG-NADP-RXN>
 ] .
-
-<http://model.geneontology.org/26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2848,7 +2848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2864,7 +2864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2875,25 +2875,25 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002233_26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://purl.obolibrary.org/obo/CHEBI_33695>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_DIHYDROFOLATEREDUCT-RXN_RO_0002234_05aa216a-cb03-4619-b19d-d551b60db314_DIHYDROFOLATEREDUCT-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_33695>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/reaction_METHENYLTHFCYCLOHYDRO-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -2903,22 +2903,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_5dfa5a19-88b1-4b52-8134-0399bc65e61f_GLYOHMETRANS-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/d7f1769f-135c-4f29-bf6f-ba52f8447785_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2926,7 +2932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2943,7 +2949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2959,7 +2965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2972,7 +2978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2985,7 +2991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -2997,7 +3003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,12 +3014,23 @@
           <http://model.geneontology.org/GLYOHMETRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_METHYLENETHFDEHYDROG-NADP-RXN_RO_0002233_3ad2bd11-a3e1-4e8f-9a8a-2e6b63f53c83_METHYLENETHFDEHYDROG-NADP-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002333_CPLX3O-630_THYMIDYLATESYN-RXN_controller_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3024,7 +3041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3035,7 +3052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3047,7 +3064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3058,30 +3075,13 @@
           <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN>
 ] .
 
-<http://model.geneontology.org/c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002333_YBR084W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3097,18 +3097,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_c4cf8306-53c8-478d-aacf-b8cd2662f61e_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
+<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_1132b178-12dc-4d9a-a44d-c75e98422686_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3120,7 +3120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3131,44 +3131,27 @@
           <http://model.geneontology.org/PWY3O-697/PWY3O-697>
 ] .
 
-<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YBR263W-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
+<http://model.geneontology.org/ev_w_id_CPLX3O-317_1.5.1.15-RXN_controller_BFO_0000051_SGD_S000001788_CPLX3O-317_component_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3176,7 +3159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3196,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3207,12 +3190,23 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GCVMULTI-RXN_RO_0002234_2e1815a0-d086-4601-bec1-23c41c3f34dc_GCVMULTI-RXN_SGD_PWY3O-697>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_CHEBI_57945_1.5.1.15-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3227,7 +3221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3244,28 +3238,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66412> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3281,9 +3258,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GCVMULTI-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> , <http://model.geneontology.org/74ced2d1-a42e-44f1-b90c-d373704470f0_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/0e0f97d1-a42d-4fdb-9489-2080ac737bee_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57540_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_57305_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> , <http://model.geneontology.org/1e985aae-1c9d-4322-bf71-68e3d293c94c_GCVMULTI-RXN> ;
+                <http://model.geneontology.org/CHEBI_57945_GCVMULTI-RXN> , <http://model.geneontology.org/2e1815a0-d086-4601-bec1-23c41c3f34dc_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_16526_GCVMULTI-RXN> , <http://model.geneontology.org/CHEBI_28938_GCVMULTI-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-213_GCVMULTI-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -3291,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3307,7 +3284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3323,7 +3300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3336,7 +3313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3349,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3360,7 +3337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3372,7 +3349,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3392,7 +3369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3412,9 +3389,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DIHYDROFOLATEREDUCT-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/26254cbe-a9ee-4202-a53a-fd3d6f3521ae_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/4306907a-96df-4ee8-b623-174805e88efb_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_58349_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/d0af0f96-4fc5-4611-ba67-5b8d4058c324_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
+                <http://model.geneontology.org/05aa216a-cb03-4619-b19d-d551b60db314_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_57783_DIHYDROFOLATEREDUCT-RXN> , <http://model.geneontology.org/CHEBI_15378_DIHYDROFOLATEREDUCT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR236W-MONOMER_DIHYDROFOLATEREDUCT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3422,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3430,23 +3407,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002234_c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN_SGD_PWY3O-697>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002234_CHEBI_15377_GLYOHMETRANS-RXN_SGD_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3454,11 +3420,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_eee3c532-3229-48b7-9219-9f30f2a3c3e9_1.5.1.15-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3466,7 +3432,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.15-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/4e6313f5-7afe-46e1-8851-4f3c78259383_1.5.1.15-RXN>
+          <http://model.geneontology.org/eee3c532-3229-48b7-9219-9f30f2a3c3e9_1.5.1.15-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-213_GCVMULTI-RXN_controller_BFO_0000051_http_//purl.obolibrary.org/obo/CHEBI_33695_CPLX3O-213_component_SGD_PWY3O-697>
@@ -3474,7 +3440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3485,7 +3451,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-697" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_1.5.1.15-RXN_RO_0002234_eee3c532-3229-48b7-9219-9f30f2a3c3e9_1.5.1.15-RXN_SGD_PWY3O-697>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3502,7 +3479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3519,7 +3496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3530,43 +3507,32 @@
           <http://model.geneontology.org/CHEBI_456216_FORMATETHFLIG-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000003436>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ec1542db-cbb7-4e36-b109-47b59253232e_METHYLENETHFDEHYDROG-NADP-RXN>
+<http://model.geneontology.org/8a718581-2913-4105-8ed2-79c0b0db8897_GLYOHMETRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methenyltetrahydrofolate" ;
+                "a 5,10-methylenetetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://identifiers.org/sgd/S000003436>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/SGD_S000001876_CPLX3O-213_component>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001876> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_29216a09-1534-4f57-abd7-57392ac73a1c_THYMIDYLATESYN-RXN_SGD_PWY3O-697>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-697" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3579,15 +3545,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_1.5.1.20-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_1.5.1.20-RXN> , <http://model.geneontology.org/62cd2644-8031-4a11-b010-56b1124174bb_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/f7c6f567-e4bd-4017-b6f7-55cd86360dc4_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
+                <http://model.geneontology.org/a78fb7ed-7cb3-44db-973c-8da242e6b762_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_57945_1.5.1.20-RXN> , <http://model.geneontology.org/CHEBI_15378_1.5.1.20-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL125W-MONOMER_1.5.1.20-RXN_controller> , <http://model.geneontology.org/YPL023C-MONOMER_1.5.1.20-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3601,7 +3567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3619,7 +3585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3634,7 +3600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3651,7 +3617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3665,7 +3631,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3681,7 +3647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3692,7 +3658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3709,18 +3675,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/c557b249-0a59-4d74-9294-8137184e520d_METHENYLTHFCYCLOHYDRO-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methenyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_METHENYLTHFCYCLOHYDRO-RXN_RO_0002411_FORMATETHFLIG-RXN_SGD_PWY3O-697>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3729,20 +3712,20 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/c38b0f2f-9e24-4b99-abfc-b15351124e65_METHENYLTHFCYCLOHYDRO-RXN>
+<http://model.geneontology.org/0e0f97d1-a42d-4fdb-9489-2080ac737bee_GCVMULTI-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 10-formyltetrahydrofolate" ;
+                "a tetrahydrofolate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66382> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3758,7 +3741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3772,7 +3755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3786,13 +3769,30 @@
 <http://purl.obolibrary.org/obo/CHEBI_43474>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/4306907a-96df-4ee8-b623-174805e88efb_DIHYDROFOLATEREDUCT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a tetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002333_YLR058C-MONOMER_GLYOHMETRANS-RXN_controller_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3808,7 +3808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3819,7 +3819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3834,7 +3834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3848,7 +3848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3864,7 +3864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3872,11 +3872,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN_SGD_PWY3O-697> ;
+          <http://model.geneontology.org/ev_w_id_1.5.1.20-RXN_RO_0002233_62cd2644-8031-4a11-b010-56b1124174bb_1.5.1.20-RXN_SGD_PWY3O-697> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3884,7 +3884,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/1.5.1.20-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/dfa2008c-e19d-4b18-8830-6d5300076755_1.5.1.20-RXN>
+          <http://model.geneontology.org/62cd2644-8031-4a11-b010-56b1124174bb_1.5.1.20-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_GLYOHMETRANS-RXN_RO_0002411_1.5.1.20-RXN_SGD_PWY3O-697>
@@ -3892,7 +3892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3907,7 +3907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3924,7 +3924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3935,12 +3935,29 @@
           <http://model.geneontology.org/YGR204W-MONOMER_METHENYLTHFCYCLOHYDRO-RXN_controller>
 ] .
 
+<http://model.geneontology.org/2e1815a0-d086-4601-bec1-23c41c3f34dc_GCVMULTI-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66130> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000066_reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829_null_PWY3O-697>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3951,7 +3968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -3965,7 +3982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3982,7 +3999,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3998,7 +4015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -4013,7 +4030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4036,7 +4053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4049,7 +4066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -4064,7 +4081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4077,7 +4094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-697" ;
         <http://purl.org/pav/providedBy>
@@ -4089,7 +4106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4109,7 +4126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4123,7 +4140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4143,27 +4160,10 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66480> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/17232f80-3318-4251-8eba-c7cbaad4304f_FORMATETHFLIG-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a tetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-697" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-697SmallMolecule66206> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/PWY3O-7-PWY3O-7.ttl
+++ b/models/PWY3O-7-PWY3O-7.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +22,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -36,7 +36,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -56,7 +56,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -72,7 +72,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -128,7 +128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -142,7 +142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -172,7 +172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -268,7 +268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -331,7 +331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -350,7 +350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -368,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -462,7 +462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -490,7 +490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -598,7 +598,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -676,7 +676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -690,7 +690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -767,7 +767,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -817,7 +817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -828,7 +828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -843,7 +843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -886,7 +886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -916,7 +916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1008,7 +1008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1025,7 +1025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1083,7 +1083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1095,7 +1095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1179,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1194,7 +1194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1209,7 +1209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1229,7 +1229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1249,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1263,7 +1263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1283,7 +1283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1299,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1314,7 +1314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1386,7 +1386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1405,7 +1405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1428,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1448,7 +1448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1509,7 +1509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1522,7 +1522,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1534,17 +1534,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_58349>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY3O-7>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-7" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YER052C-MONOMER_ASPARTATEKIN-RXN_controller>
         a       <http://identifiers.org/sgd/S000000854> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1552,13 +1541,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-7Protein39569> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_RO_0002333_YLR027C-MONOMER_ASPAMINOTRANS-RXN_controller_SGD_PWY3O-7>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-7" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_29985_ASPAMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
@@ -1569,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1584,7 +1584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1615,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1631,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1642,7 +1642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1654,7 +1654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1671,7 +1671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1691,7 +1691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1704,7 +1704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1722,7 +1722,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1736,7 +1736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1773,7 +1773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1789,7 +1789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1801,7 +1801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1842,7 +1842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1853,7 +1853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1896,7 +1896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1940,7 +1940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1957,7 +1957,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1973,7 +1973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -1990,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2005,7 +2005,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2022,7 +2022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2035,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2047,7 +2047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2063,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2078,7 +2078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2098,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2128,7 +2128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2145,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2162,7 +2162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2179,7 +2179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2229,7 +2229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2245,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2256,7 +2256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2270,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2281,7 +2281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2292,7 +2292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2303,7 +2303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2334,7 +2334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2350,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2362,7 +2362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2382,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2399,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2415,7 +2415,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2430,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2450,7 +2450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2464,7 +2464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,7 +2487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2514,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2535,7 +2535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2551,7 +2551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2571,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2591,7 +2591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2607,7 +2607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2635,7 +2635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2648,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2660,7 +2660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2676,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2688,7 +2688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2718,7 +2718,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2734,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2745,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2756,7 +2756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2771,7 +2771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2785,7 +2785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2815,7 +2815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2829,7 +2829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2849,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2863,7 +2863,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2882,7 +2882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2893,7 +2893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2908,7 +2908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2935,7 +2935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>
@@ -2946,7 +2946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-7" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-7" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-70-PWY3O-70.ttl
+++ b/models/PWY3O-70-PWY3O-70.ttl
@@ -13,7 +13,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -43,28 +43,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "chitosan" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69333> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_17029_CHITIN-DEACETYLASE-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_17029> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -75,7 +58,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -94,18 +77,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/4e4dd9d0-36b4-4931-8563-a02a5c68b73f_CHITIN-DEACETYLASE-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "chitosan" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-70SmallMolecule69333> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000050_PWY3O-70/PWY3O-70_SGD_PWY3O-70>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,7 +215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,6 +243,17 @@
 <http://purl.obolibrary.org/obo/RO_0002233>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_4e4dd9d0-36b4-4931-8563-a02a5c68b73f_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-70" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -252,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -274,7 +285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -321,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -343,13 +354,13 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15377_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_17029_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30089_CHITIN-DEACETYLASE-RXN> , <http://model.geneontology.org/4e4dd9d0-36b4-4931-8563-a02a5c68b73f_CHITIN-DEACETYLASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR307W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> , <http://model.geneontology.org/YLR308W-MONOMER_CHITIN-DEACETYLASE-RXN_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -363,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,23 +388,12 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-70" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_BFO_0000066_reaction_CHITIN-DEACETYLASE-RXN_location_lociGO_0005829_null_PWY3O-70>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-70" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -427,11 +427,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70> ;
+          <http://model.geneontology.org/ev_w_id_CHITIN-DEACETYLASE-RXN_RO_0002234_4e4dd9d0-36b4-4931-8563-a02a5c68b73f_CHITIN-DEACETYLASE-RXN_SGD_PWY3O-70> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -439,7 +439,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CHITIN-DEACETYLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0f164e4c-9e5a-4cfa-942f-260fd5f33c59_CHITIN-DEACETYLASE-RXN>
+          <http://model.geneontology.org/4e4dd9d0-36b4-4931-8563-a02a5c68b73f_CHITIN-DEACETYLASE-RXN>
 ] .
 
 <http://model.geneontology.org/PWY3O-70>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-70" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "chitosan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-743-PWY3O-743.ttl
+++ b/models/PWY3O-743-PWY3O-743.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -29,13 +29,28 @@
           <http://model.geneontology.org/CHEBI_16235_GUANPRIBOSYLTRAN-RXN>
 ] .
 
+<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "hypoxanthine guanine phosphoribosyltransferase" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-743Protein47990> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002233_CHEBI_16235_GUANINE-DEAMINASE-RXN_SGD_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,21 +60,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16235_GUANINE-DEAMINASE-RXN>
 ] .
-
-<http://model.geneontology.org/YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002807> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "hypoxanthine guanine phosphoribosyltransferase" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-743Protein47990> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -104,7 +104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -160,7 +160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -235,7 +235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -247,7 +247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -303,7 +303,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -351,7 +351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -381,7 +381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -399,7 +399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -436,7 +436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -532,7 +532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -577,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -634,7 +634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -689,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -805,7 +805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -831,7 +831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -845,7 +845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -861,7 +861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -873,7 +873,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of guanine, xanthine and their nucleosides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -930,19 +930,19 @@
 <http://purl.obolibrary.org/obo/CHEBI_58017>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002411_GUANPRIBOSYLTRAN-RXN_SGD_PWY3O-743>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -971,7 +971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -982,24 +982,13 @@
           <http://model.geneontology.org/CHEBI_58017_GUANPRIBOSYLTRAN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-743>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-743" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GUANINE-DEAMINASE-RXN_RO_0002234_CHEBI_17712_GUANINE-DEAMINASE-RXN_SGD_PWY3O-743> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1009,6 +998,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_17712_GUANINE-DEAMINASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_GUANPRIBOSYLTRAN-RXN_RO_0002333_YDR399W-MONOMER_GUANPRIBOSYLTRAN-RXN_controller_SGD_PWY3O-743>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-743" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://identifiers.org/sgd/S000002397>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1046,7 +1046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1083,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-743" ;
         <http://purl.org/pav/providedBy>
@@ -1114,7 +1114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1128,7 +1128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1161,7 +1161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-743" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-743" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-8-PWY3O-8.ttl
+++ b/models/PWY3O-8-PWY3O-8.ttl
@@ -5,7 +5,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -24,7 +24,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -47,7 +47,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -67,30 +67,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61293> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY3O-8> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/D-XYLULOSE-REDUCTASE-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN>
-] .
 
 <http://model.geneontology.org/CHEBI_57783_RXN-8773>
         a       <http://purl.obolibrary.org/obo/CHEBI_57783> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -101,13 +84,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8SmallMolecule61255> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_D-XYLULOSE-REDUCTASE-RXN_RO_0002234_CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN_SGD_PWY3O-8> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/D-XYLULOSE-REDUCTASE-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_D-XYLULOSE-REDUCTASE-RXN>
+] .
 
 <http://purl.obolibrary.org/obo/CHEBI_17151>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -209,7 +209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -232,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -290,7 +290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -395,7 +395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -425,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -436,7 +436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "xylose metabolism - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -529,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -600,7 +600,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -649,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -700,7 +700,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -720,7 +720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -768,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -780,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8" ;
         <http://purl.org/pav/providedBy>
@@ -808,7 +808,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -836,7 +836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWY3O-8514-PWY3O-8514.ttl
+++ b/models/PWY3O-8514-PWY3O-8514.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -40,7 +40,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -87,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -99,7 +99,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -138,7 +138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -165,7 +165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -253,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -283,7 +283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -334,7 +334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -454,7 +454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -471,7 +471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "palmitate biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -499,7 +499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -570,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -605,7 +605,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -632,7 +632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -658,7 +658,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -675,7 +675,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -715,7 +715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -728,7 +728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -765,7 +765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -782,7 +782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -821,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -881,7 +881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -901,7 +901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -915,7 +915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -933,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -946,7 +946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -958,7 +958,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,7 +1006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1022,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1037,7 +1037,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1053,7 +1053,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1086,7 +1086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1123,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1140,7 +1140,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1168,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,7 +1252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1267,7 +1267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1297,29 +1297,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/reaction_RXN-9539_location_lociGO_0005829>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
-
-<http://model.geneontology.org/YKL182W-MONOMER_RXN3O-9780_controller>
-        a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "fatty acid synthase, beta subunit" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8514Protein18956> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1327,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1338,6 +1320,24 @@
           <http://model.geneontology.org/CHEBI_57783_RXN-9542>
 ] .
 
+<http://model.geneontology.org/YKL182W-MONOMER_RXN3O-9780_controller>
+        a       <http://identifiers.org/sgd/S000001665> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "fatty acid synthase, beta subunit" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-8514Protein18956> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/reaction_RXN-9539_location_lociGO_0005829>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1347,7 +1347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1391,7 +1391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1405,7 +1405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1422,7 +1422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1438,7 +1438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1453,7 +1453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1466,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1478,7 +1478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1495,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1546,7 +1546,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1599,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1611,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1662,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1678,7 +1678,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1694,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1706,7 +1706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1723,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1743,7 +1743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1756,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1767,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1782,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1799,7 +1799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1816,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1829,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1844,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1860,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1905,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1918,7 +1918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -1946,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1960,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1977,7 +1977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2002,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2014,7 +2014,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2031,7 +2031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2051,7 +2051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,7 +2065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2081,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2096,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2112,7 +2112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2141,7 +2141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,7 +2161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2175,7 +2175,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2194,7 +2194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-8514" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-8514" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-862-PWY3O-862.ttl
+++ b/models/PWY3O-862-PWY3O-862.ttl
@@ -1,10 +1,21 @@
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002234_CHEBI_12876_RXN3O-1118_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -15,23 +26,12 @@
           <http://model.geneontology.org/CHEBI_12876_RXN3O-1118>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002234_CHEBI_58179_RXN3O-9805_SGD_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-1121_BFO_0000050_PWY3O-862/PWY3O-862_SGD_PWY3O-862>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -96,7 +96,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -113,7 +113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -129,7 +129,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -233,7 +233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -329,7 +329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -455,7 +455,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -475,7 +475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -486,12 +486,15 @@
 <http://identifiers.org/sgd/S000005651>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -520,7 +523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -568,7 +571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -597,7 +600,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -614,7 +617,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -643,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -662,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -679,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -717,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -742,7 +745,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +762,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,25 +773,25 @@
           <http://model.geneontology.org/CHEBI_128769_FPPSYN-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-1120_RO_0002413_RXN3O-1121_null_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FARNESYLTRANSTRANSFERASE-RXN_RO_0002233_CHEBI_175763_FARNESYLTRANSTRANSFERASE-RXN_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -801,7 +804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -818,7 +821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -836,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -863,7 +866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -878,7 +881,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -892,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -912,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -928,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -940,7 +943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -975,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -986,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +1001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1034,7 +1037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1053,7 +1056,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1075,7 +1078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1105,7 +1108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1129,7 +1132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1140,7 +1143,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1155,7 +1158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1168,7 +1171,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1180,7 +1183,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1223,7 +1226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1238,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1251,7 +1254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1263,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1279,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1296,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1331,7 +1334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1344,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1381,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1395,7 +1398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1411,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1422,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1445,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1468,7 +1471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,7 +1490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1503,7 +1506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1518,7 +1521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1535,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1598,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1610,7 +1613,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1630,7 +1633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1646,7 +1649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1662,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -1677,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1694,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1714,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1733,7 +1736,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1753,7 +1756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1767,7 +1770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1784,7 +1787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1807,7 +1810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1824,7 +1827,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1857,9 +1860,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_null_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1872,24 +1886,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52040> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002413_2.1.1.114-RXN_null_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_64253_RXN3O-102>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_64253> ;
@@ -1900,7 +1903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1923,7 +1926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1943,7 +1946,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1957,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1974,7 +1977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1990,7 +1993,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2008,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2021,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2044,24 +2047,13 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_null_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_30763_RXN-9003_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2072,13 +2064,24 @@
           <http://model.geneontology.org/CHEBI_30763_RXN-9003>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-8813_RO_0002413_RXN3O-9805_null_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-75_RO_0002233_CHEBI_17499_RXN3O-75_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2098,7 +2101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2111,7 +2114,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2129,7 +2132,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2143,7 +2146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2163,7 +2166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2177,7 +2180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2194,7 +2197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2210,7 +2213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2224,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2236,7 +2239,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2252,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2267,7 +2270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2284,7 +2287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2301,7 +2304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2318,7 +2321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2331,7 +2334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2343,7 +2346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2359,7 +2362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2371,7 +2374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,7 +2390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2402,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2415,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2427,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2444,7 +2447,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2461,7 +2464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2478,7 +2481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2495,7 +2498,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,7 +2514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2524,7 +2527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2538,7 +2541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2554,7 +2557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2565,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2580,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2593,7 +2596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2605,7 +2608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2644,7 +2647,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2657,7 +2660,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2668,7 +2671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2679,7 +2682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2693,7 +2696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2709,7 +2712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2720,7 +2723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2735,7 +2738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2754,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2765,7 +2768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2780,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2797,7 +2800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2816,7 +2819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2837,7 +2840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2850,7 +2853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2871,7 +2874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2888,7 +2891,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2908,7 +2911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2921,7 +2924,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -2944,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2960,7 +2963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2977,7 +2980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2993,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3007,7 +3010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3019,7 +3022,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3036,7 +3039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3056,7 +3059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3083,7 +3086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3096,7 +3099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3110,7 +3113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3122,7 +3125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3131,40 +3134,6 @@
           <http://model.geneontology.org/RXN3O-12> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15377_RXN3O-12>
-] .
-
-<http://model.geneontology.org/CHEBI_1109_RXN3O-73>
-        a       <http://purl.obolibrary.org/obo/CHEBI_1109> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "2-hexaprenyl-6-methoxyphenol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52040> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CHORPYRLY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_29748_CHORPYRLY-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_58179_RXN-9003>
@@ -3176,11 +3145,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51794> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002233_CHEBI_29748_CHORPYRLY-RXN_SGD_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CHORPYRLY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_29748_CHORPYRLY-RXN>
+] .
+
+<http://model.geneontology.org/CHEBI_1109_RXN3O-73>
+        a       <http://purl.obolibrary.org/obo/CHEBI_1109> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "2-hexaprenyl-6-methoxyphenol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52040> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3189,7 +3192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3202,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3216,7 +3219,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3227,24 +3230,13 @@
           <http://model.geneontology.org/HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_RO_0002234_CHEBI_15378_2.1.1.114-RXN_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3254,6 +3246,17 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_2.1.1.114-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-9003_RO_0002233_CHEBI_58179_RXN-9003_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/RXN3O-54>
         a       <http://purl.obolibrary.org/obo/GO_0043333> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -3274,7 +3277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3293,7 +3296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3313,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3338,7 +3341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3352,7 +3355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3368,7 +3371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3395,7 +3398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3409,7 +3412,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3425,7 +3428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3437,7 +3440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3453,7 +3456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3467,7 +3470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3481,7 +3484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3497,7 +3500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3509,7 +3512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3525,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3536,7 +3539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3553,7 +3556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3565,7 +3568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3595,7 +3598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3611,14 +3614,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/CHEBI_24331>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3626,7 +3626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3643,7 +3643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3659,7 +3659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3671,7 +3671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3690,7 +3690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3706,7 +3706,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3724,7 +3724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3741,7 +3741,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3755,7 +3755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3774,7 +3774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3790,7 +3790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3805,7 +3805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3821,7 +3821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3841,7 +3841,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3857,7 +3857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3877,7 +3877,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3893,7 +3893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3904,7 +3904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -3932,7 +3932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3946,7 +3946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3966,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3975,7 +3975,7 @@
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15339_RXN3O-75>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24331> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3983,7 +3983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3996,7 +3996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4008,7 +4008,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4025,7 +4025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4043,7 +4043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4062,7 +4062,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4090,7 +4090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4109,7 +4109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4125,18 +4125,35 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
+        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52090> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-12_RO_0002233_CHEBI_15379_RXN3O-12_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4159,7 +4176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4167,29 +4184,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_57916_RXN3O-73>
-        a       <http://purl.obolibrary.org/obo/CHEBI_57916> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "3-methoxy-4-hydroxy-5-<i>all-trans</i>-hexaprenylbenzoate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule52090> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-58_RO_0002233_CHEBI_15378_RXN3O-58_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4207,7 +4207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4221,7 +4221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4237,7 +4237,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4251,7 +4251,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4267,7 +4267,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4282,7 +4282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4296,7 +4296,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4315,7 +4315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4331,7 +4331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4346,7 +4346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4366,7 +4366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4383,7 +4383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4400,7 +4400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4420,7 +4420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4434,7 +4434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4451,7 +4451,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4474,7 +4474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4488,7 +4488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4505,7 +4505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4516,6 +4516,17 @@
           <http://model.geneontology.org/PWY3O-862/PWY3O-862>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002411_RXN3O-1118_SGD_PWY3O-862>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57288_RXN3O-1120>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -4525,7 +4536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4533,23 +4544,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_RO_0002411_RXN3O-1118_SGD_PWY3O-862>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_128769_RXN3O-9805_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4566,7 +4566,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4582,7 +4582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4597,7 +4597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4610,7 +4610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4621,7 +4621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4636,7 +4636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4656,7 +4656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4672,7 +4672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4692,7 +4692,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4709,7 +4709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4725,7 +4725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4736,7 +4736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4754,7 +4754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4767,7 +4767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4778,7 +4778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4790,7 +4790,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4807,7 +4807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4823,7 +4823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4836,7 +4836,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4849,7 +4849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4860,7 +4860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4885,7 +4885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4893,19 +4893,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://www.w3.org/2004/02/skos/core#exactMatch>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-1118_RO_0002233_CHEBI_10980_RXN3O-1118_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://www.w3.org/2004/02/skos/core#exactMatch>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4913,7 +4913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4935,7 +4935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -4947,7 +4947,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4966,7 +4966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4989,7 +4989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5004,7 +5004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5019,7 +5019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5033,7 +5033,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5050,7 +5050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5079,7 +5079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of ubiquinone biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -5095,7 +5095,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5111,7 +5111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5123,7 +5123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5139,7 +5139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5151,7 +5151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5167,7 +5167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5181,7 +5181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5197,7 +5197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5211,7 +5211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5225,7 +5225,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5242,7 +5242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5258,7 +5258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5269,7 +5269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5283,7 +5283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5300,7 +5300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5317,7 +5317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5334,7 +5334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5350,7 +5350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5361,7 +5361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5376,7 +5376,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5390,7 +5390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5410,7 +5410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5427,7 +5427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5440,7 +5440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5452,7 +5452,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5469,7 +5469,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5489,7 +5489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5516,7 +5516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5544,7 +5544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5558,7 +5558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5575,7 +5575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5591,7 +5591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5602,7 +5602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5613,7 +5613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5631,7 +5631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5648,7 +5648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5664,7 +5664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5679,7 +5679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5696,7 +5696,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5712,7 +5712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5727,7 +5727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5740,7 +5740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5754,7 +5754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5774,7 +5774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5791,7 +5791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5810,7 +5810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5822,7 +5822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5838,7 +5838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5849,7 +5849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5860,7 +5860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5877,7 +5877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5893,7 +5893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5904,7 +5904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -5925,7 +5925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5942,7 +5942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5962,7 +5962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5979,7 +5979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5992,7 +5992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6003,7 +6003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6017,14 +6017,14 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_17499_RXN3O-75>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -6032,7 +6032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6046,7 +6046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6063,7 +6063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6079,7 +6079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6094,7 +6094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6111,7 +6111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6131,7 +6131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6144,7 +6144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6158,7 +6158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6169,13 +6169,24 @@
           <http://model.geneontology.org/FARNESYLTRANSTRANSFERASE-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_null_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_2.1.1.114-RXN_BFO_0000050_PWY3O-862/PWY3O-862_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6186,16 +6197,22 @@
           <http://model.geneontology.org/PWY3O-862/PWY3O-862>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_BFO_0000066_reaction_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_location_lociGO_0005829_null_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58179> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "all-<i>trans</i>-hexaprenyl diphosphate" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-862" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51794> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -6203,7 +6220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6220,7 +6237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6230,23 +6247,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_RXN3O-12>
 ] .
-
-<http://model.geneontology.org/CHEBI_58179_RXN3O-9805>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58179> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "all-<i>trans</i>-hexaprenyl diphosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51794> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_84492>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -6260,7 +6260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6273,7 +6273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6285,7 +6285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6301,7 +6301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6312,7 +6312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6323,7 +6323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6334,7 +6334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6346,7 +6346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6369,7 +6369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -6389,7 +6389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6406,7 +6406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6419,7 +6419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6433,7 +6433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6444,7 +6444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6458,7 +6458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6472,7 +6472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6483,7 +6483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6501,7 +6501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6518,7 +6518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6535,7 +6535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6551,7 +6551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6562,7 +6562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6573,7 +6573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6585,7 +6585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6604,7 +6604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6624,7 +6624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6637,7 +6637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6655,7 +6655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6674,7 +6674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6691,7 +6691,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6711,7 +6711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6724,7 +6724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6735,7 +6735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6746,7 +6746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6761,7 +6761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6774,7 +6774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6785,7 +6785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6800,7 +6800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6814,7 +6814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6830,7 +6830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6845,7 +6845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6872,7 +6872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6888,7 +6888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -6896,28 +6896,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN3O-9805_SGD_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-9805> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57907_RXN3O-9805>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-102_RO_0002234_CHEBI_15378_RXN3O-102_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6937,13 +6920,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-862SmallMolecule51974> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-9805_RO_0002233_CHEBI_57907_RXN3O-9805_SGD_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-9805> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57907_RXN3O-9805>
+] .
 
 <http://model.geneontology.org/CHEBI_59789_RXN3O-54>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_59789> ;
@@ -6954,7 +6954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6971,7 +6971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -6999,7 +6999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7008,42 +7008,12 @@
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_null_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/BFO_0000066> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-58> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/reaction_RXN3O-58_location_lociGO_0005829>
-] .
-
-<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_PWY3O-862/PWY3O-862_SGD_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GPPSYN-RXN_RO_0002234_CHEBI_58057_GPPSYN-RXN_SGD_PWY3O-862> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7054,12 +7024,42 @@
           <http://model.geneontology.org/CHEBI_58057_GPPSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_BFO_0000050_PWY3O-862/PWY3O-862_SGD_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-58_BFO_0000066_reaction_RXN3O-58_location_lociGO_0005829_null_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/BFO_0000066> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-58> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/reaction_RXN3O-58_location_lociGO_0005829>
+] .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-1116_RO_0002411_HYDROXYPHENYLPYRUVATE-REDUCTASE-RXN_SGD_PWY3O-862>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7071,7 +7071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7087,7 +7087,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7098,7 +7098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7113,7 +7113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7130,7 +7130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7144,7 +7144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7158,16 +7158,22 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_PWY3O-862>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:PWY3O-862" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY3O-862> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002411> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/CHORPYRLY-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-1121>
+] .
 
 <http://model.geneontology.org/FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004337> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7188,7 +7194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7196,22 +7202,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CHORPYRLY-RXN_RO_0002411_RXN3O-1121_SGD_PWY3O-862> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002411> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/CHORPYRLY-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-1121>
-] .
+<http://model.geneontology.org/ev_w_id_RXN3O-9805_BFO_0000066_reaction_RXN3O-9805_location_lociGO_0005829_null_PWY3O-862>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:PWY3O-862" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_175763_FPPSYN-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_175763> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -7222,7 +7222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7236,7 +7236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7253,7 +7253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7269,7 +7269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>
@@ -7284,7 +7284,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -7304,7 +7304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -7317,7 +7317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-862" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-862" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-94-PWY3O-94.ttl
+++ b/models/PWY3O-94-PWY3O-94.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -99,7 +99,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -111,7 +111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -171,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -233,7 +233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +312,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -350,16 +350,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://purl.obolibrary.org/obo/RO_0002413>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -370,13 +367,16 @@
           <http://model.geneontology.org/PWY3O-94/PWY3O-94>
 ] .
 
+<http://purl.obolibrary.org/obo/RO_0002413>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002234_CHEBI_57945_MALATE-DEH-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -396,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -481,7 +481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -529,7 +529,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -596,7 +596,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -625,7 +625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -658,7 +658,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -693,7 +693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -708,7 +708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -786,7 +786,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -803,7 +803,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -839,7 +839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -853,7 +853,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -893,7 +893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -937,7 +937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,7 +968,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -984,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1014,7 +1014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1061,7 +1061,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1073,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1089,7 +1089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1101,7 +1101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1111,7 +1111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1134,7 +1134,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1178,7 +1178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1189,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1235,7 +1235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1292,7 +1292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1428,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1445,7 +1445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1462,7 +1462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1478,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1489,7 +1489,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1501,7 +1501,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1560,7 +1560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1572,7 +1572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1587,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1601,7 +1601,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1618,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1641,7 +1641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1660,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1677,7 +1677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1694,7 +1694,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1720,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1746,7 +1746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1760,7 +1760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1780,7 +1780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1793,7 +1793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1805,7 +1805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1822,7 +1822,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1842,7 +1842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1871,7 +1871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1884,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1899,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +1932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1944,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1964,7 +1964,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1977,7 +1977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -1988,7 +1988,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2002,7 +2002,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,7 +2025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2041,7 +2041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2075,7 +2075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2091,7 +2091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2105,7 +2105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2116,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2127,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2139,7 +2139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2164,7 +2164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2179,7 +2179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,7 +2195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2206,7 +2206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2217,7 +2217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2255,7 +2255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2278,7 +2278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2286,19 +2286,19 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://purl.obolibrary.org/obo/BFO_0000051>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_PWY3O-94>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/BFO_0000051>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2306,7 +2306,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2323,7 +2323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2339,7 +2339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2350,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2359,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2370,7 +2370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2381,7 +2381,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2406,7 +2406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2420,7 +2420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2440,7 +2440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2453,7 +2453,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2468,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of TCA cycle and glyoxylate cycle - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2481,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2493,7 +2493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2510,7 +2510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2526,7 +2526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2540,7 +2540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2555,7 +2555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2572,7 +2572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2589,7 +2589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2609,7 +2609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2622,7 +2622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2633,7 +2633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2648,7 +2648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2661,7 +2661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2673,7 +2673,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2690,7 +2690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2707,17 +2707,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15361>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/CHEBI_57540_MALATE-DEH-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2727,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2735,12 +2724,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_MALSYN-RXN_RO_0002233_CHEBI_57288_MALSYN-RXN_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2753,7 +2753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2773,7 +2773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2786,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2814,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2829,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2845,7 +2845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2859,7 +2859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2879,7 +2879,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2896,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2912,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2924,7 +2924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2943,7 +2943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2979,7 +2979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -2990,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3011,7 +3011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3028,7 +3028,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3046,7 +3046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3063,7 +3063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3080,7 +3080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3094,7 +3094,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3113,7 +3113,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3130,7 +3130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3150,7 +3150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3163,7 +3163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3173,7 +3173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3189,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3204,7 +3204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3220,7 +3220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3245,7 +3245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3268,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3285,7 +3285,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3301,7 +3301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3312,7 +3312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3323,7 +3323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3334,7 +3334,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3345,7 +3345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3355,7 +3355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,7 +3371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3396,7 +3396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3409,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3421,7 +3421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3437,7 +3437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3448,7 +3448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3463,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3476,7 +3476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3487,7 +3487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3499,7 +3499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3515,7 +3515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3528,7 +3528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3542,7 +3542,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3562,7 +3562,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3575,7 +3575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3585,7 +3585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3615,7 +3615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3628,7 +3628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3643,7 +3643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3660,7 +3660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3677,7 +3677,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3693,7 +3693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3704,7 +3704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3716,7 +3716,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3727,6 +3727,28 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15377_MALSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3736,7 +3758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3744,24 +3766,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_BFO_0000050_PWY3O-94/PWY3O-94_SGD_PWY3O-94>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002333_CPLX3O-88_MALATE-DEH-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3772,23 +3783,12 @@
           <http://model.geneontology.org/CPLX3O-88_MALATE-DEH-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_MALATE-DEH-RXN_RO_0002233_CHEBI_57540_MALATE-DEH-RXN_SGD_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_CITSYN-RXN_SGD_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3799,7 +3799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3810,7 +3810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3835,7 +3835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3849,7 +3849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3866,7 +3866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3885,7 +3885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3905,7 +3905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3920,7 +3920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3940,7 +3940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3959,7 +3959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3975,7 +3975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -3989,7 +3989,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4006,7 +4006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4025,7 +4025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4036,7 +4036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4050,7 +4050,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4064,7 +4064,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4076,7 +4076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4096,7 +4096,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4112,7 +4112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4126,7 +4126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4137,7 +4137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4149,7 +4149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4166,7 +4166,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4199,7 +4199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4216,7 +4216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4230,7 +4230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4247,7 +4247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4263,7 +4263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4274,7 +4274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4286,7 +4286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4302,7 +4302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4317,7 +4317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4330,7 +4330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4342,7 +4342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4362,7 +4362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4376,7 +4376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4393,7 +4393,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4413,7 +4413,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4426,7 +4426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4441,7 +4441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4457,7 +4457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4474,7 +4474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4490,7 +4490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4503,7 +4503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4518,7 +4518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4531,7 +4531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4543,7 +4543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4563,7 +4563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4579,7 +4579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4590,7 +4590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4603,7 +4603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4616,7 +4616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4627,7 +4627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4639,7 +4639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4662,7 +4662,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4679,7 +4679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4697,7 +4697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4710,7 +4710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4724,7 +4724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4734,7 +4734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4753,7 +4753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4764,7 +4764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4780,7 +4780,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4793,7 +4793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4804,7 +4804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4815,7 +4815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4840,7 +4840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4854,7 +4854,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4874,7 +4874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4891,7 +4891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4911,7 +4911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4930,7 +4930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -4942,7 +4942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4962,7 +4962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4979,7 +4979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4992,7 +4992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5003,7 +5003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5012,13 +5012,22 @@
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEHYDR-RXN_RO_0002233_CHEBI_15377_ACONITATEHYDR-RXN_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5029,21 +5038,12 @@
           <http://model.geneontology.org/CHEBI_15377_ACONITATEHYDR-RXN>
 ] .
 
-<http://model.geneontology.org/SGD_S000001624_CPLX3O-44_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001624> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_BFO_0000066_reaction_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_location_lociGO_0005829_null_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5054,7 +5054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5065,7 +5065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5076,7 +5076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5088,7 +5088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5107,7 +5107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5128,7 +5128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5144,7 +5144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5159,7 +5159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5182,7 +5182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5196,7 +5196,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5212,7 +5212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5223,7 +5223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5235,7 +5235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5254,7 +5254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5274,7 +5274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5288,7 +5288,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5304,7 +5304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5319,7 +5319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5335,7 +5335,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5345,7 +5345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5371,7 +5371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5388,7 +5388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5404,7 +5404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5422,7 +5422,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5441,7 +5441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5457,7 +5457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5468,7 +5468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5479,7 +5479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5490,7 +5490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5501,7 +5501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5512,7 +5512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5523,7 +5523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5537,7 +5537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5554,7 +5554,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5574,7 +5574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5587,7 +5587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5598,7 +5598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5613,7 +5613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5627,7 +5627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5646,7 +5646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5660,7 +5660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5679,7 +5679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5690,7 +5690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5704,7 +5704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5721,7 +5721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5738,7 +5738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5755,7 +5755,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5769,30 +5769,13 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ADP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63575> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACONITATEDEHYDR-RXN_RO_0002333_YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5803,12 +5786,29 @@
           <http://model.geneontology.org/YJL200C-MONOMER_ACONITATEDEHYDR-RXN_controller>
 ] .
 
+<http://model.geneontology.org/CHEBI_456216_SUCCCOASYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_456216> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ADP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-94SmallMolecule63575> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_BFO_0000066_reaction_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_location_lociGO_0005886_null_PWY3O-94>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5819,18 +5819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_PWY3O-94>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-94" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -5840,7 +5829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5851,13 +5840,24 @@
           <http://model.geneontology.org/SGD_S000001387_CPLX3O-33_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_PWY3O-94>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-94" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-679_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_controller_BFO_0000051_SGD_S000005662_CPLX3O-679_component_SGD_PWY3O-94> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5873,7 +5873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>
@@ -5884,7 +5884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-94" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-94" ;
         <http://purl.org/pav/providedBy>

--- a/models/PWY3O-954-PWY3O-954.ttl
+++ b/models/PWY3O-954-PWY3O-954.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -87,7 +87,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -174,7 +174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -209,7 +209,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -270,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -340,17 +340,6 @@
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22_SGD_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -359,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -413,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -436,7 +425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -461,7 +450,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -481,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -495,7 +484,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -538,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -554,7 +543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -583,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +589,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -620,7 +609,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -637,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -660,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -673,7 +662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +673,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -699,7 +688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -749,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -765,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -794,9 +783,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-22_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_30616_RXN3O-22> , <http://model.geneontology.org/29171376-949e-4111-982e-2529d619a7ef_RXN3O-22> , <http://model.geneontology.org/CHEBI_29985_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
+                <http://model.geneontology.org/CHEBI_43474_RXN3O-22> , <http://model.geneontology.org/cd2e62b8-b36c-4f08-b430-e0993548cd4b_RXN3O-22> , <http://model.geneontology.org/CHEBI_456216_RXN3O-22> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YOR241W-MONOMER_RXN3O-22_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -804,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -818,7 +807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -838,7 +827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,6 +838,9 @@
 <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://purl.obolibrary.org/obo/CHEBI_29991>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -857,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -870,26 +862,6 @@
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://purl.obolibrary.org/obo/CHEBI_29991>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY3O-954> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
-] .
 
 <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0003961> ;
@@ -910,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -918,22 +890,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "ATP" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63917> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002234_CHEBI_58140_HOMOCYSMET-RXN_SGD_PWY3O-954> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/HOMOCYSMET-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_58140_HOMOCYSMET-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -941,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -952,6 +924,40 @@
           <http://model.geneontology.org/CHEBI_43474_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/CHEBI_30616_ASPARTATEKIN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "ATP" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63917> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/29171376-949e-4111-982e-2529d619a7ef_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -960,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -971,7 +977,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -980,13 +986,16 @@
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://identifiers.org/sgd/S000005221>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002411_HOMOCYSMET-RXN_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -997,8 +1006,16 @@
           <http://model.geneontology.org/HOMOCYSMET-RXN>
 ] .
 
-<http://identifiers.org/sgd/S000005221>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_29171376-949e-4111-982e-2529d619a7ef_RXN3O-22_SGD_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1006,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1043,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1059,7 +1076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1074,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1091,7 +1108,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1108,7 +1125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1142,7 +1159,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1159,13 +1176,41 @@
 <http://purl.obolibrary.org/obo/GO_0004072>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_29171376-949e-4111-982e-2529d619a7ef_RXN3O-22_SGD_PWY3O-954> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-22> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/29171376-949e-4111-982e-2529d619a7ef_RXN3O-22>
+] .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000050_PWY3O-954/PWY3O-954_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1176,34 +1221,6 @@
           <http://model.geneontology.org/PWY3O-954/PWY3O-954>
 ] .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22_SGD_PWY3O-954> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-22> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002333_YOR241W-MONOMER_RXN3O-22_controller_SGD_PWY3O-954>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/GO_0004414>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1212,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1225,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1239,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1269,7 +1286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1283,6 +1300,17 @@
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_cd2e62b8-b36c-4f08-b430-e0993548cd4b_RXN3O-22_SGD_PWY3O-954>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1293,7 +1321,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1310,7 +1338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1330,7 +1358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1349,7 +1377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1361,7 +1389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1380,7 +1408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1392,7 +1420,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1413,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1435,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1450,7 +1478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1481,7 +1509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1492,30 +1520,13 @@
           <http://model.geneontology.org/ACETYLHOMOSER-CYS-RXN>
 ] .
 
-<http://model.geneontology.org/b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_HOMOCYSMET-RXN_RO_0002233_CHEBI_58207_HOMOCYSMET-RXN_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1548,7 +1559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1576,7 +1587,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1604,7 +1615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1619,7 +1630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1635,11 +1646,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22_SGD_PWY3O-954> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002234_cd2e62b8-b36c-4f08-b430-e0993548cd4b_RXN3O-22_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1647,7 +1658,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-22> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22>
+          <http://model.geneontology.org/cd2e62b8-b36c-4f08-b430-e0993548cd4b_RXN3O-22>
 ] .
 
 <http://model.geneontology.org/CHEBI_58207_HOMOCYSMET-RXN>
@@ -1659,7 +1670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1672,7 +1683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1687,7 +1698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1715,7 +1726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1731,35 +1742,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/37f95fba-fe64-4a88-820b-ff1159502b6a_RXN3O-22>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5-methyltetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_BFO_0000050_PWY3O-954/PWY3O-954_SGD_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1773,7 +1767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1788,7 +1782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1808,7 +1802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1825,7 +1819,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1841,7 +1835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1853,7 +1847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,7 +1873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1892,7 +1886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1904,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,7 +1918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1941,7 +1935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1971,7 +1965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -1996,7 +1990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,7 +2003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2030,7 +2024,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2044,7 +2038,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2060,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2082,7 +2076,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2107,7 +2101,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2124,7 +2118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2140,7 +2134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2151,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2162,7 +2156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2173,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2184,7 +2178,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2198,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2210,7 +2204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2226,7 +2220,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2240,7 +2234,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2259,7 +2253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2273,7 +2267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2289,7 +2283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2332,7 +2326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2351,7 +2345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2385,7 +2379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2408,7 +2402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2434,7 +2428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2449,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2462,7 +2456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2474,7 +2468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2490,7 +2484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2502,7 +2496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2518,7 +2512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2529,7 +2523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2541,7 +2535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2557,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2571,7 +2565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2586,7 +2580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2599,7 +2593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2611,7 +2605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2627,7 +2621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2639,7 +2633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2650,17 +2644,6 @@
           <http://model.geneontology.org/CHEBI_57844_HOMOCYSMET-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -2669,7 +2652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2680,16 +2663,44 @@
           <http://model.geneontology.org/reaction_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_location_lociGO_0005829>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ASPARTATEKIN-RXN_RO_0002234_CHEBI_57535_ASPARTATEKIN-RXN_SGD_PWY3O-954>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-954" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ACETYLHOMOSER-CYS-RXN_RO_0002234_CHEBI_15378_ACETYLHOMOSER-CYS-RXN_SGD_PWY3O-954>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/cd2e62b8-b36c-4f08-b430-e0993548cd4b_RXN3O-22>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5-methyltetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-954SmallMolecule63884> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/HOMOSERDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004412> ;
@@ -2710,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2723,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2735,7 +2746,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2755,7 +2766,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2766,24 +2777,13 @@
           <http://model.geneontology.org/CHEBI_13392_HOMOSERDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-22_RO_0002233_b3aa7f9c-3c94-41b5-b8a3-f163fdb9c7a2_RXN3O-22_SGD_PWY3O-954>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-954" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPARTATE-SEMIALDEHYDE-DEHYDROGENASE-RXN_RO_0002411_HOMOSERDEHYDROG-RXN_SGD_PWY3O-954> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2799,7 +2799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2810,7 +2810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2821,7 +2821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2835,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-954" ;
         <http://purl.org/pav/providedBy>
@@ -2848,7 +2848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-954" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-96-PWY3O-96.ttl
+++ b/models/PWY3O-96-PWY3O-96.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +38,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -86,7 +86,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -102,7 +102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -130,7 +130,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -167,7 +167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -181,7 +181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -252,7 +252,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -298,7 +298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -313,7 +313,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -332,7 +332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,7 +360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -390,7 +390,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -536,7 +536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -548,7 +548,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -584,7 +584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -626,7 +626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -638,7 +638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -663,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -680,7 +680,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -699,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-96" ;
         <http://purl.org/pav/providedBy>
@@ -720,7 +720,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -740,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -757,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -800,7 +800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "nicotinamide riboside salvage pathway II - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-96" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PWY3O-981-PWY3O-981.ttl
+++ b/models/PWY3O-981-PWY3O-981.ttl
@@ -1,27 +1,10 @@
-<http://model.geneontology.org/ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-6161_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -38,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -54,7 +37,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -66,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -111,7 +94,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -122,23 +105,6 @@
 <http://www.w3.org/2004/02/skos/core#note>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -147,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -159,7 +125,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,7 +142,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -218,7 +184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -229,8 +195,22 @@
           <http://model.geneontology.org/CHEBI_15378_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_16583>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/bff47207-f5b2-4db5-8a55-e7204b8986bc_RXN3O-470>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -238,7 +218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -249,8 +229,25 @@
           <http://model.geneontology.org/CHEBI_16526_ACETOLACTSYN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/CHEBI_24331>
+<http://purl.obolibrary.org/obo/CHEBI_16583>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/b2d781f1-52d6-4dfc-978c-d820c074bc27_ACETOINDEHYDROG-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -261,7 +258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -298,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -327,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -335,24 +332,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470_SGD_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_4bab708b-ea69-46df-9a95-0ebc1d61b2b1_RXN0-2022_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -360,24 +346,26 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-2022> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022>
+          <http://model.geneontology.org/4bab708b-ea69-46df-9a95-0ebc1d61b2b1_RXN0-2022>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_b2d781f1-52d6-4dfc-978c-d820c074bc27_ACETOINDEHYDROG-RXN_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/SGD_S000004034_CPLX3O-118_component>
         a       <http://identifiers.org/sgd/S000004034> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
-        a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -387,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -398,6 +386,15 @@
           <http://model.geneontology.org/CHEBI_58476_RXN-6081>
 ] .
 
+<http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
+        a       <http://identifiers.org/sgd/S000004714> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_16583> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -407,7 +404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -421,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,17 +428,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/SGD_S000004714_CPLX3O-30_component>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/ECO_0000363>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -454,7 +440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -480,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -493,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -504,7 +490,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -519,12 +505,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_15343>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/4bab708b-ea69-46df-9a95-0ebc1d61b2b1_RXN0-2022>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "acetoin" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-67_RXN-6161_controller_BFO_0000051_SGD_S000004124_CPLX3O-67_component_SGD_PWY3O-981>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -532,11 +535,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_bff47207-f5b2-4db5-8a55-e7204b8986bc_RXN3O-470_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +547,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-470> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470>
+          <http://model.geneontology.org/bff47207-f5b2-4db5-8a55-e7204b8986bc_RXN3O-470>
 ] .
 
 <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981>
@@ -552,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -564,7 +567,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -575,13 +578,24 @@
           <http://model.geneontology.org/CHEBI_15378_RXN-6161>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002234_4bab708b-ea69-46df-9a95-0ebc1d61b2b1_RXN0-2022_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-79_RR-BUTANEDIOL-DEHYDROGENASE-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -623,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -639,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -655,7 +669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -667,7 +681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -700,7 +714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +737,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ACETOINDEHYDROG-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN> ;
+                <http://model.geneontology.org/CHEBI_57540_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/b2d781f1-52d6-4dfc-978c-d820c074bc27_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57945_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN> , <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -733,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -746,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -757,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -768,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -779,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +803,7 @@
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_17499_RXN-6081>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -797,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -828,7 +842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -842,13 +856,24 @@
 <http://purl.obolibrary.org/obo/GO_0004737>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-58_RXN3O-470_controller_BFO_0000051_SGD_S000003319_CPLX3O-58_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,24 +893,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981Complex64663> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
-
-<http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -895,28 +909,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
-] .
+<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0032991> ;
@@ -927,7 +933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -935,14 +941,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Complex" .
 
-<http://model.geneontology.org/SGD_S000000056_CPLX3O-79_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000000056> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_15378_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
+] .
 
 <http://model.geneontology.org/CHEBI_15361_RXN0-2022>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15361> ;
@@ -953,7 +967,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -970,7 +984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -983,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -994,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1005,7 +1019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1020,7 +1034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1033,7 +1047,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1044,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1054,7 +1068,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1070,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1081,7 +1095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1116,7 +1130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1132,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1160,7 +1174,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1182,7 +1196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1193,7 +1207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1208,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1221,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1263,7 +1277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1275,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1295,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1309,7 +1323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1332,7 +1346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of acetoin and butanediol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1345,7 +1359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1366,7 +1380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1383,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1396,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1410,7 +1424,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1426,7 +1440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1441,13 +1455,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64549> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1457,7 +1482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1468,23 +1493,12 @@
           <http://model.geneontology.org/reaction_RXN-6161_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6081_RO_0002233_CHEBI_15378_RXN-6081_SGD_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-2022_RO_0002333_CPLX3O-67_RXN0-2022_controller_SGD_PWY3O-981>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1496,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1524,7 +1538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1540,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1555,7 +1569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1574,7 +1588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1588,7 +1602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1618,7 +1632,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,7 +1662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1660,7 +1674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1676,7 +1690,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1699,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1717,7 +1731,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1754,7 +1768,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1771,7 +1785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1791,7 +1805,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1811,7 +1825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1828,7 +1842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1842,6 +1856,23 @@
 <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_16526_RXN-6161>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "CO<SUB>2</SUB>" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64596> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/CHEBI_15378_ACETOINDEHYDROG-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1851,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1865,7 +1896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1876,30 +1907,13 @@
           <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller>
 ] .
 
-<http://model.geneontology.org/CHEBI_16526_RXN-6161>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16526> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "CO<SUB>2</SUB>" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64596> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_BFO_0000050_PWY3O-981/PWY3O-981_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1910,13 +1924,24 @@
           <http://model.geneontology.org/PWY3O-981/PWY3O-981>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-470_RO_0002234_bff47207-f5b2-4db5-8a55-e7204b8986bc_RXN3O-470_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002234_CHEBI_15343_RXN-6161_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1927,12 +1952,12 @@
           <http://model.geneontology.org/CHEBI_15343_RXN-6161>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY3O-981>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1944,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1955,12 +1980,12 @@
           <http://model.geneontology.org/PWY3O-981/PWY3O-981>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002333_CPLX3O-67_RXN-6161_controller_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1971,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -1986,7 +2011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,7 +2027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2013,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2027,7 +2052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2038,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2053,7 +2078,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2075,7 +2100,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15343_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e263d7bd-26f8-4019-8dca-f5f3afa7b9cb_RXN3O-470> ;
+                <http://model.geneontology.org/bff47207-f5b2-4db5-8a55-e7204b8986bc_RXN3O-470> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-118_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-67_RXN3O-470_controller> , <http://model.geneontology.org/CPLX3O-58_RXN3O-470_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2083,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2097,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2114,7 +2139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2130,7 +2155,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2145,7 +2170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2165,7 +2190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2179,7 +2204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2196,7 +2221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2213,7 +2238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2224,30 +2249,13 @@
           <http://model.geneontology.org/SGD_S000004124_CPLX3O-67_component>
 ] .
 
-<http://model.geneontology.org/5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "acetoin" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWY3O-981SmallMolecule64491> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002234_CHEBI_16583_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2258,17 +2266,6 @@
           <http://model.geneontology.org/CHEBI_16583_ACETOINDEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN_SGD_PWY3O-981>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
@@ -2277,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2288,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2319,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2331,7 +2328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2342,22 +2339,13 @@
           <http://model.geneontology.org/CPLX3O-58_RXN-6161_controller>
 ] .
 
-<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RR-BUTANEDIOL-DEHYDROGENASE-RXN_RO_0002233_CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2368,13 +2356,22 @@
           <http://model.geneontology.org/CHEBI_57540_RR-BUTANEDIOL-DEHYDROGENASE-RXN>
 ] .
 
+<http://model.geneontology.org/SGD_S000003319_CPLX3O-58_component>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003319> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002233_CHEBI_15378_ACETOLACTSYN-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2394,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2407,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2421,7 +2418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2433,7 +2430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2449,7 +2446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2461,7 +2458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2481,7 +2478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2495,7 +2492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2511,7 +2508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2522,7 +2519,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2534,7 +2531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2554,7 +2551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2571,7 +2568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2601,7 +2598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2615,7 +2612,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2629,13 +2626,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_16982>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY3O-981>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWY3O-981" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-6161_RO_0002233_CHEBI_15361_RXN-6161_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2646,24 +2654,13 @@
           <http://model.geneontology.org/CHEBI_15361_RXN-6161>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACETOLACTSYN-RXN_RO_0002333_CPLX3O-30_ACETOLACTSYN-RXN_controller_SGD_PWY3O-981>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWY3O-981" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-79_ACETOINDEHYDROG-RXN_controller_BFO_0000051_SGD_S000000056_CPLX3O-79_component_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2679,7 +2676,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2691,7 +2688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2711,7 +2708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2728,7 +2725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2745,7 +2742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2758,7 +2755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2778,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2790,7 +2787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2806,7 +2803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2818,7 +2815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2838,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2852,7 +2849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2871,7 +2868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2885,7 +2882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2902,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2917,7 +2914,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2933,7 +2930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -2948,7 +2945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2962,7 +2959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2979,7 +2976,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2999,7 +2996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3009,11 +3006,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
+          <http://model.geneontology.org/ev_w_id_ACETOINDEHYDROG-RXN_RO_0002233_b2d781f1-52d6-4dfc-978c-d820c074bc27_ACETOINDEHYDROG-RXN_SGD_PWY3O-981> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3021,7 +3018,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACETOINDEHYDROG-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5ed4e1e0-82d1-4677-82a9-2a4be63c10d9_ACETOINDEHYDROG-RXN>
+          <http://model.geneontology.org/b2d781f1-52d6-4dfc-978c-d820c074bc27_ACETOINDEHYDROG-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-2022>
@@ -3033,7 +3030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3046,7 +3043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3057,7 +3054,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3069,7 +3066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3086,7 +3083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3105,7 +3102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3124,7 +3121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3146,7 +3143,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15361_RXN0-2022> , <http://model.geneontology.org/CHEBI_15343_RXN0-2022> , <http://model.geneontology.org/CHEBI_15378_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/ff10db93-8f9b-43be-b452-1e0feb0a4acd_RXN0-2022> , <http://model.geneontology.org/CHEBI_16526_RXN0-2022> ;
+                <http://model.geneontology.org/CHEBI_16526_RXN0-2022> , <http://model.geneontology.org/4bab708b-ea69-46df-9a95-0ebc1d61b2b1_RXN0-2022> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-58_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-118_RXN0-2022_controller> , <http://model.geneontology.org/CPLX3O-67_RXN0-2022_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -3154,7 +3151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3167,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3177,7 +3174,7 @@
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
 <http://model.geneontology.org/CHEBI_15339_RXN-6081>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -3185,7 +3182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3198,7 +3195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3209,7 +3206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3221,7 +3218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3237,7 +3234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3251,7 +3248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3271,7 +3268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3285,7 +3282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3301,7 +3298,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3312,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWY3O-981" ;
         <http://purl.org/pav/providedBy>
@@ -3327,7 +3324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWY3O-981" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/PWYQT-4432-PWYQT-4432.ttl
+++ b/models/PWYQT-4432-PWYQT-4432.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -57,7 +57,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -105,7 +105,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57925_RXN-6601> , <http://model.geneontology.org/CHEBI_83813_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
+                <http://model.geneontology.org/6b712c97-9cff-40da-8125-eac25a8e45e2_RXN-6601> , <http://model.geneontology.org/CHEBI_61694_RXN-6601> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR299W-MONOMER_RXN-6601_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -141,7 +141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -166,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -178,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -226,7 +226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -252,23 +252,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://model.geneontology.org/0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0032991>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -277,7 +260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -310,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -321,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -336,7 +319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -355,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -374,7 +357,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -405,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -420,7 +403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -434,7 +417,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -452,7 +435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -466,7 +449,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -482,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -494,7 +477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -510,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -522,8 +505,36 @@
 <http://purl.obolibrary.org/obo/CHEBI_57305>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/6b712c97-9cff-40da-8125-eac25a8e45e2_RXN-6601>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an &alpha;-(&gamma;-L-glutamyl)-L-amino acid" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PWYQT-4432SmallMolecule62604> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/reaction_RXN-6601_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
+
+<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_6b712c97-9cff-40da-8125-eac25a8e45e2_RXN-6601_SGD_PWYQT-4432>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PWYQT-4432" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/PWYQT-4432>
         a       <http://www.w3.org/2002/07/owl#Ontology> ;
@@ -534,7 +545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "glutathione degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,27 +573,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601_SGD_PWYQT-4432>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PWYQT-4432" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.org/dc/elements/1.1/date>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601_SGD_PWYQT-4432> ;
+          <http://model.geneontology.org/ev_w_id_RXN-6601_RO_0002234_6b712c97-9cff-40da-8125-eac25a8e45e2_RXN-6601_SGD_PWYQT-4432> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-6601> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0e95d647-9763-4a4d-b2b5-71ab16651646_RXN-6601>
+          <http://model.geneontology.org/6b712c97-9cff-40da-8125-eac25a8e45e2_RXN-6601>
 ] .
 
 <http://geneontology.org/lego/modelstate>
@@ -610,7 +610,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -644,7 +644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -712,7 +712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>
@@ -724,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -758,7 +758,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -778,7 +778,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -792,7 +792,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PWYQT-4432" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PWYQT-4432" ;
         <http://purl.org/pav/providedBy>

--- a/models/PYRIMID-RNTSYN-PWY-PYRIMID-RNTSYN-PWY.ttl
+++ b/models/PYRIMID-RNTSYN-PWY-PYRIMID-RNTSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -37,7 +37,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,7 +60,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -111,7 +111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -124,7 +124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -184,7 +184,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -201,7 +201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -215,7 +215,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -269,7 +269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -317,7 +317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -348,7 +348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -359,6 +359,17 @@
           <http://model.geneontology.org/CHEBI_57538_OROTPDECARB-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_b1d93b98-486a-486b-8c59-254af91d3468_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_15378_CTPSYN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -368,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -405,7 +416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -421,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +445,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +464,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +481,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -486,7 +497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -498,7 +509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -521,7 +532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -532,6 +543,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_58228>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_a2001bc6-0648-4cad-ab5f-dd64ba68c302_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_57538_OROPRIBTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57538> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -541,7 +563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -571,24 +593,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46434> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_30616>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -602,7 +613,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -619,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,7 +645,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -664,7 +675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -676,7 +687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -693,7 +704,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -713,7 +724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +740,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -769,7 +780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -780,12 +791,29 @@
           <http://model.geneontology.org/CHEBI_15378_DIHYDROOROT-RXN>
 ] .
 
+<http://model.geneontology.org/a2001bc6-0648-4cad-ab5f-dd64ba68c302_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinol" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_CARBPSYN-RXN_RO_0002333_CPLX3O-887_CARBPSYN-RXN_controller_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +825,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -816,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -856,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -889,7 +917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -908,7 +936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -942,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -958,7 +986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -987,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1004,7 +1032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1018,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,7 +1063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1051,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1062,7 +1090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1071,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1084,7 +1112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1101,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1120,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1145,11 +1173,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002233_b1d93b98-486a-486b-8c59-254af91d3468_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1185,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/b1d93b98-486a-486b-8c59-254af91d3468_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002411_OROPRIBTRANS-RXN_SGD_PYRIMID-RNTSYN-PWY>
@@ -1165,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1177,7 +1205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1204,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,7 +1258,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1255,7 +1283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1286,7 +1314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1304,7 +1332,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1320,7 +1348,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1335,7 +1363,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1349,7 +1377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1369,7 +1397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1400,7 +1428,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1434,7 +1462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1451,7 +1479,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1487,7 +1515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1504,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1517,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1528,7 +1556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1540,7 +1568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1570,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1587,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1607,7 +1635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1620,7 +1648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1632,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1652,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1675,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1692,7 +1720,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1712,7 +1740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1740,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1754,7 +1782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1770,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1782,7 +1810,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1800,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1820,7 +1848,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1833,7 +1861,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1846,7 +1874,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1859,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1877,7 +1905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1897,7 +1925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1913,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1928,7 +1956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1942,7 +1970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1958,7 +1986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1977,11 +2005,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
+          <http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_a2001bc6-0648-4cad-ab5f-dd64ba68c302_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +2017,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+          <http://model.geneontology.org/a2001bc6-0648-4cad-ab5f-dd64ba68c302_DIHYDROOROTATE-DEHYDROGENASE-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN>
@@ -2001,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2015,7 +2043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,7 +2063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,7 +2083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2071,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2099,7 +2127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2111,7 +2139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2124,17 +2152,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0004152>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/ev_w_id_DIHYDROOROTATE-DEHYDROGENASE-RXN_RO_0002234_2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN_SGD_PYRIMID-RNTSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -2158,7 +2175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2175,7 +2192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2195,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2208,7 +2225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2222,7 +2239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2237,7 +2254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2251,7 +2268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2267,7 +2284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2282,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2298,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2321,7 +2338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2338,7 +2355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2352,7 +2369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2385,7 +2402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,7 +2422,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2419,7 +2436,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2439,7 +2456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2466,7 +2483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,7 +2497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2497,7 +2514,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2513,7 +2530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2530,7 +2547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2553,7 +2570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2566,7 +2583,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2580,7 +2597,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2601,9 +2618,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000050>
                 <http://model.geneontology.org/PYRIMID-RNTSYN-PWY/PYRIMID-RNTSYN-PWY> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+                <http://model.geneontology.org/b1d93b98-486a-486b-8c59-254af91d3468_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/CHEBI_30864_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
+                <http://model.geneontology.org/CHEBI_30839_DIHYDROOROTATE-DEHYDROGENASE-RXN> , <http://model.geneontology.org/a2001bc6-0648-4cad-ab5f-dd64ba68c302_DIHYDROOROTATE-DEHYDROGENASE-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKL216W-MONOMER_DIHYDROOROTATE-DEHYDROGENASE-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2611,7 +2628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2625,7 +2642,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2642,7 +2659,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2658,7 +2675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2672,7 +2689,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2698,7 +2715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2714,7 +2731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2728,7 +2745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2743,7 +2760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2757,7 +2774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2779,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2794,7 +2811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2807,7 +2824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2818,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2832,7 +2849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2849,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2865,7 +2882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2877,7 +2894,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2893,7 +2910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2904,7 +2921,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2915,7 +2932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2930,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2946,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2959,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2973,7 +2990,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2989,7 +3006,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3000,7 +3017,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3012,7 +3029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3028,7 +3045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3043,7 +3060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3057,7 +3074,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3073,7 +3090,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3086,7 +3103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3103,28 +3120,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46492> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/2a807928-a3a0-4484-92b2-a4a67449a906_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46251> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -3133,7 +3133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3144,7 +3144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3156,7 +3156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3176,7 +3176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3189,7 +3189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3201,7 +3201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3217,7 +3217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3228,7 +3228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3240,7 +3240,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3262,7 +3262,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3273,7 +3273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3284,7 +3284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3299,7 +3299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3319,7 +3319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3333,7 +3333,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3361,13 +3361,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYBiochemicalReaction46392> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
+
+<http://model.geneontology.org/b1d93b98-486a-486b-8c59-254af91d3468_DIHYDROOROTATE-DEHYDROGENASE-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in GO:0005886" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an electron-transfer quinone" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.org/dc/elements/1.1/contributor>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -3380,7 +3397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3400,7 +3417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3413,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3425,7 +3442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3445,7 +3462,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3461,7 +3478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3478,7 +3495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3497,7 +3514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3515,7 +3532,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3526,29 +3543,12 @@
           <http://model.geneontology.org/CHEBI_15378_OROTPDECARB-RXN>
 ] .
 
-<http://model.geneontology.org/716e57f1-a5c8-48ce-b04f-5e247f203aaf_DIHYDROOROTATE-DEHYDROGENASE-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in GO:0005886" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an electron-transfer quinone" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRIMID-RNTSYN-PWYSmallMolecule46229> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_CTPSYN-RXN_RO_0002233_CHEBI_58359_CTPSYN-RXN_SGD_PYRIMID-RNTSYN-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3560,7 +3560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3576,7 +3576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3594,7 +3594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3619,7 +3619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3633,7 +3633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3644,7 +3644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3656,7 +3656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3672,7 +3672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3684,7 +3684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3703,7 +3703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3715,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3732,7 +3732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3752,7 +3752,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3769,7 +3769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3786,7 +3786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3800,7 +3800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3820,7 +3820,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3837,7 +3837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3871,7 +3871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRIMID-RNTSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/PYRUVDEHYD-PWY-PYRUVDEHYD-PWY.ttl
+++ b/models/PYRUVDEHYD-PWY-PYRUVDEHYD-PWY.ttl
@@ -3,28 +3,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15378_RXN0-1134>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
@@ -35,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -43,29 +26,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN0-1133> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134_SGD_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_a88ab155-06cb-4d58-b3ef-192dda866278_RXN0-1132_SGD_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -73,11 +39,28 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_8d6c8199-a6da-4755-84e6-7a4d31a96c56_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN0-1133> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/8d6c8199-a6da-4755-84e6-7a4d31a96c56_RXN0-1133>
+] .
+
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_CHEBI_15378_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -91,9 +74,6 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/PYRUVDEHYD-PWY/PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0008150> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -103,7 +83,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -111,16 +91,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Pathway" .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_57288_RXN0-1133>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -131,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -156,11 +128,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_23c8f2ef-4295-41ae-9a04-83d1f73f49fa_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +140,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134>
+          <http://model.geneontology.org/23c8f2ef-4295-41ae-9a04-83d1f73f49fa_RXN0-1134>
 ] .
 
 <http://model.geneontology.org/CHEBI_57540_RXN0-1132>
@@ -180,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -196,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,23 +177,12 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133_SGD_PYRUVDEHYD-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_CHEBI_57540_RXN0-1132_SGD_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -236,7 +197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,24 +208,30 @@
           <http://model.geneontology.org/CHEBI_57287_RXN0-1133>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/23c8f2ef-4295-41ae-9a04-83d1f73f49fa_RXN0-1134>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_a88ab155-06cb-4d58-b3ef-192dda866278_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -272,7 +239,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132>
+          <http://model.geneontology.org/a88ab155-06cb-4d58-b3ef-192dda866278_RXN0-1132>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -281,7 +248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -306,7 +273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -324,9 +291,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1134_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN0-1134> , <http://model.geneontology.org/23c8f2ef-4295-41ae-9a04-83d1f73f49fa_RXN0-1134> , <http://model.geneontology.org/CHEBI_15361_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134> , <http://model.geneontology.org/CHEBI_16526_RXN0-1134> ;
+                <http://model.geneontology.org/CHEBI_16526_RXN0-1134> , <http://model.geneontology.org/cd93facf-5711-47ee-9d44-4c8c29d45765_RXN0-1134> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YER178W-MONOMER_RXN0-1134_controller> , <http://model.geneontology.org/YBR221C-MONOMER_RXN0-1134_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -334,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,13 +363,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "pyruvate decarboxylation to acetyl CoA - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <https://w3id.org/biolink/vocab/in_taxon>
                 <http://purl.obolibrary.org/obo/NCBITaxon_559292> .
+
+<http://model.geneontology.org/61898c0c-18e7-4d6e-af79-10a7b61ae47e_RXN0-1132>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -412,7 +396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -434,7 +418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -448,23 +432,6 @@
 <http://model.geneontology.org/reaction_RXN0-1133_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/f0a64b83-ad51-4620-a423-b0743f919aa0_RXN0-1134>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-lipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43773> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN0-1132>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15378> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -474,28 +441,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43786> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -504,11 +454,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_fe2afb8f-beb9-4d64-8d59-367846a45b69_RXN0-1133_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,8 +466,25 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1133> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133>
+          <http://model.geneontology.org/fe2afb8f-beb9-4d64-8d59-367846a45b69_RXN0-1133>
 ] .
+
+<http://model.geneontology.org/cd93facf-5711-47ee-9d44-4c8c29d45765_RXN0-1134>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -525,7 +492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -542,7 +509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -553,23 +520,12 @@
           <http://model.geneontology.org/YER178W-MONOMER_RXN0-1134_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002333_YNL071W-MONOMER_RXN0-1133_controller_SGD_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -593,9 +549,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1133_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133> , <http://model.geneontology.org/CHEBI_57288_RXN0-1133> ;
+                <http://model.geneontology.org/fe2afb8f-beb9-4d64-8d59-367846a45b69_RXN0-1133> , <http://model.geneontology.org/CHEBI_57288_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_57287_RXN0-1133> , <http://model.geneontology.org/27433854-2ccf-4148-93c7-f10a835adb3c_RXN0-1133> ;
+                <http://model.geneontology.org/8d6c8199-a6da-4755-84e6-7a4d31a96c56_RXN0-1133> , <http://model.geneontology.org/CHEBI_57287_RXN0-1133> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -603,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -617,7 +573,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -633,18 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:PYRUVDEHYD-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002233_aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132_SGD_PYRUVDEHYD-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -671,7 +616,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +633,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -704,7 +649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +661,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,25 +672,23 @@
           <http://model.geneontology.org/CHEBI_57288_RXN0-1133>
 ] .
 
-<http://model.geneontology.org/e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
+<http://identifiers.org/sgd/S000000980>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller>
+        a       <http://identifiers.org/sgd/S000005015> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
+                "dihydrolipoamide acetyltransferase" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYProtein43870> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://identifiers.org/sgd/S000000980>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+                "org.biopax.paxtools.model.level3.Protein" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -755,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -766,20 +709,22 @@
           <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/YNL071W-MONOMER_RXN0-1133_controller>
-        a       <http://identifiers.org/sgd/S000005015> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/fe2afb8f-beb9-4d64-8d59-367846a45b69_RXN0-1133>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
-                "dihydrolipoamide acetyltransferase" ;
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYProtein43870> ;
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
         <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57945>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -790,7 +735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -823,7 +768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -837,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -848,7 +793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -863,9 +808,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132> , <http://model.geneontology.org/CHEBI_57540_RXN0-1132> ;
+                <http://model.geneontology.org/a88ab155-06cb-4d58-b3ef-192dda866278_RXN0-1132> , <http://model.geneontology.org/CHEBI_57540_RXN0-1132> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132> , <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> ;
+                <http://model.geneontology.org/CHEBI_15378_RXN0-1132> , <http://model.geneontology.org/61898c0c-18e7-4d6e-af79-10a7b61ae47e_RXN0-1132> , <http://model.geneontology.org/CHEBI_57945_RXN0-1132> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YFL018C-MONOMER_RXN0-1132_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -873,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -890,12 +835,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_57287>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/a88ab155-06cb-4d58-b3ef-192dda866278_RXN0-1132>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_CHEBI_57287_RXN0-1133_SGD_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -910,7 +872,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -923,11 +885,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_61898c0c-18e7-4d6e-af79-10a7b61ae47e_RXN0-1132_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +897,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1132> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/35c809f9-9a59-433f-97d3-4232a1320d92_RXN0-1132>
+          <http://model.geneontology.org/61898c0c-18e7-4d6e-af79-10a7b61ae47e_RXN0-1132>
 ] .
 
 <http://model.geneontology.org/CHEBI_57945_RXN0-1132>
@@ -947,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -984,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1004,7 +966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1015,13 +977,30 @@
           <http://model.geneontology.org/PYRUVDEHYD-PWY/PYRUVDEHYD-PWY>
 ] .
 
+<http://model.geneontology.org/8d6c8199-a6da-4755-84e6-7a4d31a96c56_RXN0-1133>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-<i>S</i>-acetyldihydrolipoyl-L-lysine" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43793> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_cd93facf-5711-47ee-9d44-4c8c29d45765_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +1008,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN0-1134> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e0ed0a7e-4a77-443b-b830-25a83e2951be_RXN0-1134>
+          <http://model.geneontology.org/cd93facf-5711-47ee-9d44-4c8c29d45765_RXN0-1134>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000050_PYRUVDEHYD-PWY/PYRUVDEHYD-PWY_SGD_PYRUVDEHYD-PWY>
@@ -1037,7 +1016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1045,6 +1024,17 @@
 
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002233_fe2afb8f-beb9-4d64-8d59-367846a45b69_RXN0-1133_SGD_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_16526_RXN0-1134>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16526> ;
@@ -1055,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1068,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1077,29 +1067,12 @@
 <http://www.w3.org/2004/02/skos/core#exactMatch>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/f25f0839-3f95-4aeb-94fc-2b4f55cedc2d_RXN0-1133>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1133_BFO_0000066_reaction_RXN0-1133_location_lociGO_0005829_null_PYRUVDEHYD-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1115,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1126,43 +1099,48 @@
 <http://model.geneontology.org/reaction_RXN0-1132_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1132_RO_0002234_61898c0c-18e7-4d6e-af79-10a7b61ae47e_RXN0-1132_SGD_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN0-1134_BFO_0000066_reaction_RXN0-1134_location_lociGO_0005829_null_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_23c8f2ef-4295-41ae-9a04-83d1f73f49fa_RXN0-1134_SGD_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/aae9d3fe-8bd2-4080-915a-acfcab5a23c3_RXN0-1132>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a [pyruvate dehydrogenase E2 protein] <i>N<sup>6</sup></i>-dihydrolipoyl-L-lysine" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=PYRUVDEHYD-PWYSmallMolecule43847> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002233_CHEBI_15378_RXN0-1134_SGD_PYRUVDEHYD-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1174,7 +1152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1201,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1213,7 +1191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1232,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:PYRUVDEHYD-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1247,7 +1225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,7 +1242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,13 +1256,24 @@
 <http://purl.org/dc/elements/1.1/title>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_RXN0-1133_RO_0002234_8d6c8199-a6da-4755-84e6-7a4d31a96c56_RXN0-1133_SGD_PYRUVDEHYD-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_CHEBI_16526_RXN0-1134_SGD_PYRUVDEHYD-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1294,3 +1283,14 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_16526_RXN0-1134>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN0-1134_RO_0002234_cd93facf-5711-47ee-9d44-4c8c29d45765_RXN0-1134_SGD_PYRUVDEHYD-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=PYRUVDEHYD-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:PYRUVDEHYD-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .

--- a/models/SAM-PWY-SAM-PWY.ttl
+++ b/models/SAM-PWY-SAM-PWY.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -30,7 +30,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -46,7 +46,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -69,7 +69,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -145,7 +145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -160,7 +160,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -202,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -220,7 +220,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -250,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -264,7 +264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,7 +280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "S-adenosyl-L-methionine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -386,7 +386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -400,7 +400,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -446,7 +446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -477,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -494,7 +494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -513,7 +513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SAM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -539,7 +539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SAM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/SERDEG-PWY-SERDEG-PWY.ttl
+++ b/models/SERDEG-PWY-SERDEG-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -28,7 +28,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -60,7 +60,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -144,7 +144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -156,7 +156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -219,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -314,7 +314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -352,7 +352,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -365,7 +365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -378,7 +378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -423,7 +423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -443,7 +443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -473,7 +473,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -487,7 +487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -507,7 +507,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -523,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -549,7 +549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -579,7 +579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -591,7 +591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -621,7 +621,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -637,7 +637,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -688,7 +688,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -707,7 +707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERDEG-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -770,7 +770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -784,7 +784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -801,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -821,7 +821,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERDEG-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/SERSYN-PWY-SERSYN-PWY.ttl
+++ b/models/SERSYN-PWY-SERSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -60,13 +60,24 @@
           <http://model.geneontology.org/CHEBI_18110_PSERTRANSAM-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_SERSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SERSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PGLYCDEHYDROG-RXN_RO_0002234_CHEBI_15378_PGLYCDEHYDROG-RXN_SGD_SERSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -76,17 +87,6 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_15378_PGLYCDEHYDROG-RXN>
 ] .
-
-<http://model.geneontology.org/ev_w_id_RXN0-5114_RO_0002333_YGR208W-MONOMER_RXN0-5114_controller_SGD_SERSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SERSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -103,7 +103,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -155,7 +155,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-serine biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -279,7 +279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -291,7 +291,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -311,7 +311,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -329,7 +329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -346,7 +346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,7 +363,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -379,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -395,7 +395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -445,7 +445,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -466,7 +466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -505,7 +505,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -522,7 +522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,7 +557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -579,7 +579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -615,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -652,7 +652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -679,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -696,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -739,7 +739,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -753,7 +753,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -848,7 +848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -864,7 +864,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -901,7 +901,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -918,7 +918,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -934,7 +934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -965,7 +965,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -979,7 +979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -996,7 +996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1010,7 +1010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1021,7 +1021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1035,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1047,7 +1047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1064,7 +1064,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,7 +1084,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1111,7 +1111,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1137,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1150,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SERSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1162,7 +1162,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1188,7 +1188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1202,7 +1202,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SERSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/SO4ASSIM-PWY-SO4ASSIM-PWY.ttl
+++ b/models/SO4ASSIM-PWY-SO4ASSIM-PWY.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -34,7 +34,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -46,7 +46,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -62,7 +62,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +76,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -147,7 +147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -228,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -242,7 +242,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -279,7 +279,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -323,7 +323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -403,7 +403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -438,7 +438,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -475,7 +475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -525,7 +525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -615,7 +615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,7 +628,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -646,7 +646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -659,7 +659,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -714,7 +714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "assimilatory sulfate reduction I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -747,7 +747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -757,7 +757,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -773,7 +773,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -785,7 +785,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -815,7 +815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -832,7 +832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -865,7 +865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -875,7 +875,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -908,7 +908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -923,7 +923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -952,7 +952,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -971,7 +971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -997,7 +997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1011,7 +1011,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1045,7 +1045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1060,7 +1060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1082,7 +1082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,7 +1099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1193,7 +1193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1206,7 +1206,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1217,7 +1217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1232,7 +1232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1246,7 +1246,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1266,7 +1266,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1300,7 +1300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1319,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1342,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1390,7 +1390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1407,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1524,7 +1524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1535,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1581,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1603,7 +1603,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1621,7 +1621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1634,7 +1634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1646,7 +1646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1684,7 +1684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1697,7 +1697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1709,7 +1709,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1729,7 +1729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1743,7 +1743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1766,7 +1766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1783,7 +1783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,7 +1797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1824,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SO4ASSIM-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SO4ASSIM-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/SPHINGOLIPID-SYN-PWY-1-SPHINGOLIPID-SYN-PWY-1.ttl
+++ b/models/SPHINGOLIPID-SYN-PWY-1-SPHINGOLIPID-SYN-PWY-1.ttl
@@ -1,10 +1,27 @@
+<http://model.geneontology.org/e20759b6-bd1d-4710-8f94-1b9f922ed3fb_RXN3O-4042>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002234_CHEBI_64124_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -22,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -30,30 +47,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_57287_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,30 +79,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -124,7 +107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -153,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -170,7 +153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -183,7 +166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -195,7 +178,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -212,7 +195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -231,7 +214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -253,11 +236,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_e20759b6-bd1d-4710-8f94-1b9f922ed3fb_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -265,7 +248,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-4042> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042>
+          <http://model.geneontology.org/e20759b6-bd1d-4710-8f94-1b9f922ed3fb_RXN3O-4042>
 ] .
 
 <http://model.geneontology.org/SERINE-C-PALMITOYLTRANSFERASE-RXN>
@@ -287,7 +270,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -363,35 +346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -414,12 +369,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_FERRICYTOCHROME-B5_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002333_YMR272C-MONOMER_RXN3O-4042_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -439,13 +405,24 @@
 <http://identifiers.org/sgd/S000002702>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_854ac4d6-c53d-44eb-a3d5-484be54d04f4_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002233_CHEBI_30616_SPHINGANINE-KINASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -458,11 +435,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_854ac4d6-c53d-44eb-a3d5-484be54d04f4_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +447,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680>
+          <http://model.geneontology.org/854ac4d6-c53d-44eb-a3d5-484be54d04f4_RXN3O-680>
 ] .
 
 <http://purl.obolibrary.org/obo/RO_0002413>
@@ -482,7 +459,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -500,7 +477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -516,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,7 +523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -563,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -583,7 +560,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -600,7 +577,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -631,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -644,7 +621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -661,7 +638,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_CERAMIDASE-YEAST-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> ;
+                <http://model.geneontology.org/74f6adc4-4fcf-4791-97c5-41480ca8d9f3_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_15377_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_10283_CERAMIDASE-YEAST-RXN> , <http://model.geneontology.org/CHEBI_64124_CERAMIDASE-YEAST-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -671,7 +648,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -687,7 +664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -702,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -716,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,23 +704,23 @@
           <http://model.geneontology.org/CHEBI_16749_RXN3O-581>
 ] .
 
-<http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component>
-        a       <http://identifiers.org/sgd/S000004913> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_SERINE-C-PALMITOYLTRANSFERASE-RXN_RO_0002333_YMR296C-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/SGD_S000004913_CPLX3O-78_component>
+        a       <http://identifiers.org/sgd/S000004913> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -753,7 +730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -770,7 +747,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -789,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -800,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -812,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -829,7 +806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -847,7 +824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +837,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -872,7 +849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -894,7 +871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +897,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -957,12 +934,29 @@
 <http://model.geneontology.org/reaction_RXN3O-581_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ec6edcb4-ad26-4ad2-9128-6b4ef2aedd7b_RXN3O-663>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_CHEBI_16749_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -977,7 +971,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -994,7 +988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1013,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1028,7 +1022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1041,7 +1035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1056,7 +1050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1073,7 +1067,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1084,24 +1078,13 @@
           <http://model.geneontology.org/YBR183W-MONOMER_CERAMIDASE-YEAST-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1112,17 +1095,6 @@
           <http://model.geneontology.org/CHEBI_64124_RXN3O-1380>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/YDR062W-MONOMER_SERINE-C-PALMITOYLTRANSFERASE-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000002469> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1130,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1143,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1157,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1177,7 +1149,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1194,7 +1166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1207,7 +1179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1238,7 +1210,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1249,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1261,7 +1233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1277,7 +1249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1288,7 +1260,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1303,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1317,7 +1289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1357,7 +1329,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1382,7 +1354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,7 +1373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1420,7 +1392,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1455,11 +1427,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19561> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/b5da541e-d51e-4145-bec1-67242eba5f7d_RXN3O-328>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a very long chain fatty acyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1472,15 +1461,15 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-680_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
+                <http://model.geneontology.org/854ac4d6-c53d-44eb-a3d5-484be54d04f4_RXN3O-680> , <http://model.geneontology.org/CHEBI_16749_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17815_RXN3O-680> , <http://model.geneontology.org/966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680> ;
+                <http://model.geneontology.org/49d3dfd9-9a1f-4356-9376-378adf35b551_RXN3O-680> , <http://model.geneontology.org/CHEBI_17815_RXN3O-680> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,7 +1485,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_b5da541e-d51e-4145-bec1-67242eba5f7d_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1510,7 +1510,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1521,23 +1521,6 @@
           <http://model.geneontology.org/reaction_RXN3O-1380_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/CHEBI_15378_RXN3O-4042>
         a       <http://purl.obolibrary.org/obo/CHEBI_15378> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1547,7 +1530,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1582,7 +1565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1596,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1616,7 +1599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1632,7 +1615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1648,7 +1631,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1660,7 +1643,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1680,7 +1663,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1697,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1716,7 +1699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1727,7 +1710,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1741,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1758,7 +1741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1769,12 +1752,29 @@
           <http://model.geneontology.org/CHEBI_15378_SPHINGANINE-KINASE-RXN>
 ] .
 
+<http://model.geneontology.org/13f106b5-9c18-4313-a378-f5d5a2ea7582_RXN3O-663>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_RO_0002333_YOR171C-MONOMER_SPHINGANINE-KINASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1785,46 +1785,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a very long chain fatty acyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19853> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_15378_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1838,11 +1810,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_8d36c045-ecbf-46bb-9b97-0ef403eea638_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1850,7 +1822,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581>
+          <http://model.geneontology.org/8d36c045-ecbf-46bb-9b97-0ef403eea638_RXN3O-581>
 ] .
 
 <http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002234_CHEBI_57783_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
@@ -1858,7 +1830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1875,7 +1847,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1859,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,7 +1876,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1920,7 +1892,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1935,7 +1907,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1948,7 +1920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1963,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1977,7 +1949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1994,7 +1966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2011,7 +1983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2025,24 +1997,13 @@
 <http://identifiers.org/sgd/S000001491>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002233_CHEBI_31998_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,7 +2022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2072,7 +2033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2083,7 +2044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2094,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2107,7 +2068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2121,7 +2082,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2137,7 +2098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2147,42 +2108,12 @@
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' 'null' 'a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002413_RXN3O-680_null_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-663> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/RXN3O-680>
-] .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002234_CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2193,12 +2124,31 @@
           <http://model.geneontology.org/CHEBI_58190_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
 ] .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'an inositol-phospho-&alpha; hydroxyphytoceramide + GDP-&alpha;-D-mannose &rarr; a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + GDP + H<SUP>+</SUP>' 'null' 'a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide + a 1-phosphatidyl-1D-<i>myo</i>-inositol &rarr; a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide + a 1,2-diacyl-<i>sn</i>-glycerol' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002413_RXN3O-680_null_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-663> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/RXN3O-680>
+] .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-383_RXN3O-663_controller_BFO_0000051_SGD_S000005978_CPLX3O-383_component_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2209,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2220,7 +2170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2235,7 +2185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2249,7 +2199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,26 +2210,26 @@
           <http://model.geneontology.org/CHEBI_456216_RXN3O-458>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0050291>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002413_RXN3O-328_null_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000363> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/GO_0050291>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002333_YDR297W-MONOMER_RXN3O-1380_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2291,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2320,7 +2270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2342,7 +2292,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15379_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15378_RXN3O-4042> , <http://model.geneontology.org/FERROCYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_31998_RXN3O-4042> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> , <http://model.geneontology.org/59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042> ;
+                <http://model.geneontology.org/FERRICYTOCHROME-B5_RXN3O-4042> , <http://model.geneontology.org/e20759b6-bd1d-4710-8f94-1b9f922ed3fb_RXN3O-4042> , <http://model.geneontology.org/CHEBI_15377_RXN3O-4042> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YMR272C-MONOMER_RXN3O-4042_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2350,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2367,7 +2317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2380,7 +2330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2393,7 +2343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2409,7 +2359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2429,7 +2379,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2449,11 +2399,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19713> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/74f6adc4-4fcf-4791-97c5-41480ca8d9f3_CERAMIDASE-YEAST-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2466,7 +2433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2482,7 +2449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2494,7 +2461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2516,7 +2483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2529,7 +2496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2540,12 +2507,29 @@
 <http://purl.obolibrary.org/obo/CHEBI_15378>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/8d36c045-ecbf-46bb-9b97-0ef403eea638_RXN3O-581>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (2'R)-2'-hydroxy-phytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/ev_w_id_CPLX3O-78_RXN3O-328_controller_BFO_0000051_SGD_S000000995_CPLX3O-78_component_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2557,7 +2541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2574,7 +2558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2597,7 +2581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2620,7 +2604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2636,7 +2620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2656,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sphingolipid biosynthesis (yeast) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2669,7 +2653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2683,28 +2667,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/CHEBI_16749_RXN3O-680>
-        a       <http://purl.obolibrary.org/obo/CHEBI_16749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 1-phosphatidyl-1D-<i>myo</i>-inositol" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19753> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/CHEBI_15377_RXN3O-4042>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_15377> ;
@@ -2715,7 +2682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2723,16 +2690,22 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002233_71ded954-6756-407e-a3ce-d39a63f6855b_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/CHEBI_16749_RXN3O-680>
+        a       <http://purl.obolibrary.org/obo/CHEBI_16749> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 1-phosphatidyl-1D-<i>myo</i>-inositol" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19753> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -2740,7 +2713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2757,7 +2730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2773,7 +2746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2784,18 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2813,7 +2775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2823,11 +2785,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_49d3dfd9-9a1f-4356-9376-378adf35b551_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2835,7 +2797,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-680> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680>
+          <http://model.geneontology.org/49d3dfd9-9a1f-4356-9376-378adf35b551_RXN3O-680>
 ] .
 
 <http://model.geneontology.org/CHEBI_57939_DHS-PHOSPHATASE-RXN>
@@ -2847,7 +2809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2861,7 +2823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2881,13 +2843,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19967> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_13f106b5-9c18-4313-a378-f5d5a2ea7582_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2897,7 +2870,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2911,12 +2884,23 @@
 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_e20759b6-bd1d-4710-8f94-1b9f922ed3fb_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_DHS-PHOSPHATASE-RXN_RO_0002333_YKR053C-MONOMER_DHS-PHOSPHATASE-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -2931,9 +2915,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-663_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
+                <http://model.geneontology.org/13f106b5-9c18-4313-a378-f5d5a2ea7582_RXN3O-663> , <http://model.geneontology.org/CHEBI_57527_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
+                <http://model.geneontology.org/ec6edcb4-ad26-4ad2-9128-6b4ef2aedd7b_RXN3O-663> , <http://model.geneontology.org/CHEBI_58189_RXN3O-663> , <http://model.geneontology.org/CHEBI_15378_RXN3O-663> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-383_RXN3O-663_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -2941,7 +2925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2955,7 +2939,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2972,7 +2956,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2991,7 +2975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3006,7 +2990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3019,7 +3003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3031,7 +3015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3050,7 +3034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3062,7 +3046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3075,11 +3059,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_0a8dc035-f36e-45ac-b70a-be5655d2da93_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3087,7 +3071,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-581> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581>
+          <http://model.geneontology.org/0a8dc035-f36e-45ac-b70a-be5655d2da93_RXN3O-581>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_SERINE-C-PALMITOYLTRANSFERASE-RXN>
@@ -3099,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3116,7 +3100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3130,7 +3114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3150,7 +3134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3164,7 +3148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3180,7 +3164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3191,7 +3175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3206,7 +3190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3219,35 +3203,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_64124_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3259,7 +3226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3276,7 +3243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3293,7 +3260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3309,7 +3276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3326,7 +3293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3342,7 +3309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3354,7 +3321,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3376,7 +3343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3388,7 +3355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3418,7 +3385,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3431,7 +3398,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3442,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3467,7 +3434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3480,7 +3447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3495,7 +3462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3511,7 +3478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3531,7 +3498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3544,7 +3511,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-680_RO_0002234_49d3dfd9-9a1f-4356-9376-378adf35b551_RXN3O-680_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3558,7 +3536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3574,7 +3552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3585,7 +3563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3597,7 +3575,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3617,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3633,7 +3611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3641,11 +3619,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_13f106b5-9c18-4313-a378-f5d5a2ea7582_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3653,7 +3631,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663>
+          <http://model.geneontology.org/13f106b5-9c18-4313-a378-f5d5a2ea7582_RXN3O-663>
 ] .
 
 <http://identifiers.org/sgd/S000003670>
@@ -3664,7 +3642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3675,7 +3653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3690,7 +3668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3706,7 +3684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3717,7 +3695,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3726,41 +3704,13 @@
 <http://identifiers.org/sgd/S000002469>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-1380> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_15379_RXN3O-1380>
-] .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3771,15 +3721,43 @@
           <http://model.geneontology.org/SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1>
 ] .
 
-<http://identifiers.org/sgd/S000002705>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002233_CHEBI_15379_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/RXN3O-1380> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_15379_RXN3O-1380>
+] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1>
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002333_YPL087W-MONOMER_CERAMIDASE-YEAST-RXN_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://identifiers.org/sgd/S000002705>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3790,7 +3768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3802,7 +3780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3813,12 +3791,12 @@
           <http://model.geneontology.org/YDR072C-MONOMER_RXN3O-680_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_RO_0002233_CHEBI_58349_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/ev_w_id_RXN3O-458_RO_0002234_CHEBI_456216_RXN3O-458_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3829,7 +3807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3837,11 +3815,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_74f6adc4-4fcf-4791-97c5-41480ca8d9f3_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3849,8 +3827,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/CERAMIDASE-YEAST-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN>
+          <http://model.geneontology.org/74f6adc4-4fcf-4791-97c5-41480ca8d9f3_CERAMIDASE-YEAST-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_CERAMIDASE-YEAST-RXN_RO_0002233_74f6adc4-4fcf-4791-97c5-41480ca8d9f3_CERAMIDASE-YEAST-RXN_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -3858,7 +3847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3874,7 +3863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3882,11 +3871,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_b5da541e-d51e-4145-bec1-67242eba5f7d_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3894,7 +3883,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN3O-328> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328>
+          <http://model.geneontology.org/b5da541e-d51e-4145-bec1-67242eba5f7d_RXN3O-328>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -3903,7 +3892,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3920,7 +3909,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3936,7 +3925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -3951,7 +3940,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3971,7 +3960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3984,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4002,7 +3991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4015,7 +4004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4026,7 +4015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4038,7 +4027,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4055,7 +4044,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4071,7 +4060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4082,7 +4071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4094,7 +4083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4111,7 +4100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4134,7 +4123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4164,7 +4153,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4177,7 +4166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4191,7 +4180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4204,7 +4193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4218,7 +4207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4238,13 +4227,24 @@
 <http://identifiers.org/sgd/S000004913>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002233_8d36c045-ecbf-46bb-9b97-0ef403eea638_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_SPHINGANINE-KINASE-RXN_BFO_0000050_SPHINGOLIPID-SYN-PWY-1/SPHINGOLIPID-SYN-PWY-1_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4263,7 +4263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4279,7 +4279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4293,7 +4293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4308,7 +4308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4326,7 +4326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4341,7 +4341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4354,7 +4354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4368,7 +4368,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4390,7 +4390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4401,17 +4401,6 @@
           <http://model.geneontology.org/reaction_3-DEHYDROSPHINGANINE-REDUCTASE-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -4420,7 +4409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4431,7 +4420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4446,7 +4435,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4459,20 +4448,9 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002233_d270bbe9-35e7-4793-a951-67944bf66ae1_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4482,7 +4460,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4498,7 +4476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4516,7 +4494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4533,7 +4511,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4549,7 +4527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4564,7 +4542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4577,7 +4555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4591,7 +4569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4608,7 +4586,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4624,7 +4602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4639,7 +4617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4656,7 +4634,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4672,7 +4650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4683,7 +4661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4696,7 +4674,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4713,7 +4691,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4733,7 +4711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4749,7 +4727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4768,7 +4746,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4779,7 +4757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4791,7 +4769,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4810,7 +4788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4826,9 +4804,37 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_ec6edcb4-ad26-4ad2-9128-6b4ef2aedd7b_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/854ac4d6-c53d-44eb-a3d5-484be54d04f4_RXN3O-680>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19742> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -4836,7 +4842,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4854,7 +4860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4874,7 +4880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4887,7 +4893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -4899,7 +4905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4919,7 +4925,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4936,7 +4942,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4956,7 +4962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4967,30 +4973,13 @@
 <http://identifiers.org/sgd/S000005697>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
-<http://model.geneontology.org/ffb7c7fc-71f3-4340-a143-84f80ae0c843_CERAMIDASE-YEAST-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002234_CHEBI_31998_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5010,9 +4999,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-581_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_16749_RXN3O-581> , <http://model.geneontology.org/00f6b2d2-79a8-4c53-8fda-f690876460cc_RXN3O-581> ;
+                <http://model.geneontology.org/8d36c045-ecbf-46bb-9b97-0ef403eea638_RXN3O-581> , <http://model.geneontology.org/CHEBI_16749_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/5e0a356c-5c01-42b4-8a0c-4fe76f186ca6_RXN3O-581> ;
+                <http://model.geneontology.org/CHEBI_17815_RXN3O-581> , <http://model.geneontology.org/0a8dc035-f36e-45ac-b70a-be5655d2da93_RXN3O-581> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/MONOMER3O-630_RXN3O-581_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -5020,7 +5009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5037,7 +5026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5057,7 +5046,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -5074,7 +5063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5091,7 +5080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5111,7 +5100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5125,7 +5114,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5144,7 +5133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5155,22 +5144,16 @@
           <http://model.geneontology.org/RXN3O-663>
 ] .
 
-<http://model.geneontology.org/59eadb54-6caf-4aa0-a50a-34ebbb4a2f9b_RXN3O-4042>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (2'R)-2'-hydroxy-phytoceramide" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-581_RO_0002234_0a8dc035-f36e-45ac-b70a-be5655d2da93_RXN3O-581_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19670> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57527>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -5184,7 +5167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5200,7 +5183,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5214,7 +5197,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5230,7 +5213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5241,7 +5224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5255,7 +5238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5272,7 +5255,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5293,7 +5276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5310,7 +5293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5318,44 +5301,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002333_YKR053C-MONOMER_RXN3O-504_controller_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
-<http://model.geneontology.org/966ab496-bd50-476d-a93f-2a70a2539c5a_RXN3O-680>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
+<http://model.geneontology.org/ev_w_id_RXN3O-4042_RO_0002234_CHEBI_15377_RXN3O-4042_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -5363,7 +5329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5379,7 +5345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5394,7 +5360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5410,7 +5376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5429,7 +5395,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5454,7 +5420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5467,7 +5433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5485,7 +5451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5498,7 +5464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5512,7 +5478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5528,7 +5494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5539,7 +5505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5556,7 +5522,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5573,7 +5539,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5589,7 +5555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5604,7 +5570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5618,7 +5584,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5637,7 +5603,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5657,7 +5623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5670,7 +5636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5682,7 +5648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5698,7 +5664,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5709,7 +5675,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5721,7 +5687,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5738,25 +5704,36 @@
 <http://model.geneontology.org/reaction_RXN3O-504_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://purl.obolibrary.org/obo/CHEBI_58299>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
+          <http://purl.obolibrary.org/obo/RO_0002233> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/RXN3O-663> ;
+          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/c49989b9-b300-44a9-a1c6-c1a53c99e9c2_RXN3O-663>
+          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/CHEBI_58299>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_30616_RXN3O-458>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
@@ -5767,7 +5744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5782,7 +5759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5790,23 +5767,12 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://model.geneontology.org/ev_w_id_RXN3O-504_RO_0002233_CHEBI_64795_RXN3O-504_SGD_SPHINGOLIPID-SYN-PWY-1>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:SPHINGOLIPID-SYN-PWY-1" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/ev_w_id_RXN3O-328_RO_0002233_CHEBI_64124_RXN3O-328_SGD_SPHINGOLIPID-SYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -5818,7 +5784,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5831,19 +5797,19 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_RO_0002233_CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN_SGD_SPHINGOLIPID-SYN-PWY-1> ;
+          <http://model.geneontology.org/ev_w_id_RXN3O-663_RO_0002234_ec6edcb4-ad26-4ad2-9128-6b4ef2aedd7b_RXN3O-663_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002233> ;
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
   <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN> ;
+          <http://model.geneontology.org/RXN3O-663> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57939_SPHINGANINE-1-PHOSPHATE-ALDOLASE-RXN>
+          <http://model.geneontology.org/ec6edcb4-ad26-4ad2-9128-6b4ef2aedd7b_RXN3O-663>
 ] .
 
 <http://model.geneontology.org/CHEBI_64124_RXN3O-458>
@@ -5855,7 +5821,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5872,7 +5838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5889,7 +5855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5906,7 +5872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5920,7 +5886,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5931,6 +5897,23 @@
           <http://model.geneontology.org/CHEBI_64124_RXN3O-458>
 ] .
 
+<http://model.geneontology.org/0a8dc035-f36e-45ac-b70a-be5655d2da93_RXN3O-581>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "an inositol-phospho-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19792> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://purl.obolibrary.org/obo/BFO_0000066>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
@@ -5940,7 +5923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5960,7 +5943,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN3O-328_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/1a2023a7-7361-4b19-b8f9-7c61bc385385_RXN3O-328> , <http://model.geneontology.org/CHEBI_64124_RXN3O-328> ;
+                <http://model.geneontology.org/b5da541e-d51e-4145-bec1-67242eba5f7d_RXN3O-328> , <http://model.geneontology.org/CHEBI_64124_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_RXN3O-328> , <http://model.geneontology.org/CHEBI_57287_RXN3O-328> , <http://model.geneontology.org/CHEBI_31998_RXN3O-328> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -5972,7 +5955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -5980,13 +5963,30 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
+<http://model.geneontology.org/49d3dfd9-9a1f-4356-9376-378adf35b551_RXN3O-680>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a mannosyl-diphosphoinositol-&alpha; hydroxyphytoceramide" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=SPHINGOLIPID-SYN-PWY-1SmallMolecule19761> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN3O-1380_RO_0002234_CHEBI_15377_RXN3O-1380_SGD_SPHINGOLIPID-SYN-PWY-1> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6002,7 +6002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6013,7 +6013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6025,7 +6025,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -6041,7 +6041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6052,7 +6052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -6067,7 +6067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SPHINGOLIPID-SYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/SUCUTIL-PWY-2-SUCUTIL-PWY-2.ttl
+++ b/models/SUCUTIL-PWY-2-SUCUTIL-PWY-2.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -18,7 +18,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -103,7 +103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -118,7 +118,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -136,7 +136,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -163,7 +163,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -192,7 +192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -277,7 +277,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "sucrose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -320,7 +320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -334,7 +334,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -369,7 +369,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:SUCUTIL-PWY-2" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=SUCUTIL-PWY-2" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/TCA-EUK-PWY-TCA-EUK-PWY.ttl
+++ b/models/TCA-EUK-PWY-TCA-EUK-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -21,7 +21,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,7 +77,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +88,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -97,7 +97,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -131,7 +131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -142,7 +142,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -152,7 +152,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -169,7 +169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -185,7 +185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -223,7 +223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -243,7 +243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -263,7 +263,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -327,7 +327,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -355,7 +355,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -371,7 +371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -397,7 +397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "TCA cycle, aerobic respiration - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -414,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -429,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -443,7 +443,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -459,7 +459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -471,7 +471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -494,7 +494,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -519,7 +519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -536,7 +536,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -556,7 +556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -582,7 +582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -604,7 +604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -616,7 +616,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -645,7 +645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -681,7 +681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -693,7 +693,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -743,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -811,7 +811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -904,7 +904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -935,7 +935,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -951,7 +951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -962,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -974,7 +974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -984,7 +984,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1029,7 +1029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1048,7 +1048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1085,7 +1085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1099,7 +1099,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1115,7 +1115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1126,7 +1126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1138,7 +1138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1154,7 +1154,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1182,7 +1182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1197,7 +1197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1216,7 +1216,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1228,7 +1228,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1248,7 +1248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1264,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1284,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1297,7 +1297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1309,7 +1309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1336,7 +1336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1348,7 +1348,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1375,21 +1375,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://purl.obolibrary.org/obo/GO_0003674>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/ev_w_id_FUMHYDR-RXN_RO_0002411_MALATE-DEH-RXN_SGD_TCA-EUK-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1401,7 +1398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1412,6 +1409,9 @@
           <http://model.geneontology.org/CHEBI_57287_SUCCCOASYN-RXN>
 ] .
 
+<http://purl.obolibrary.org/obo/GO_0003674>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 <http://model.geneontology.org/CHEBI_57540_ISOCITRATE-DEHYDROGENASE-NAD+-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57540> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1421,7 +1421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1437,7 +1437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1454,7 +1454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1466,7 +1466,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1506,7 +1506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1529,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1545,7 +1545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1557,7 +1557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1574,7 +1574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1591,7 +1591,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1610,7 +1610,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1625,7 +1625,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1642,13 +1642,30 @@
 <http://identifiers.org/sgd/S000005284>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "H<sub>2</sub>O" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36437> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CITSYN-RXN_RO_0002233_CHEBI_16452_CITSYN-RXN_SGD_TCA-EUK-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1659,29 +1676,12 @@
           <http://model.geneontology.org/CHEBI_16452_CITSYN-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_15377_ACONITATEDEHYDR-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_15377> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "H<sub>2</sub>O" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TCA-EUK-PWYSmallMolecule36437> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000363> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1725,7 +1725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1738,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1750,7 +1750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1759,25 +1759,6 @@
           <http://model.geneontology.org/SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CPLX3O-742_SUCCINATE-DEHYDROGENASE-UBIQUINONE-RXN_controller>
-] .
-
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://www.w3.org/2000/01/rdf-schema#comment>
-          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_TCA-EUK-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002413> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_15378_MALATE-DEH-RXN>
@@ -1789,7 +1770,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,12 +1778,31 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://www.w3.org/2000/01/rdf-schema#comment>
+          "Provides Input For Rule. The relation 'D-<i>threo</i>-isocitrate + NAD<sup>+</sup> &rarr; 2-oxoglutarate + CO<SUB>2</SUB> + NADH' 'null' '2-oxoglutarate + coenzyme A + NAD<sup>+</sup> &rarr; succinyl-CoA + CO<SUB>2</SUB> + NADH' was inferred because:\n reaction1 has an output that is an input of reaction 2. " ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ISOCITRATE-DEHYDROGENASE-NAD+-RXN_RO_0002413_2OXOGLUTARATEDEH-RXN_null_TCA-EUK-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002413> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ISOCITRATE-DEHYDROGENASE-NAD+-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/2OXOGLUTARATEDEH-RXN>
+] .
+
 <http://model.geneontology.org/ev_w_id_2OXOGLUTARATEDEH-RXN_RO_0002233_CHEBI_57540_2OXOGLUTARATEDEH-RXN_SGD_TCA-EUK-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1813,7 +1813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1824,7 +1824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1858,7 +1858,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1884,7 +1884,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1900,7 +1900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1923,7 +1923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1939,7 +1939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1954,7 +1954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1970,7 +1970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1995,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2009,7 +2009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2035,7 +2035,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2061,7 +2061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2081,7 +2081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2104,7 +2104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2117,7 +2117,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2129,7 +2129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2167,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2212,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2226,7 +2226,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2243,7 +2243,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2260,7 +2260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2283,7 +2283,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2300,7 +2300,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2317,7 +2317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2337,7 +2337,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2350,7 +2350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2361,7 +2361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2373,7 +2373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,7 +2389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2410,7 +2410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2425,7 +2425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2438,7 +2438,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2452,7 +2452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2467,7 +2467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,7 +2480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2495,7 +2495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2508,7 +2508,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2526,7 +2526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2543,7 +2543,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2559,7 +2559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2571,7 +2571,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2588,7 +2588,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2608,7 +2608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2624,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2635,7 +2635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2644,7 +2644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2656,7 +2656,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2672,7 +2672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2684,7 +2684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2704,7 +2704,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2721,7 +2721,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2735,7 +2735,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2751,7 +2751,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2763,7 +2763,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2783,7 +2783,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2796,7 +2796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2806,7 +2806,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2829,7 +2829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2843,7 +2843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2873,7 +2873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2896,7 +2896,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2912,7 +2912,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2923,7 +2923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2934,7 +2934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2945,7 +2945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2955,7 +2955,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2971,7 +2971,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2982,7 +2982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2994,7 +2994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3014,7 +3014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3027,7 +3027,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3039,7 +3039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3055,7 +3055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3068,7 +3068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3081,7 +3081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3093,7 +3093,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3109,7 +3109,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3120,7 +3120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3135,7 +3135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3148,7 +3148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -3158,7 +3158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3188,7 +3188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3201,7 +3201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3216,7 +3216,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3233,7 +3233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3249,7 +3249,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3261,7 +3261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3278,7 +3278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3294,7 +3294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3305,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3317,7 +3317,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3333,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3344,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3369,7 +3369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3383,7 +3383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3399,7 +3399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3411,7 +3411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3431,7 +3431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3444,7 +3444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3455,7 +3455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3468,7 +3468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3488,7 +3488,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3504,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3518,7 +3518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3535,7 +3535,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3552,7 +3552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3571,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3582,7 +3582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3593,7 +3593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3604,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3619,7 +3619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3639,7 +3639,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3655,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3669,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3681,7 +3681,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3697,7 +3697,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3708,7 +3708,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3736,7 +3736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3749,7 +3749,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3764,7 +3764,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3780,7 +3780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3797,7 +3797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3813,7 +3813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3835,7 +3835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3850,7 +3850,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3866,7 +3866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3886,7 +3886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3902,7 +3902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3918,7 +3918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3933,7 +3933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3950,7 +3950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3966,7 +3966,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3983,7 +3983,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3999,7 +3999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4012,7 +4012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4025,7 +4025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4037,7 +4037,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4057,7 +4057,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4073,7 +4073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4086,7 +4086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4099,7 +4099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4111,7 +4111,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4127,7 +4127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4144,7 +4144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4161,7 +4161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4179,7 +4179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4195,7 +4195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4204,7 +4204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4215,7 +4215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4226,7 +4226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4238,7 +4238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4254,7 +4254,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4268,7 +4268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4293,7 +4293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4310,7 +4310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4323,7 +4323,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4341,7 +4341,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4361,7 +4361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4377,7 +4377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4391,7 +4391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4401,7 +4401,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4417,7 +4417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4428,7 +4428,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4440,7 +4440,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4457,7 +4457,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4478,7 +4478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4500,7 +4500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4523,7 +4523,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4537,7 +4537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4553,7 +4553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4564,7 +4564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4578,7 +4578,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4595,7 +4595,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4611,7 +4611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4626,7 +4626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4639,7 +4639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4650,7 +4650,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4660,7 +4660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4686,7 +4686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4703,7 +4703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4726,7 +4726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4742,7 +4742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4754,7 +4754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4771,7 +4771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4791,7 +4791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4804,7 +4804,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4819,7 +4819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4833,7 +4833,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4849,7 +4849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4861,7 +4861,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4881,7 +4881,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4898,7 +4898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4915,7 +4915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4932,7 +4932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4955,7 +4955,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4969,7 +4969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4985,7 +4985,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4995,7 +4995,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -5011,7 +5011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5022,7 +5022,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5033,7 +5033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5044,7 +5044,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5055,7 +5055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -5066,7 +5066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TCA-EUK-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TCA-EUK-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/THIOREDOX-PWY-THIOREDOX-PWY.ttl
+++ b/models/THIOREDOX-PWY-THIOREDOX-PWY.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "thioredoxin pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -77,7 +77,7 @@
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://model.geneontology.org/CHEBI_15339_THIOREDOXIN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24331> ;
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -128,7 +128,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -145,7 +145,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -161,7 +161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -172,6 +172,9 @@
 
 <http://purl.obolibrary.org/obo/RO_0002413>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_24431>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/THIOREDOXIN-RXN>
         a       <http://purl.obolibrary.org/obo/go/extensions/reacto.owl#molecular_event> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -190,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -201,9 +204,6 @@
 <http://purl.obolibrary.org/obo/BFO_0000050>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
-<http://purl.obolibrary.org/obo/CHEBI_24331>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/CHEBI_58349_THIOREDOXIN-REDUCT-NADPH-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58349> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -213,7 +213,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -230,7 +230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -250,7 +250,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
 
 <http://model.geneontology.org/CHEBI_17499_THIOREDOXIN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24331> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -290,7 +290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -322,7 +322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -342,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -369,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -383,7 +383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -402,7 +402,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -432,7 +432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -448,7 +448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -485,7 +485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -514,7 +514,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -538,7 +538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -597,7 +597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -622,7 +622,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -633,7 +633,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -682,7 +682,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,7 +730,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -743,7 +743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -796,7 +796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THIOREDOX-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THIOREDOX-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/THREOCAT2-PWY-THREOCAT2-PWY.ttl
+++ b/models/THREOCAT2-PWY-THREOCAT2-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -50,7 +50,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -61,7 +61,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -113,7 +113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -153,7 +153,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -173,7 +173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -186,7 +186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -198,7 +198,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -252,7 +252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +289,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -308,7 +308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -345,7 +345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -359,7 +359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -407,7 +407,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -423,7 +423,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -435,7 +435,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -462,7 +462,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -474,7 +474,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -509,7 +509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -524,7 +524,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -565,7 +565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +576,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -593,7 +593,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -642,7 +642,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -694,7 +694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -710,7 +710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -733,7 +733,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -764,7 +764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,7 +781,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -829,7 +829,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -890,7 +890,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -904,7 +904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -975,7 +975,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -995,7 +995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1008,7 +1008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1046,7 +1046,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1066,7 +1066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1083,7 +1083,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,7 +1099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1110,7 +1110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1135,7 +1135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1149,7 +1149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1169,7 +1169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1186,7 +1186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1200,7 +1200,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1241,7 +1241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1256,7 +1256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1269,7 +1269,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1294,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1308,7 +1308,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1324,7 +1324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1338,7 +1338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1354,7 +1354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1365,7 +1365,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1383,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1399,7 +1399,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1424,7 +1424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1441,7 +1441,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1461,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1491,7 +1491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1502,7 +1502,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1517,7 +1517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1531,7 +1531,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1551,7 +1551,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1567,7 +1567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1579,7 +1579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1595,7 +1595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1606,7 +1606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1617,7 +1617,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1629,7 +1629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1649,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1697,7 +1697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1714,7 +1714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1734,7 +1734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1765,7 +1765,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1792,7 +1792,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1806,7 +1806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1817,7 +1817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1846,7 +1846,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1872,7 +1872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1889,7 +1889,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1905,7 +1905,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1928,7 +1928,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1941,7 +1941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1953,7 +1953,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1984,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1998,7 +1998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2014,7 +2014,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2035,7 +2035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2049,7 +2049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2066,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,7 +2085,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2099,7 +2099,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2113,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2124,7 +2124,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2135,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2147,7 +2147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2176,7 +2176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2190,7 +2190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2207,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2226,7 +2226,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2241,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2261,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2274,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2285,7 +2285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2299,7 +2299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2316,7 +2316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2336,7 +2336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2349,7 +2349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2361,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2377,7 +2377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2389,7 +2389,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,7 +2405,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2420,7 +2420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2434,7 +2434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2468,7 +2468,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2488,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2502,7 +2502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2521,7 +2521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2539,7 +2539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2553,7 +2553,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2573,7 +2573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2590,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2604,7 +2604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2624,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2641,7 +2641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2654,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2668,7 +2668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2683,7 +2683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2705,7 +2705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2716,7 +2716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2728,7 +2728,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2756,7 +2756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2770,7 +2770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2786,7 +2786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2798,7 +2798,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2814,7 +2814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2835,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2851,7 +2851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2867,7 +2867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2879,7 +2879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2905,7 +2905,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2918,7 +2918,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2932,7 +2932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2948,7 +2948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2959,7 +2959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2974,7 +2974,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2988,7 +2988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3021,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3050,7 +3050,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3070,7 +3070,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "threonine degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -3083,7 +3083,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3094,7 +3094,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3106,7 +3106,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3122,7 +3122,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3133,7 +3133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3160,7 +3160,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3174,7 +3174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3194,7 +3194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3211,7 +3211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3230,7 +3230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3248,7 +3248,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3262,7 +3262,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3280,7 +3280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3297,7 +3297,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3314,7 +3314,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3330,7 +3330,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3346,7 +3346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3361,7 +3361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3378,7 +3378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3394,7 +3394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3409,7 +3409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3425,7 +3425,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3441,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3456,7 +3456,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3475,7 +3475,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3489,7 +3489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3505,7 +3505,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3516,7 +3516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3531,7 +3531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3548,7 +3548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3565,7 +3565,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3581,7 +3581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3592,7 +3592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3604,7 +3604,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3623,7 +3623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3655,7 +3655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3669,7 +3669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3689,7 +3689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3705,7 +3705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3719,7 +3719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3734,7 +3734,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3750,7 +3750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3761,7 +3761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3776,7 +3776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3789,7 +3789,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3801,7 +3801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3824,7 +3824,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3838,7 +3838,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3856,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3873,7 +3873,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3887,7 +3887,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3904,7 +3904,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3926,7 +3926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3949,7 +3949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3966,7 +3966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3980,7 +3980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4003,7 +4003,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4017,7 +4017,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4033,7 +4033,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THREOCAT2-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -4045,7 +4045,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4065,7 +4065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THREOCAT2-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/THRESYN-PWY-THRESYN-PWY.ttl
+++ b/models/THRESYN-PWY-THRESYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -32,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -63,7 +63,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -122,7 +122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -154,7 +154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,7 +221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -260,7 +260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -282,7 +282,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -301,7 +301,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -316,7 +316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -336,7 +336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -356,7 +356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -413,7 +413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -430,7 +430,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -450,7 +450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -479,7 +479,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +496,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -524,7 +524,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -574,7 +574,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -585,7 +585,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -634,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -648,7 +648,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -665,7 +665,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -685,7 +685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -711,7 +711,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -745,7 +745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -759,7 +759,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -777,7 +777,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -839,7 +839,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +855,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -867,7 +867,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -887,7 +887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -900,7 +900,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -966,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -980,7 +980,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1015,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1049,7 +1049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1063,7 +1063,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1080,7 +1080,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1100,7 +1100,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1144,7 +1144,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1162,7 +1162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1175,7 +1175,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1190,7 +1190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1210,7 +1210,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1240,7 +1240,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1271,7 +1271,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1284,7 +1284,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1336,7 +1336,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1356,7 +1356,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1370,7 +1370,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1414,7 +1414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1429,7 +1429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1442,7 +1442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1463,7 +1463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1477,7 +1477,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1494,7 +1494,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1510,7 +1510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1536,7 +1536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1549,7 +1549,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1578,7 +1578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1594,7 +1594,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1611,7 +1611,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1644,7 +1644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1665,7 +1665,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1682,7 +1682,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1699,7 +1699,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1735,7 +1735,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1760,7 +1760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1787,7 +1787,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1799,7 +1799,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1815,7 +1815,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1832,7 +1832,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1843,35 +1843,13 @@
           <http://model.geneontology.org/reaction_ASPARTATEKIN-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERKIN-RXN_SGD_THRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_THRESYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:THRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ASPAMINOTRANS-RXN_BFO_0000050_THRESYN-PWY/THRESYN-PWY_SGD_THRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1882,12 +1860,34 @@
           <http://model.geneontology.org/THRESYN-PWY/THRESYN-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_RO_0002234_CHEBI_15378_HOMOSERDEHYDROG-RXN_SGD_THRESYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_HOMOSERKIN-RXN_RO_0002233_CHEBI_57476_HOMOSERKIN-RXN_SGD_THRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:THRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_HOMOSERDEHYDROG-RXN_BFO_0000066_reaction_HOMOSERDEHYDROG-RXN_location_lociGO_0005829_null_THRESYN-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1901,7 +1901,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1913,7 +1913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1943,7 +1943,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1960,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1994,7 +1994,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2010,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2039,7 +2039,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2062,7 +2062,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2104,7 +2104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2120,7 +2120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2132,7 +2132,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2159,7 +2159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2171,7 +2171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2187,7 +2187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2215,7 +2215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2229,7 +2229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2248,7 +2248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2264,7 +2264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2279,7 +2279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "superpathway of L-threonine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,7 +2320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2340,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2353,7 +2353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2365,7 +2365,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2388,7 +2388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2401,7 +2401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2412,7 +2412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=THRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:THRESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/TREDEG-YEAST-PWY-TREDEG-YEAST-PWY.ttl
+++ b/models/TREDEG-YEAST-PWY-TREDEG-YEAST-PWY.ttl
@@ -6,7 +6,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -53,7 +53,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -65,7 +65,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -105,7 +105,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -120,7 +120,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -137,7 +137,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +188,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,7 +227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -264,7 +264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -281,7 +281,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -297,7 +297,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -317,7 +317,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -374,7 +374,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -400,7 +400,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -416,7 +416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -434,7 +434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TREDEG-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TREDEG-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/TRESYN-PWY-TRESYN-PWY.ttl
+++ b/models/TRESYN-PWY-TRESYN-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "trehalose biosynthesis I - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -48,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -62,7 +62,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -79,7 +79,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +104,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -115,7 +115,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -139,7 +139,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +221,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -238,7 +238,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -277,7 +277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -294,7 +294,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -313,7 +313,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -331,7 +331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -345,7 +345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -362,7 +362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -449,7 +449,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -478,7 +478,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -501,13 +501,24 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=TRESYN-PWYSmallMolecule67310> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_58885_TREHALOSE6PSYN-RXN_SGD_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/TREHALOSE6PSYN-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0003825> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -528,7 +539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -536,24 +547,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002233_CHEBI_58885_TREHALOSE6PSYN-RXN_SGD_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_RO_0002233_CHEBI_15377_TREHALOSEPHOSPHA-RXN_SGD_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -626,7 +626,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -654,7 +654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -671,7 +671,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -687,7 +687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -711,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -724,7 +724,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -742,7 +742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -753,24 +753,13 @@
           <http://model.geneontology.org/YDR074W-MONOMER_TREHALOSEPHOSPHA-RXN_controller>
 ] .
 
-<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_null_TRESYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:TRESYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_RO_0002234_CHEBI_58223_TREHALOSE6PSYN-RXN_SGD_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -781,13 +770,24 @@
           <http://model.geneontology.org/CHEBI_58223_TREHALOSE6PSYN-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_TREHALOSE6PSYN-RXN_BFO_0000066_reaction_TREHALOSE6PSYN-RXN_location_lociGO_0005829_null_TRESYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:TRESYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_TREHALOSEPHOSPHA-RXN_BFO_0000050_TRESYN-PWY/TRESYN-PWY_SGD_TRESYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -806,7 +806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -820,7 +820,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRESYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRESYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/TRIGLSYN-PWY-TRIGLSYN-PWY.ttl
+++ b/models/TRIGLSYN-PWY-TRIGLSYN-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -23,7 +23,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -39,7 +39,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -51,7 +51,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -74,7 +74,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "diacylglycerol and triacylglycerol biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -91,7 +91,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -107,7 +107,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -137,7 +137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -149,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -190,7 +190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -208,7 +208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -274,7 +274,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +293,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -315,7 +315,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -338,7 +338,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -358,7 +358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +375,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -406,7 +406,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -419,7 +419,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -464,7 +464,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -478,7 +478,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -493,7 +493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -512,7 +512,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -528,7 +528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -542,7 +542,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -555,7 +555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -580,7 +580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -608,7 +608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -619,7 +619,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -630,7 +630,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -641,7 +641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +690,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -709,7 +709,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -721,7 +721,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -743,7 +743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -759,7 +759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -771,7 +771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -791,7 +791,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -808,7 +808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -825,7 +825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -838,7 +838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -856,7 +856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -869,7 +869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -880,7 +880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -920,7 +920,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -973,7 +973,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -999,7 +999,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1065,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1078,7 +1078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1106,7 +1106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1114,24 +1114,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000050_TRIGLSYN-PWY/TRIGLSYN-PWY_SGD_TRIGLSYN-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:TRIGLSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_RXN-1623_RO_0002333_YDL052C-MONOMER_RXN-1623_controller_SGD_TRIGLSYN-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1142,6 +1131,17 @@
           <http://model.geneontology.org/YDL052C-MONOMER_RXN-1623_controller>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-1381_BFO_0000050_TRIGLSYN-PWY/TRIGLSYN-PWY_SGD_TRIGLSYN-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:TRIGLSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://identifiers.org/sgd/S000001775>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -1151,7 +1151,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1198,7 +1198,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1212,7 +1212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1227,7 +1227,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1244,7 +1244,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1264,7 +1264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1280,7 +1280,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1291,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1304,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1322,7 +1322,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1341,7 +1341,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1355,7 +1355,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1372,7 +1372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1388,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1403,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1423,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1443,7 +1443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1476,7 +1476,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1493,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1513,7 +1513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1532,7 +1532,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1544,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1563,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1581,7 +1581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1598,7 +1598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1611,7 +1611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1640,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1656,7 +1656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1671,7 +1671,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1685,7 +1685,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1717,7 +1717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1753,7 +1753,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1796,7 +1796,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1813,7 +1813,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1830,7 +1830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1847,7 +1847,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1880,7 +1880,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1891,7 +1891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1902,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1923,7 +1923,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1936,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1951,7 +1951,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1970,7 +1970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,7 +1987,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2004,7 +2004,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2020,7 +2020,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2038,7 +2038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2055,7 +2055,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2071,7 +2071,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2088,7 +2088,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2108,7 +2108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2124,7 +2124,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2144,7 +2144,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2161,7 +2161,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2186,7 +2186,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2201,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2218,7 +2218,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2238,7 +2238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2252,7 +2252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2289,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2302,7 +2302,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2316,7 +2316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2327,7 +2327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2340,7 +2340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2354,7 +2354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2374,7 +2374,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2388,7 +2388,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2405,7 +2405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2421,7 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2432,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2443,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2454,7 +2454,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2469,7 +2469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2482,7 +2482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2497,7 +2497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2513,7 +2513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRIGLSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2527,7 +2527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2545,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2575,7 +2575,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2592,7 +2592,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRIGLSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/TRPSYN-PWY-1-TRPSYN-PWY-1.ttl
+++ b/models/TRPSYN-PWY-1-TRPSYN-PWY-1.ttl
@@ -6,7 +6,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -26,7 +26,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -45,7 +45,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -56,7 +56,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -90,7 +90,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -109,7 +109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -177,7 +177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -191,7 +191,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -211,7 +211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -243,7 +243,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -256,7 +256,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -268,7 +268,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -288,7 +288,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -305,7 +305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -318,7 +318,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -333,7 +333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -347,7 +347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -358,19 +358,19 @@
           <http://model.geneontology.org/CHEBI_33384_TRYPSYN-RXN>
 ] .
 
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
 <http://model.geneontology.org/ev_w_id_PRTRANS-RXN_BFO_0000066_reaction_PRTRANS-RXN_location_lociGO_0005829_null_TRPSYN-PWY-1>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -378,7 +378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -401,7 +401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -418,7 +418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -434,7 +434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -446,7 +446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -469,7 +469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -483,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -527,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -541,7 +541,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -560,7 +560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -572,7 +572,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -595,7 +595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -611,7 +611,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -639,7 +639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +683,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -697,7 +697,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -727,7 +727,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -761,7 +761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -774,7 +774,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -785,7 +785,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -797,7 +797,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -814,7 +814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -845,7 +845,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -858,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -876,7 +876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -890,7 +890,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -924,7 +924,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -944,7 +944,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -959,7 +959,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -976,7 +976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -989,7 +989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1015,7 +1015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1032,7 +1032,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1079,7 +1079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1104,7 +1104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1129,7 +1129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1148,7 +1148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1170,7 +1170,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1181,7 +1181,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1193,7 +1193,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1224,7 +1224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1283,7 +1283,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1294,7 +1294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1305,7 +1305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1328,7 +1328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1345,7 +1345,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1364,7 +1364,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1376,7 +1376,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1396,7 +1396,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1416,7 +1416,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1433,7 +1433,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1446,7 +1446,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1457,7 +1457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1471,7 +1471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1486,7 +1486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1500,7 +1500,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1519,7 +1519,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1535,7 +1535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1547,7 +1547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1563,7 +1563,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1580,7 +1580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1591,7 +1591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1605,7 +1605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1622,7 +1622,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1638,7 +1638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1652,7 +1652,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,7 +1669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1694,7 +1694,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1705,7 +1705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1718,7 +1718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1732,7 +1732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1752,7 +1752,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1768,7 +1768,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1786,7 +1786,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1803,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1816,7 +1816,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1827,7 +1827,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1838,7 +1838,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1852,7 +1852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1862,7 +1862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1879,7 +1879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1899,7 +1899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1914,7 +1914,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1931,7 +1931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1945,7 +1945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1962,7 +1962,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1978,7 +1978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>
@@ -1996,7 +1996,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2012,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRPSYN-PWY-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRPSYN-PWY-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/TRYPTOPHAN-DEGRADATION-1-TRYPTOPHAN-DEGRADATION-1.ttl
+++ b/models/TRYPTOPHAN-DEGRADATION-1-TRYPTOPHAN-DEGRADATION-1.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -24,7 +24,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -73,7 +73,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -84,7 +84,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -95,7 +95,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -107,7 +107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -126,7 +126,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -138,7 +138,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -158,7 +158,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -172,7 +172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -195,7 +195,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -212,7 +212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -229,7 +229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -242,7 +242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -276,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -310,7 +310,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -354,7 +354,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -366,7 +366,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -382,7 +382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -393,7 +393,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -411,7 +411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-tryptophan degradation III (eukaryotic) - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -426,7 +426,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -473,7 +473,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -490,7 +490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -518,7 +518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -537,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -552,7 +552,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -589,7 +589,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -605,7 +605,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -621,7 +621,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -650,7 +650,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -701,7 +701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -715,7 +715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,7 +736,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -750,7 +750,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +775,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -789,7 +789,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -809,7 +809,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,7 +823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -843,7 +843,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -870,7 +870,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -883,7 +883,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -898,7 +898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -911,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -926,7 +926,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -946,7 +946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -962,7 +962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -974,7 +974,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -991,7 +991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1007,7 +1007,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1030,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1052,7 +1052,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1063,7 +1063,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1075,7 +1075,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1091,7 +1091,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1133,7 +1133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1147,7 +1147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1164,7 +1164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1180,7 +1180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1192,7 +1192,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1219,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1253,7 +1253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1273,7 +1273,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1290,7 +1290,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1318,7 +1318,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1340,7 +1340,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1362,7 +1362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1373,7 +1373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1385,7 +1385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1401,7 +1401,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1413,7 +1413,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1441,7 +1441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1458,7 +1458,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1481,7 +1481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1497,7 +1497,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1520,7 +1520,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1537,7 +1537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1551,7 +1551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1590,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1636,7 +1636,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1653,7 +1653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1667,7 +1667,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1687,7 +1687,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1712,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1726,7 +1726,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1742,7 +1742,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1756,7 +1756,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1776,7 +1776,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1795,7 +1795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1807,7 +1807,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1824,7 +1824,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1844,7 +1844,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1860,7 +1860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -1875,7 +1875,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1893,7 +1893,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1910,7 +1910,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1930,7 +1930,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1949,7 +1949,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1969,7 +1969,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1989,7 +1989,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2002,7 +2002,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2019,7 +2019,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2034,7 +2034,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2048,7 +2048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2068,7 +2068,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2088,7 +2088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2133,7 +2133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2147,7 +2147,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2167,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2187,7 +2187,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2207,7 +2207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2224,7 +2224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2241,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2261,7 +2261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2274,7 +2274,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2286,7 +2286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2306,7 +2306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2320,7 +2320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2336,7 +2336,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2353,7 +2353,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,7 +2373,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2389,7 +2389,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2403,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2418,7 +2418,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2434,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2448,7 +2448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2459,7 +2459,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2470,7 +2470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2481,7 +2481,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2493,7 +2493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2509,7 +2509,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2537,7 +2537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2555,7 +2555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2582,7 +2582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2599,7 +2599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2612,7 +2612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2624,7 +2624,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2640,7 +2640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2651,7 +2651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2662,7 +2662,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2674,7 +2674,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2693,7 +2693,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2714,7 +2714,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2734,7 +2734,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2750,7 +2750,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2764,7 +2764,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2784,7 +2784,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2801,7 +2801,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2818,7 +2818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2835,7 +2835,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2849,7 +2849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2869,7 +2869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2883,7 +2883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2913,7 +2913,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2926,7 +2926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2937,7 +2937,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2948,7 +2948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2962,7 +2962,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -2988,7 +2988,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3008,7 +3008,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3021,7 +3021,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3036,7 +3036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3049,7 +3049,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3061,7 +3061,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3081,7 +3081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3098,7 +3098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3112,7 +3112,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3128,7 +3128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3146,7 +3146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3159,7 +3159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3172,7 +3172,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3189,7 +3189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3206,7 +3206,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3222,7 +3222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3237,7 +3237,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3253,7 +3253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3264,7 +3264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3279,7 +3279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3295,7 +3295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3314,7 +3314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3333,7 +3333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3347,7 +3347,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3371,7 +3371,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3385,7 +3385,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3418,7 +3418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3434,7 +3434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3450,7 +3450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3471,7 +3471,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3491,7 +3491,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3504,7 +3504,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3516,7 +3516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3535,7 +3535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3547,7 +3547,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3565,7 +3565,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3579,7 +3579,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3595,7 +3595,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3607,7 +3607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3626,7 +3626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3641,7 +3641,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3668,7 +3668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3685,7 +3685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3698,7 +3698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>
@@ -3710,7 +3710,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3730,7 +3730,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3760,7 +3760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3774,7 +3774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3790,7 +3790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:TRYPTOPHAN-DEGRADATION-1" ;
         <http://purl.org/pav/providedBy>

--- a/models/UDPNAGSYN-YEAST-PWY-UDPNAGSYN-YEAST-PWY.ttl
+++ b/models/UDPNAGSYN-YEAST-PWY-UDPNAGSYN-YEAST-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -51,11 +51,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_436c4ce2-4fb9-4dd5-b811-8f7658bd1836_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -63,7 +63,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+          <http://model.geneontology.org/436c4ce2-4fb9-4dd5-b811-8f7658bd1836_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/CHEBI_15378>
@@ -78,7 +78,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -92,7 +92,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -119,7 +119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -131,7 +131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -147,7 +147,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -179,7 +179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -199,6 +199,17 @@
 <http://purl.org/pav/providedBy>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_7ea8b0d9-9753-4bc7-b663-7b75182ea8ba_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_29985> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -208,7 +219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -221,7 +232,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -229,9 +240,6 @@
 
 <http://purl.obolibrary.org/obo/GO_0008150>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829>
-        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 <http://model.geneontology.org/CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57634> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -242,7 +250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -250,16 +258,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829>
+        a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -267,7 +267,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -280,11 +280,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
+          <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_7ea8b0d9-9753-4bc7-b663-7b75182ea8ba_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN>
+          <http://model.geneontology.org/7ea8b0d9-9753-4bc7-b663-7b75182ea8ba_GLUCOSAMINEPNACETYLTRANS-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN>
@@ -304,7 +304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -320,7 +320,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,7 +343,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -370,7 +370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -378,22 +378,8 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
-<http://purl.obolibrary.org/obo/BFO_0000050>
-        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/436c4ce2-4fb9-4dd5-b811-8f7658bd1836_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
                 "located_in cytosol" ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -401,7 +387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -409,13 +395,27 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://purl.obolibrary.org/obo/BFO_0000050>
+        a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_46398_NAG1P-URIDYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -435,24 +435,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42360> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_RO_0002233_9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/CHEBI_57288> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -463,7 +452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -476,7 +465,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -491,7 +480,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -513,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -546,7 +535,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -562,7 +551,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -578,7 +567,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -592,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -607,7 +596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -634,7 +623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -645,7 +634,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -657,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -674,7 +663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -690,7 +679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -707,7 +696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -719,13 +708,24 @@
 <http://purl.obolibrary.org/obo/CHEBI_57705>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000066_reaction_NAG1P-URIDYLTRANS-RXN_location_lociGO_0005829_null_UDPNAGSYN-YEAST-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002233_CHEBI_15378_NAG1P-URIDYLTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -736,14 +736,14 @@
           <http://model.geneontology.org/CHEBI_15378_NAG1P-URIDYLTRANS-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_BFO_0000066_reaction_NAG1P-URIDYLTRANS-RXN_location_lociGO_0005829_null_UDPNAGSYN-YEAST-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+<http://model.geneontology.org/ev_w_id_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_RO_0002234_436c4ce2-4fb9-4dd5-b811-8f7658bd1836_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
-                "null:UDPNAGSYN-YEAST-PWY" ;
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -754,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -777,7 +777,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -813,7 +813,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -826,7 +826,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -843,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -860,7 +860,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -877,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -913,7 +913,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -931,7 +931,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -961,7 +961,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -972,7 +972,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -998,7 +998,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1018,7 +1018,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "UDP-N-acetylglucosamine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1031,7 +1031,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1065,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_57634_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/CHEBI_58359_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_29985_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> , <http://model.geneontology.org/436c4ce2-4fb9-4dd5-b811-8f7658bd1836_L-GLN-FRUCT-6-P-AMINOTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKL104C-MONOMER_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1073,7 +1073,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1093,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1104,6 +1104,17 @@
 <http://identifiers.org/sgd/S000001877>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
           "Occurs In Rule. This relation was asserted because all entities involved in the reaction are in the same location. " ;
@@ -1112,7 +1123,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1123,24 +1134,13 @@
           <http://model.geneontology.org/reaction_L-GLN-FRUCT-6-P-AMINOTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_PHOSACETYLGLUCOSAMINEMUT-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_GLUCOSAMINEPNACETYLTRANS-RXN_BFO_0000050_UDPNAGSYN-YEAST-PWY/UDPNAGSYN-YEAST-PWY_SGD_UDPNAGSYN-YEAST-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1157,7 +1157,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1187,7 +1187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1205,7 +1205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1230,7 +1230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1252,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1272,7 +1272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1292,7 +1292,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1325,18 +1325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_UDPNAGSYN-YEAST-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1348,7 +1337,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1359,22 +1348,16 @@
           <http://model.geneontology.org/CHEBI_57776_PHOSACETYLGLUCOSAMINEMUT-RXN>
 ] .
 
-<http://model.geneontology.org/7645779c-4ae5-4202-812e-c95dcd92b9cd_L-GLN-FRUCT-6-P-AMINOTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "D-glucosamine 6-phosphate" ;
+<http://model.geneontology.org/ev_w_id_NAG1P-URIDYLTRANS-RXN_RO_0002333_YDL103C-MONOMER_NAG1P-URIDYLTRANS-RXN_controller_SGD_UDPNAGSYN-YEAST-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/GLUCOSAMINEPNACETYLTRANS-RXN>
         a       <http://purl.obolibrary.org/obo/GO_0004343> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -1385,7 +1368,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_GLUCOSAMINEPNACETYLTRANS-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/9d5eac55-9f9a-4ab3-9408-1f11fb332519_GLUCOSAMINEPNACETYLTRANS-RXN> ;
+                <http://model.geneontology.org/CHEBI_57288_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/7ea8b0d9-9753-4bc7-b663-7b75182ea8ba_GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_15378_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57287_GLUCOSAMINEPNACETYLTRANS-RXN> , <http://model.geneontology.org/CHEBI_57513_GLUCOSAMINEPNACETYLTRANS-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1395,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1412,7 +1395,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1428,7 +1411,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1440,7 +1423,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1456,7 +1439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1467,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1478,7 +1461,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:UDPNAGSYN-YEAST-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1486,3 +1469,20 @@
 
 <http://identifiers.org/sgd/S000000784>
         a       <http://www.w3.org/2002/07/owl#Class> .
+
+<http://model.geneontology.org/7ea8b0d9-9753-4bc7-b663-7b75182ea8ba_GLUCOSAMINEPNACETYLTRANS-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "D-glucosamine 6-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=UDPNAGSYN-YEAST-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=UDPNAGSYN-YEAST-PWYSmallMolecule42445> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .

--- a/models/VALSYN-PWY-VALSYN-PWY.ttl
+++ b/models/VALSYN-PWY-VALSYN-PWY.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -17,7 +17,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -29,7 +29,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -86,7 +86,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -110,7 +110,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -130,7 +130,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -157,7 +157,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -217,7 +217,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -234,7 +234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -247,7 +247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -261,7 +261,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -275,7 +275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -287,7 +287,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -304,7 +304,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -324,7 +324,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -353,7 +353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -366,7 +366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -387,7 +387,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -404,7 +404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "L-valine biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -440,7 +440,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -451,7 +451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -465,7 +465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -484,7 +484,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -516,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -529,7 +529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -540,7 +540,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -553,7 +553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -570,7 +570,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -587,7 +587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -607,7 +607,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -668,7 +668,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -685,7 +685,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -698,7 +698,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -713,7 +713,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -729,7 +729,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -741,7 +741,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -760,7 +760,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -769,7 +769,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -787,7 +787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -804,7 +804,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -834,7 +834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -857,7 +857,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -874,7 +874,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -893,7 +893,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -910,7 +910,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -930,7 +930,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -943,7 +943,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -954,7 +954,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -970,7 +970,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -987,7 +987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1011,7 +1011,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1026,7 +1026,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1049,7 +1049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1067,7 +1067,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1080,7 +1080,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1128,7 +1128,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1141,7 +1141,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1173,7 +1173,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1189,7 +1189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1209,7 +1209,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1227,7 +1227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1256,7 +1256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1275,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1293,7 +1293,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1306,7 +1306,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1320,7 +1320,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1331,7 +1331,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1346,7 +1346,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1366,7 +1366,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1379,7 +1379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1388,16 +1388,22 @@
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_VALSYN-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:VALSYN-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
+  <http://geneontology.org/lego/evidence>
+          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_VALSYN-PWY> ;
+  <http://purl.org/dc/elements/1.1/contributor>
+          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+  <http://purl.org/dc/elements/1.1/date>
+          "2022-04-13" ;
+  <http://purl.org/pav/providedBy>
+          "https://yeastgenome.org" ;
+  <http://www.w3.org/2002/07/owl#annotatedProperty>
+          <http://purl.obolibrary.org/obo/RO_0002234> ;
+  <http://www.w3.org/2002/07/owl#annotatedSource>
+          <http://model.geneontology.org/ACETOLACTREDUCTOISOM-RXN> ;
+  <http://www.w3.org/2002/07/owl#annotatedTarget>
+          <http://model.geneontology.org/CHEBI_57783_ACETOLACTREDUCTOISOM-RXN>
+] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1405,7 +1411,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1442,7 +1448,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1450,22 +1456,16 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-[ a       <http://www.w3.org/2002/07/owl#Axiom> ;
-  <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACETOLACTREDUCTOISOM-RXN_RO_0002234_CHEBI_57783_ACETOLACTREDUCTOISOM-RXN_SGD_VALSYN-PWY> ;
-  <http://purl.org/dc/elements/1.1/contributor>
-          "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
-  <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
-  <http://purl.org/pav/providedBy>
-          "https://yeastgenome.org" ;
-  <http://www.w3.org/2002/07/owl#annotatedProperty>
-          <http://purl.obolibrary.org/obo/RO_0002234> ;
-  <http://www.w3.org/2002/07/owl#annotatedSource>
-          <http://model.geneontology.org/ACETOLACTREDUCTOISOM-RXN> ;
-  <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/CHEBI_57783_ACETOLACTREDUCTOISOM-RXN>
-] .
+<http://model.geneontology.org/ev_w_id_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_RO_0002233_CHEBI_57762_BRANCHED-CHAINAMINOTRANSFERVAL-RXN_SGD_VALSYN-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:VALSYN-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1475,7 +1475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1497,7 +1497,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1509,7 +1509,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1528,7 +1528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1543,7 +1543,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1566,7 +1566,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1579,7 +1579,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1590,7 +1590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=VALSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:VALSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-4AMINOBUTMETAB-PWY-YEAST-4AMINOBUTMETAB-PWY.ttl
+++ b/models/YEAST-4AMINOBUTMETAB-PWY-YEAST-4AMINOBUTMETAB-PWY.ttl
@@ -7,7 +7,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -20,7 +20,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -35,7 +35,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -52,7 +52,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -69,7 +69,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -98,7 +98,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -118,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "4-aminobutyrate degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -140,7 +140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -151,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -177,7 +177,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -193,7 +193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -205,7 +205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -225,7 +225,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -238,7 +238,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -259,7 +259,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -287,7 +287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -310,7 +310,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -344,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -364,7 +364,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -392,7 +392,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -408,7 +408,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -431,7 +431,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -444,7 +444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -468,7 +468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -486,7 +486,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -502,7 +502,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -518,7 +518,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -533,7 +533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -552,7 +552,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -572,7 +572,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -588,7 +588,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -596,6 +596,9 @@
 
 <http://geneontology.org/lego/evidence>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
+
+<http://purl.obolibrary.org/obo/CHEBI_30031>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://model.geneontology.org/CHEBI_16810_GABATRANSAM-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_16810> ;
@@ -606,16 +609,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-4AMINOBUTMETAB-PWYSmallMolecule20119> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://purl.obolibrary.org/obo/CHEBI_30031>
-        a       <http://www.w3.org/2002/07/owl#Class> .
 
 <http://identifiers.org/sgd/S000003251>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -629,7 +629,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -646,7 +646,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -667,7 +667,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -684,7 +684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -701,7 +701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -723,7 +723,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -771,7 +771,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -800,7 +800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -849,7 +849,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -868,7 +868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-4AMINOBUTMETAB-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-DE-NOVO-PYRMID-DNT-YEAST-DE-NOVO-PYRMID-DNT.ttl
+++ b/models/YEAST-DE-NOVO-PYRMID-DNT-YEAST-DE-NOVO-PYRMID-DNT.ttl
@@ -3,7 +3,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -15,7 +15,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -31,7 +31,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -42,7 +42,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -54,7 +54,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -70,7 +70,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -81,7 +81,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -112,7 +112,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -123,28 +123,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 7,8-dihydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -152,7 +135,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -168,7 +151,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -180,7 +163,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -196,7 +179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -213,7 +196,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -225,7 +208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -245,7 +228,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -258,7 +241,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -276,7 +259,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -293,7 +276,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -312,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -326,7 +309,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -359,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -375,7 +358,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -386,7 +369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -401,7 +384,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -415,7 +398,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -431,7 +414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -446,7 +429,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -463,7 +446,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -493,7 +476,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -507,7 +490,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -523,7 +506,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -534,7 +517,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -543,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +537,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -565,7 +548,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -576,7 +559,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -587,7 +570,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +581,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -616,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -632,7 +615,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -652,7 +635,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +649,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -683,7 +666,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -700,7 +683,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,7 +699,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -728,7 +711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -743,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -757,7 +740,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -775,7 +758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -791,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -812,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -820,13 +803,24 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_3acc5676-71c0-496a-9958-e0081e7ad879_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CPLX3O-270_CDPREDUCT-RXN_controller_BFO_0000051_SGD_S000003563_CPLX3O-270_component_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -848,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +853,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -867,11 +861,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_3acc5676-71c0-496a-9958-e0081e7ad879_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -879,7 +873,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/3acc5676-71c0-496a-9958-e0081e7ad879_THYMIDYLATESYN-RXN>
 ] .
 
 <http://purl.obolibrary.org/obo/BFO_0000050>
@@ -894,7 +888,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +909,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -929,7 +923,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -959,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -972,7 +966,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -987,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1018,7 +1012,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1037,7 +1031,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1065,7 +1059,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1079,7 +1073,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1099,7 +1093,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1113,7 +1107,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1133,9 +1127,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/CHEBI_246422_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/3acc5676-71c0-496a-9958-e0081e7ad879_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
+                <http://model.geneontology.org/6898a5d3-a95e-4b34-acf3-54bf73c6ffd0_THYMIDYLATESYN-RXN> , <http://model.geneontology.org/CHEBI_63528_THYMIDYLATESYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/CPLX3O-630_THYMIDYLATESYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
@@ -1143,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1156,7 +1150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1165,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1191,7 +1185,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1208,7 +1202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1224,7 +1218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1239,7 +1233,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1258,7 +1252,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1274,7 +1268,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1285,7 +1279,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1296,7 +1290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1308,7 +1302,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1325,7 +1319,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,7 +1347,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1366,7 +1360,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1372,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,7 +1388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1409,7 +1403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1424,7 +1418,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1440,7 +1434,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1456,7 +1450,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1467,11 +1461,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/6898a5d3-a95e-4b34-acf3-54bf73c6ffd0_THYMIDYLATESYN-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 7,8-dihydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44945> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_57566>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1482,7 +1493,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1502,7 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1516,7 +1527,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1533,7 +1544,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1564,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1570,7 +1581,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1586,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1609,7 +1620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,7 +1640,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1649,7 +1660,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1669,7 +1680,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1685,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1696,7 +1707,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1708,7 +1719,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1727,7 +1738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1752,7 +1763,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1769,7 +1780,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1791,7 +1802,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1807,7 +1818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1818,7 +1829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1829,7 +1840,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1840,7 +1851,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1855,7 +1866,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1872,7 +1883,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1889,7 +1900,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1908,7 +1919,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1924,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1939,7 +1950,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1958,7 +1969,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1969,7 +1980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -1984,7 +1995,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2001,7 +2012,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "de novo biosynthesis of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2018,7 +2029,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2034,7 +2045,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2049,7 +2060,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2065,7 +2076,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2085,7 +2096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2102,7 +2113,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2118,7 +2129,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2141,7 +2152,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2158,7 +2169,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2188,7 +2199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2201,7 +2212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2216,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2230,7 +2241,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2247,7 +2258,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2264,7 +2275,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2280,7 +2291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2292,7 +2303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2308,7 +2319,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2322,7 +2333,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2333,7 +2344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2351,7 +2362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2371,7 +2382,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2388,7 +2399,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2399,6 +2410,23 @@
           <http://model.geneontology.org/CHEBI_63528_DTMPKI-RXN>
 ] .
 
+<http://model.geneontology.org/3acc5676-71c0-496a-9958-e0081e7ad879_THYMIDYLATESYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 5,10-methylenetetrahydrofolate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 <http://model.geneontology.org/YKL067W-MONOMER_DTDPKIN-RXN_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000001550> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -2406,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2420,7 +2448,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2440,7 +2468,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2470,7 +2498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2480,11 +2508,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
+          <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_6898a5d3-a95e-4b34-acf3-54bf73c6ffd0_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2492,7 +2520,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/THYMIDYLATESYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN>
+          <http://model.geneontology.org/6898a5d3-a95e-4b34-acf3-54bf73c6ffd0_THYMIDYLATESYN-RXN>
 ] .
 
 <http://model.geneontology.org/ev_w_id_DUDPKIN-RXN_RO_0002233_CHEBI_30616_DUDPKIN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
@@ -2500,7 +2528,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2517,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2528,7 +2556,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2543,7 +2571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2559,7 +2587,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2579,7 +2607,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2596,7 +2624,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2610,7 +2638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2621,17 +2649,6 @@
           <http://model.geneontology.org/YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002233_f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://model.geneontology.org/reaction_THYMIDYLATESYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
@@ -2640,7 +2657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2652,7 +2669,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2669,7 +2686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2685,7 +2702,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2697,7 +2714,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2727,7 +2744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2740,7 +2757,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2749,7 +2766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2761,7 +2778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2777,7 +2794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2788,7 +2805,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2802,7 +2819,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2817,7 +2834,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2831,7 +2848,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2851,7 +2868,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2871,7 +2888,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2885,7 +2902,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2896,24 +2913,13 @@
           <http://model.geneontology.org/SGD_S000000872_CPLX3O-270_component>
 ] .
 
-<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_7887ea7e-5ed3-4f2a-ab97-338d462ed863_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2936,7 +2942,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2953,7 +2959,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2969,7 +2975,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -2980,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -2990,7 +2996,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3010,7 +3016,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3026,7 +3032,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3037,7 +3043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3049,7 +3055,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3072,7 +3078,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3089,7 +3095,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3102,7 +3108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3114,7 +3120,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3133,7 +3139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3149,28 +3155,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/f93aa13e-8b25-41bf-8d4f-58c62e013ba7_THYMIDYLATESYN-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 5,10-methylenetetrahydrofolate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-DE-NOVO-PYRMID-DNTSmallMolecule44939> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/CHEBI_33695>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -3180,7 +3169,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3191,7 +3180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3202,7 +3191,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3219,7 +3208,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3235,7 +3224,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3246,7 +3235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3258,7 +3247,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3274,7 +3263,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3289,7 +3278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3305,7 +3294,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3316,7 +3305,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3327,7 +3316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3339,7 +3328,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3355,7 +3344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3367,7 +3356,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3383,7 +3372,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3394,7 +3383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3408,7 +3397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3428,7 +3417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3441,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3452,7 +3441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3463,7 +3452,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3474,7 +3463,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3486,7 +3475,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3512,7 +3501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3532,7 +3521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3549,7 +3538,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3569,7 +3558,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3589,7 +3578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3602,7 +3591,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3617,7 +3606,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3634,7 +3623,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3650,7 +3639,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3664,7 +3653,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3680,7 +3669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3695,7 +3684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3711,7 +3700,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3722,7 +3711,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3737,7 +3726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3754,7 +3743,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3771,7 +3760,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3794,7 +3783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3811,7 +3800,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3834,7 +3823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3848,7 +3837,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3867,7 +3856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3882,7 +3871,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3902,7 +3891,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -3919,7 +3908,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3936,7 +3925,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3952,7 +3941,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3963,7 +3952,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -3975,7 +3964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3991,7 +3980,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4002,7 +3991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -4012,7 +4001,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4023,12 +4012,23 @@
           <http://model.geneontology.org/SGD_S000003563_CPLX3O-270_component>
 ] .
 
+<http://model.geneontology.org/ev_w_id_THYMIDYLATESYN-RXN_RO_0002234_6898a5d3-a95e-4b34-acf3-54bf73c6ffd0_THYMIDYLATESYN-RXN_SGD_YEAST-DE-NOVO-PYRMID-DNT>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_UDPREDUCT-RXN_BFO_0000050_YEAST-DE-NOVO-PYRMID-DNT/YEAST-DE-NOVO-PYRMID-DNT_SGD_YEAST-DE-NOVO-PYRMID-DNT>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4043,7 +4043,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_DUDPKIN-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_60471_DUDPKIN-RXN> , <http://model.geneontology.org/CHEBI_30616_DUDPKIN-RXN> ;
+                <http://model.geneontology.org/CHEBI_30616_DUDPKIN-RXN> , <http://model.geneontology.org/CHEBI_60471_DUDPKIN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_456216_DUDPKIN-RXN> , <http://model.geneontology.org/CHEBI_61555_DUDPKIN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -4053,7 +4053,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4069,7 +4069,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4089,7 +4089,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4106,7 +4106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4119,7 +4119,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>
@@ -4133,7 +4133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4150,7 +4150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4167,7 +4167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4184,7 +4184,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4212,7 +4212,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4229,7 +4229,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4247,7 +4247,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -4261,7 +4261,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -4277,7 +4277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-DE-NOVO-PYRMID-DNT" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-FAO-PWY-YEAST-FAO-PWY.ttl
+++ b/models/YEAST-FAO-PWY-YEAST-FAO-PWY.ttl
@@ -4,7 +4,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -20,28 +20,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -49,7 +32,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -65,7 +48,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -76,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -88,7 +71,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -104,7 +87,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +110,7 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_15455_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN> , <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> ;
+                <http://model.geneontology.org/CHEBI_15377_ENOYL-COA-HYDRAT-RXN> , <http://model.geneontology.org/d1f6d534-f501-4098-9db5-dd05c267554d_ENOYL-COA-HYDRAT-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YKR009C-MONOMER_ENOYL-COA-HYDRAT-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -135,7 +118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -152,7 +135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -166,7 +149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -188,7 +171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -219,7 +202,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -227,12 +210,23 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_c4966e6b-16c9-488e-a101-267b2dc380aa_RXN-11026_SGD_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_BFO_0000050_YEAST-FAO-PWY/YEAST-FAO-PWY_SGD_YEAST-FAO-PWY>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -243,23 +237,6 @@
 
 <http://purl.obolibrary.org/obo/CHEBI_15377>
         a       <http://www.w3.org/2002/07/owl#Class> .
-
-<http://model.geneontology.org/40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0004300>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -276,7 +253,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -289,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -301,7 +278,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -318,7 +295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -343,15 +320,15 @@
         <http://purl.obolibrary.org/obo/RO_0002233>
                 <http://model.geneontology.org/CHEBI_30616_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_71627_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> ;
+                <http://model.geneontology.org/1e369a45-0100-41de-bb28-82b29247db00_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_456215_ACYLCOASYN-RXN> , <http://model.geneontology.org/CHEBI_29888_ACYLCOASYN-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
-                <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YMR246W-MONOMER_ACYLCOASYN-RXN_controller> ;
+                <http://model.geneontology.org/YBR041W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YOR317W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YIL009W-MONOMER_ACYLCOASYN-RXN_controller> , <http://model.geneontology.org/YMR246W-MONOMER_ACYLCOASYN-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002413>
                 <http://model.geneontology.org/RXN-11026> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -367,7 +344,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -385,7 +362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -402,7 +379,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -417,7 +394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -453,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -466,11 +443,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_360170cb-0028-4e05-aea3-1ce509986217_RXN-11026_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -478,7 +455,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026>
+          <http://model.geneontology.org/360170cb-0028-4e05-aea3-1ce509986217_RXN-11026>
 ] .
 
 <http://model.geneontology.org/CHEBI_57287_ACYLCOASYN-RXN>
@@ -490,7 +467,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -506,7 +483,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,28 +503,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59316> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -556,7 +516,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -567,7 +527,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -581,7 +541,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -595,7 +555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -611,11 +571,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_7ced0bf6-cff4-4c97-8790-2252b72252f4_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -623,7 +583,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/7ced0bf6-cff4-4c97-8790-2252b72252f4_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://model.geneontology.org/YER015W-MONOMER_ACYLCOASYN-RXN_controller>
@@ -633,7 +593,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -657,13 +617,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYProtein59398> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/c4966e6b-16c9-488e-a101-267b2dc380aa_RXN-11026>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/GO_0003857>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -677,7 +654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "fatty acid oxidation pathway - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -690,28 +667,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN>
-        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a (3Z)-alk-3-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -719,7 +679,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -730,13 +690,24 @@
           <http://model.geneontology.org/YEAST-FAO-PWY/YEAST-FAO-PWY>
 ] .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_d1f6d534-f501-4098-9db5-dd05c267554d_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_CHEBI_15377_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -755,7 +726,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +738,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,7 +754,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -796,13 +767,30 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYProtein59392> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.Protein" .
+
+<http://model.geneontology.org/0e8eb35b-39ed-4a50-8365-ee2ad684db62_KETOACYLCOATHIOL-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -813,7 +801,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -830,7 +818,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -855,7 +843,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -870,7 +858,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -878,28 +866,11 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
-<http://purl.obolibrary.org/obo/GO_0005829>
-        a       <http://www.w3.org/2002/07/owl#Class> .
-
 <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0005829> .
 
-<http://model.geneontology.org/b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
+<http://purl.obolibrary.org/obo/GO_0005829>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -907,7 +878,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -924,7 +895,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -940,7 +911,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -955,7 +926,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -968,7 +939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -982,7 +953,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -990,11 +961,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_c4966e6b-16c9-488e-a101-267b2dc380aa_RXN-11026_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1002,7 +973,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/RXN-11026> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026>
+          <http://model.geneontology.org/c4966e6b-16c9-488e-a101-267b2dc380aa_RXN-11026>
 ] .
 
 <http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002411_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY>
@@ -1010,7 +981,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1022,7 +993,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1035,11 +1006,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_1e369a45-0100-41de-bb28-82b29247db00_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1047,7 +1018,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ACYLCOASYN-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN>
+          <http://model.geneontology.org/1e369a45-0100-41de-bb28-82b29247db00_ACYLCOASYN-RXN>
 ] .
 
 <http://purl.org/pav/providedBy>
@@ -1059,7 +1030,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1076,7 +1047,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1092,11 +1063,45 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
+
+<http://model.geneontology.org/360170cb-0028-4e05-aea3-1ce509986217_RXN-11026>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/d1f6d534-f501-4098-9db5-dd05c267554d_ENOYL-COA-HYDRAT-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <https://w3id.org/biolink/vocab/in_taxon>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
@@ -1118,7 +1123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1132,7 +1137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1141,13 +1146,16 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
+<http://purl.obolibrary.org/obo/GO_0003997>
+        a       <http://www.w3.org/2002/07/owl#Class> .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_RO_0002333_YKR009C-MONOMER_OHACYL-COA-DEHYDROG-RXN_controller_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1158,8 +1166,16 @@
           <http://model.geneontology.org/YKR009C-MONOMER_OHACYL-COA-DEHYDROG-RXN_controller>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0003997>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_0e8eb35b-39ed-4a50-8365-ee2ad684db62_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -1169,7 +1185,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1185,7 +1201,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1203,7 +1219,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1217,7 +1233,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1235,7 +1251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1248,7 +1264,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1259,7 +1275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1275,7 +1291,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1288,7 +1304,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1303,11 +1319,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59525> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/7ced0bf6-cff4-4c97-8790-2252b72252f4_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a (3Z)-alk-3-enoyl-CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59385> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -1317,7 +1350,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1337,7 +1370,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1351,7 +1384,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1371,7 +1404,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1387,7 +1420,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1396,34 +1429,29 @@
 <http://model.geneontology.org/reaction_ACYLCOASYN-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+<http://model.geneontology.org/51e68c90-d023-43b8-90b0-385cb1243d4d_ENOYL-COA-DELTA-ISOM-RXN>
+        a       <http://purl.obolibrary.org/obo/CHEBI_24431> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a <i>trans</i>-2-enoyl-CoA" ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://model.geneontology.org/ev_w_id_OHACYL-COA-DEHYDROG-RXN_BFO_0000066_reaction_OHACYL-COA-DEHYDROG-RXN_location_lociGO_0005829_null_YEAST-FAO-PWY>
         a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1435,7 +1463,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1446,24 +1474,13 @@
           <http://model.geneontology.org/CHEBI_15455_OHACYL-COA-DEHYDROG-RXN>
 ] .
 
-<http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_51e68c90-d023-43b8-90b0-385cb1243d4d_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1471,7 +1488,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-DELTA-ISOM-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN>
+          <http://model.geneontology.org/51e68c90-d023-43b8-90b0-385cb1243d4d_ENOYL-COA-DELTA-ISOM-RXN>
 ] .
 
 <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN>
@@ -1483,7 +1500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1496,18 +1513,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002233_b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1523,7 +1529,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1538,7 +1544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1551,7 +1557,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1565,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1576,7 +1582,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1590,7 +1596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,27 +1607,16 @@
           <http://model.geneontology.org/reaction_RXN-11026_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 <http://purl.obolibrary.org/obo/CHEBI_16240>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_d1f6d534-f501-4098-9db5-dd05c267554d_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1629,8 +1624,19 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/ENOYL-COA-HYDRAT-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN>
+          <http://model.geneontology.org/d1f6d534-f501-4098-9db5-dd05c267554d_ENOYL-COA-HYDRAT-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002234_51e68c90-d023-43b8-90b0-385cb1243d4d_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -1638,7 +1644,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,39 +1663,11 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026_SGD_YEAST-FAO-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/e4d126ba-9cc4-4438-b134-59287909e3d5_ACYLCOASYN-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a 2,3,4-saturated fatty acyl CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://identifiers.org/sgd/S000004860>
         a       <http://www.w3.org/2002/07/owl#Class> .
@@ -1706,7 +1684,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1723,7 +1701,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1723,18 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002234_1e369a45-0100-41de-bb28-82b29247db00_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1756,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1759,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1782,7 +1771,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1799,7 +1788,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1822,7 +1811,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1842,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1855,7 +1844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1870,7 +1859,7 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_KETOACYLCOATHIOL-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> ;
+                <http://model.geneontology.org/0e8eb35b-39ed-4a50-8365-ee2ad684db62_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/CHEBI_57288_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
                 <http://model.geneontology.org/CHEBI_57287_KETOACYLCOATHIOL-RXN> , <http://model.geneontology.org/CHEBI_15489_KETOACYLCOATHIOL-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
@@ -1880,7 +1869,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1891,6 +1880,17 @@
 <http://identifiers.org/sgd/S000001271>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_ENOYL-COA-DELTA-ISOM-RXN_RO_0002233_7ced0bf6-cff4-4c97-8790-2252b72252f4_ENOYL-COA-DELTA-ISOM-RXN_SGD_YEAST-FAO-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/YGL205W-MONOMER_RXN-11026_controller>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://identifiers.org/sgd/S000003173> ;
         <http://www.w3.org/2000/01/rdf-schema#label>
@@ -1898,7 +1898,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1912,7 +1912,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1929,7 +1929,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1946,7 +1946,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1968,7 +1968,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1979,7 +1979,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1991,7 +1991,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2010,7 +2010,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2030,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2053,11 +2053,28 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59469> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
+<http://model.geneontology.org/1e369a45-0100-41de-bb28-82b29247db00_ACYLCOASYN-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "a 2,3,4-saturated fatty acyl CoA" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59300> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
@@ -2070,9 +2087,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_ENOYL-COA-DELTA-ISOM-RXN_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/0c84d755-eb55-4350-8b21-da81387c8e3c_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/7ced0bf6-cff4-4c97-8790-2252b72252f4_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/40adeb0e-0e21-411b-9937-2a0af0ce2802_ENOYL-COA-DELTA-ISOM-RXN> ;
+                <http://model.geneontology.org/51e68c90-d023-43b8-90b0-385cb1243d4d_ENOYL-COA-DELTA-ISOM-RXN> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YLR284C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> , <http://model.geneontology.org/YOR180C-MONOMER_ENOYL-COA-DELTA-ISOM-RXN_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2080,30 +2097,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYBiochemicalReaction59379> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
-
-<http://model.geneontology.org/5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_24431> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "a <i>trans</i>-2-enoyl-CoA" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-FAO-PWYSmallMolecule59323> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
 
 <http://purl.obolibrary.org/obo/RO_0002333>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -2116,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2131,7 +2131,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2148,7 +2148,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2159,13 +2159,24 @@
           <http://model.geneontology.org/CHEBI_15455_ENOYL-COA-HYDRAT-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_RXN-11026_RO_0002234_360170cb-0028-4e05-aea3-1ce509986217_RXN-11026_SGD_YEAST-FAO-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-FAO-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_ACYLCOASYN-RXN_RO_0002233_CHEBI_57287_ACYLCOASYN-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,7 +2192,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2192,7 +2203,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2203,7 +2214,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2218,7 +2229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2235,7 +2246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2249,7 +2260,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2265,7 +2276,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2276,7 +2287,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2284,11 +2295,11 @@
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
-          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY> ;
+          <http://model.geneontology.org/ev_w_id_KETOACYLCOATHIOL-RXN_RO_0002233_0e8eb35b-39ed-4a50-8365-ee2ad684db62_KETOACYLCOATHIOL-RXN_SGD_YEAST-FAO-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2296,7 +2307,7 @@
   <http://www.w3.org/2002/07/owl#annotatedSource>
           <http://model.geneontology.org/KETOACYLCOATHIOL-RXN> ;
   <http://www.w3.org/2002/07/owl#annotatedTarget>
-          <http://model.geneontology.org/56f5f94b-d536-48eb-9f64-9fc18b05aadf_KETOACYLCOATHIOL-RXN>
+          <http://model.geneontology.org/0e8eb35b-39ed-4a50-8365-ee2ad684db62_KETOACYLCOATHIOL-RXN>
 ] .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
@@ -2305,7 +2316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,9 +2336,9 @@
         <http://purl.obolibrary.org/obo/BFO_0000066>
                 <http://model.geneontology.org/reaction_RXN-11026_location_lociGO_0005829> ;
         <http://purl.obolibrary.org/obo/RO_0002233>
-                <http://model.geneontology.org/CHEBI_15379_RXN-11026> , <http://model.geneontology.org/b7c7cfee-d7eb-4556-ab20-a76c19dc35e9_RXN-11026> ;
+                <http://model.geneontology.org/CHEBI_15379_RXN-11026> , <http://model.geneontology.org/c4966e6b-16c9-488e-a101-267b2dc380aa_RXN-11026> ;
         <http://purl.obolibrary.org/obo/RO_0002234>
-                <http://model.geneontology.org/CHEBI_16240_RXN-11026> , <http://model.geneontology.org/5ead561a-6e69-46f5-ab5c-aa930610ac42_RXN-11026> ;
+                <http://model.geneontology.org/CHEBI_16240_RXN-11026> , <http://model.geneontology.org/360170cb-0028-4e05-aea3-1ce509986217_RXN-11026> ;
         <http://purl.obolibrary.org/obo/RO_0002333>
                 <http://model.geneontology.org/YGL205W-MONOMER_RXN-11026_controller> ;
         <http://purl.obolibrary.org/obo/RO_0002411>
@@ -2335,7 +2346,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2348,7 +2359,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2360,7 +2371,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2380,7 +2391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2394,7 +2405,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2410,18 +2421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-FAO-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_ENOYL-COA-HYDRAT-RXN_RO_0002234_b809c19e-0ab8-45b3-84e8-0d4c237f124d_ENOYL-COA-HYDRAT-RXN_SGD_YEAST-FAO-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-FAO-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2434,7 +2434,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-FAO-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>

--- a/models/YEAST-GALACT-METAB-PWY-YEAST-GALACT-METAB-PWY.ttl
+++ b/models/YEAST-GALACT-METAB-PWY-YEAST-GALACT-METAB-PWY.ttl
@@ -15,7 +15,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -32,7 +32,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -49,7 +49,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -82,7 +82,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -93,7 +93,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -108,7 +108,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -123,7 +123,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -139,7 +139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -159,7 +159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "galactose degradation - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -176,7 +176,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -190,7 +190,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -204,13 +204,30 @@
 <http://model.geneontology.org/reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
 
+<http://model.geneontology.org/CHEBI_58601_GALACTURIDYLYLTRANS-RXN>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58601> ;
+        <http://www.w3.org/2000/01/rdf-schema#comment>
+                "located_in cytosol" ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "&alpha;-D-glucopyranose 1-phosphate" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27393> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.SmallMolecule" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002234_CHEBI_4170_PHOSPHOGLUCMUT-RXN_SGD_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -221,23 +238,6 @@
           <http://model.geneontology.org/CHEBI_4170_PHOSPHOGLUCMUT-RXN>
 ] .
 
-<http://model.geneontology.org/CHEBI_58601_GALACTURIDYLYLTRANS-RXN>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_58601> ;
-        <http://www.w3.org/2000/01/rdf-schema#comment>
-                "located_in cytosol" ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "&alpha;-D-glucopyranose 1-phosphate" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27393> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.SmallMolecule" .
-
 <http://purl.obolibrary.org/obo/GO_0005829>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
@@ -246,7 +246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -257,7 +257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -272,7 +272,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -292,7 +292,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -309,7 +309,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -324,7 +324,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -338,7 +338,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -380,7 +380,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -391,7 +391,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -412,7 +412,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -426,7 +426,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -442,7 +442,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -454,7 +454,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -470,7 +470,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -498,7 +498,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -515,7 +515,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -530,7 +530,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -550,7 +550,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -568,7 +568,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -585,7 +585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -599,16 +599,8 @@
 <http://purl.org/dc/elements/1.1/source>
         a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002333_YBR019C-MONOMER_UDPGLUCEPIM-RXN_controller_SGD_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
+<http://purl.obolibrary.org/obo/GO_0004335>
+        a       <http://www.w3.org/2002/07/owl#Class> .
 
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
@@ -616,7 +608,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -627,8 +619,16 @@
           <http://model.geneontology.org/CHEBI_28061_GALACTOKIN-RXN>
 ] .
 
-<http://purl.obolibrary.org/obo/GO_0004335>
-        a       <http://www.w3.org/2002/07/owl#Class> .
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_RO_0002333_YBR019C-MONOMER_UDPGLUCEPIM-RXN_controller_SGD_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/reaction_PHOSPHOGLUCMUT-RXN_location_lociGO_0005829>
         a       <http://purl.obolibrary.org/obo/GO_0005829> , <http://www.w3.org/2002/07/owl#NamedIndividual> .
@@ -638,7 +638,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -732,7 +732,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -748,7 +748,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -772,7 +772,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -783,6 +783,28 @@
           <http://model.geneontology.org/CHEBI_58601_GALACTURIDYLYLTRANS-RXN>
 ] .
 
+<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_GALACTOKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -792,35 +814,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-GALACT-METAB-PWYSmallMolecule27486> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_GALACTURIDYLYLTRANS-RXN_BFO_0000066_reaction_GALACTURIDYLYLTRANS-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
-<http://model.geneontology.org/ev_w_id_PHOSPHOGLUCMUT-RXN_RO_0002233_CHEBI_58601_PHOSPHOGLUCMUT-RXN_SGD_YEAST-GALACT-METAB-PWY>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/YMR105C-MONOMER_PHOSPHOGLUCMUT-RXN_controller>
         a       <http://identifiers.org/sgd/S000004711> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
@@ -829,7 +829,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -842,7 +842,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -857,7 +857,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -877,7 +877,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -896,7 +896,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -919,7 +919,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -932,7 +932,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -945,7 +945,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -958,7 +958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -970,7 +970,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -990,7 +990,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1006,7 +1006,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1038,7 +1038,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1052,7 +1052,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1071,7 +1071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1088,7 +1088,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1102,7 +1102,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1116,7 +1116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1133,7 +1133,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1156,7 +1156,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1172,7 +1172,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1195,7 +1195,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1211,7 +1211,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1222,7 +1222,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1236,7 +1236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1248,7 +1248,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1278,7 +1278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1295,7 +1295,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1315,7 +1315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1331,7 +1331,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1353,7 +1353,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1378,7 +1378,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1394,7 +1394,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1408,9 +1408,20 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "null:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" .
 
@@ -1433,7 +1444,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1441,24 +1452,13 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.BiochemicalReaction" .
 
-<http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000066_reaction_UDPGLUCEPIM-RXN_location_lociGO_0005829_null_YEAST-GALACT-METAB-PWY>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "null:YEAST-GALACT-METAB-PWY" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_UDPGLUCEPIM-RXN_BFO_0000050_YEAST-GALACT-METAB-PWY/YEAST-GALACT-METAB-PWY_SGD_YEAST-GALACT-METAB-PWY> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1474,7 +1474,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1495,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1526,7 +1526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1545,7 +1545,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1562,7 +1562,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1623,7 +1623,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1635,7 +1635,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1651,7 +1651,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-GALACT-METAB-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1663,7 +1663,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-GALACT-METAB-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YEAST-RIBOSYN-PWY-YEAST-RIBOSYN-PWY.ttl
+++ b/models/YEAST-RIBOSYN-PWY-YEAST-RIBOSYN-PWY.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -43,7 +43,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -55,7 +55,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -71,7 +71,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -85,7 +85,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -100,7 +100,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -116,7 +116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -127,7 +127,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -141,7 +141,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -167,7 +167,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -187,7 +187,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -204,7 +204,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -223,7 +223,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -235,7 +235,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -251,7 +251,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -266,7 +266,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -280,7 +280,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -300,7 +300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -314,7 +314,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -330,7 +330,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -342,7 +342,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -361,7 +361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -377,7 +377,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -388,7 +388,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -402,7 +402,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -417,7 +417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -430,7 +430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -441,7 +441,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -456,7 +456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "riboflavin, FMN and FAD biosynthesis - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -472,7 +472,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -489,7 +489,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -506,7 +506,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -526,7 +526,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -544,7 +544,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -569,7 +569,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -586,7 +586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -599,7 +599,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -614,7 +614,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -628,7 +628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -644,7 +644,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -655,7 +655,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -670,7 +670,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -686,7 +686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -698,7 +698,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -718,7 +718,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -738,7 +738,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -754,7 +754,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -774,7 +774,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -794,7 +794,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -807,7 +807,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -818,7 +818,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -830,7 +830,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -863,7 +863,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -882,7 +882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -915,7 +915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -927,7 +927,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -947,7 +947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -963,7 +963,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -983,7 +983,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1013,7 +1013,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1026,7 +1026,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1043,7 +1043,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1069,7 +1069,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1098,7 +1098,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1115,7 +1115,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1131,7 +1131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1146,7 +1146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1159,7 +1159,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1189,7 +1189,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1203,7 +1203,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1223,7 +1223,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1242,7 +1242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1254,7 +1254,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1282,7 +1282,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,7 +1299,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1312,7 +1312,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1327,7 +1327,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1344,7 +1344,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1358,7 +1358,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1377,7 +1377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1394,7 +1394,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1417,7 +1417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1430,7 +1430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1456,7 +1456,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1469,7 +1469,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1483,7 +1483,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1495,7 +1495,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1511,7 +1511,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1523,7 +1523,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1539,7 +1539,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1554,7 +1554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1571,7 +1571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1585,7 +1585,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1601,7 +1601,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1615,7 +1615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1626,7 +1626,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1638,7 +1638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1654,7 +1654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1668,7 +1668,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1688,7 +1688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1701,7 +1701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1712,7 +1712,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1724,7 +1724,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1745,7 +1745,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1758,7 +1758,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1770,7 +1770,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1787,7 +1787,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1803,7 +1803,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1815,7 +1815,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1831,7 +1831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1849,7 +1849,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1865,7 +1865,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1876,7 +1876,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1887,7 +1887,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1902,7 +1902,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1916,7 +1916,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1936,7 +1936,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1949,7 +1949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1960,7 +1960,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -1972,7 +1972,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1992,7 +1992,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2009,7 +2009,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2025,7 +2025,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2036,7 +2036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2048,7 +2048,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2066,7 +2066,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2085,7 +2085,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2102,7 +2102,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2122,7 +2122,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2145,7 +2145,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2167,7 +2167,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2201,7 +2201,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2221,7 +2221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2234,7 +2234,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2245,7 +2245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2257,7 +2257,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2277,7 +2277,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2290,7 +2290,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2305,7 +2305,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2325,7 +2325,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2361,7 +2361,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2378,7 +2378,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2397,7 +2397,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2416,7 +2416,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2432,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2443,7 +2443,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2458,7 +2458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2472,7 +2472,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2488,7 +2488,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2499,7 +2499,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2510,7 +2510,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2521,7 +2521,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2533,7 +2533,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2555,7 +2555,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2580,7 +2580,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2596,7 +2596,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2615,7 +2615,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2627,7 +2627,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2646,7 +2646,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2661,7 +2661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2681,7 +2681,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2695,7 +2695,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2715,7 +2715,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2728,7 +2728,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2743,7 +2743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2766,7 +2766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2779,7 +2779,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2790,7 +2790,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2808,7 +2808,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2825,7 +2825,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2866,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2886,7 +2886,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2899,7 +2899,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2911,7 +2911,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2934,7 +2934,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2947,7 +2947,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2958,7 +2958,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2973,7 +2973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2986,7 +2986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -2997,7 +2997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3009,7 +3009,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3029,7 +3029,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3049,7 +3049,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3079,7 +3079,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3092,7 +3092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3104,7 +3104,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3125,7 +3125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3138,7 +3138,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3150,7 +3150,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3166,7 +3166,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3177,7 +3177,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3189,7 +3189,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3205,7 +3205,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3217,7 +3217,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3236,7 +3236,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3256,7 +3256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3273,7 +3273,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3289,7 +3289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3307,7 +3307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3329,7 +3329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3349,7 +3349,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3362,7 +3362,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3377,7 +3377,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3397,7 +3397,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3417,7 +3417,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3430,7 +3430,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3442,7 +3442,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3458,7 +3458,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3471,7 +3471,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3485,7 +3485,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3501,7 +3501,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3513,7 +3513,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3536,7 +3536,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3555,7 +3555,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3571,7 +3571,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3584,7 +3584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3604,7 +3604,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3620,7 +3620,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3640,7 +3640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3654,7 +3654,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3670,7 +3670,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3688,7 +3688,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3701,7 +3701,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3715,7 +3715,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3731,7 +3731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3743,7 +3743,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3766,7 +3766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3782,7 +3782,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3800,7 +3800,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3814,7 +3814,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3830,7 +3830,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3845,7 +3845,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3862,7 +3862,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3878,7 +3878,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3903,7 +3903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3916,7 +3916,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3939,7 +3939,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3956,7 +3956,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3973,7 +3973,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3986,7 +3986,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>
@@ -3997,7 +3997,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RIBOSYN-PWY" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RIBOSYN-PWY" ;
         <http://purl.org/pav/providedBy>

--- a/models/YEAST-RNT-SALV-YEAST-RNT-SALV.ttl
+++ b/models/YEAST-RNT-SALV-YEAST-RNT-SALV.ttl
@@ -7,7 +7,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -27,7 +27,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -41,7 +41,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -59,7 +59,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -79,7 +79,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -96,7 +96,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -110,7 +110,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -133,7 +133,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -146,7 +146,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -164,7 +164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -180,7 +180,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -194,7 +194,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -214,7 +214,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -230,7 +230,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -245,7 +245,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -265,7 +265,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -278,7 +278,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -295,7 +295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -307,7 +307,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -326,7 +326,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -342,7 +342,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -354,7 +354,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -373,7 +373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -390,7 +390,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -409,7 +409,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -424,7 +424,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -437,7 +437,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -457,7 +457,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -482,7 +482,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -496,7 +496,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -515,7 +515,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -531,7 +531,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -554,7 +554,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -568,7 +568,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -584,7 +584,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -598,7 +598,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -612,7 +612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -627,7 +627,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -640,7 +640,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -653,7 +653,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -666,7 +666,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -677,7 +677,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -689,7 +689,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -706,7 +706,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -725,7 +725,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -737,7 +737,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -756,7 +756,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -767,7 +767,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -782,7 +782,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -795,7 +795,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -810,7 +810,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -823,7 +823,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -835,7 +835,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -852,7 +852,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -872,7 +872,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -885,7 +885,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -899,7 +899,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -922,7 +922,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -938,7 +938,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -949,7 +949,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -978,7 +978,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -991,7 +991,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1003,7 +1003,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1023,7 +1023,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1040,7 +1040,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1058,7 +1058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1077,7 +1077,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1092,7 +1092,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1109,7 +1109,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1125,7 +1125,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1140,7 +1140,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine ribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -1154,7 +1154,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1171,7 +1171,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1190,7 +1190,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1208,7 +1208,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1221,7 +1221,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1235,7 +1235,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1246,7 +1246,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1257,7 +1257,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1272,7 +1272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1286,7 +1286,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,7 +1316,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1352,7 +1352,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1368,7 +1368,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1383,7 +1383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1410,7 +1410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1427,7 +1427,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1447,7 +1447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1461,7 +1461,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1477,7 +1477,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1492,7 +1492,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1512,7 +1512,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -1525,7 +1525,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1537,7 +1537,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1578,7 +1578,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1592,7 +1592,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1608,7 +1608,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1641,7 +1641,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1657,7 +1657,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1672,7 +1672,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1686,7 +1686,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1703,7 +1703,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1719,7 +1719,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1737,7 +1737,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1751,7 +1751,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1781,7 +1781,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1797,7 +1797,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1812,7 +1812,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1828,7 +1828,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1840,7 +1840,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1856,7 +1856,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1868,7 +1868,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1885,7 +1885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1904,7 +1904,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1915,7 +1915,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1932,7 +1932,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1948,7 +1948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -1960,7 +1960,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1982,7 +1982,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1996,6 +1996,17 @@
 <http://purl.obolibrary.org/obo/CHEBI_16040>
         a       <http://www.w3.org/2002/07/owl#Class> .
 
+<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_YEAST-RNT-SALV>
+        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-RNT-SALV" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
 <http://model.geneontology.org/CHEBI_30616_CDPKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_30616> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -2005,24 +2016,13 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
                 <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVSmallMolecule46617> ;
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
-
-<http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002333_YNR012W-MONOMER_CYTIDINEKIN-RXN_controller_SGD_YEAST-RNT-SALV>
-        a       <http://purl.obolibrary.org/obo/ECO_0000313> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-RNT-SALV" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
 
 <http://model.geneontology.org/URIDINEKIN-RXN>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/GO_0004849> ;
@@ -2041,7 +2041,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2058,7 +2058,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2071,7 +2071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2103,7 +2103,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2116,7 +2116,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2131,7 +2131,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2148,7 +2148,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2164,7 +2164,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2181,7 +2181,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2197,7 +2197,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2211,7 +2211,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2227,7 +2227,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2242,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2256,7 +2256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2275,7 +2275,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2286,7 +2286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2311,7 +2311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2323,7 +2323,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2340,7 +2340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2357,7 +2357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2373,7 +2373,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2386,7 +2386,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2404,7 +2404,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2421,7 +2421,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2439,7 +2439,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2455,7 +2455,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2467,7 +2467,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2487,7 +2487,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2503,7 +2503,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2518,7 +2518,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2534,7 +2534,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2545,7 +2545,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2560,7 +2560,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2574,7 +2574,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2590,7 +2590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2602,7 +2602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2619,7 +2619,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2638,7 +2638,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2654,7 +2654,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2669,7 +2669,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2686,7 +2686,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2703,7 +2703,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2717,7 +2717,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2742,7 +2742,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2761,7 +2761,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2773,7 +2773,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2793,7 +2793,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2806,7 +2806,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2817,7 +2817,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2831,7 +2831,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2852,7 +2852,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2866,7 +2866,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2885,7 +2885,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2903,7 +2903,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2917,7 +2917,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2933,7 +2933,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -2945,7 +2945,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2963,7 +2963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2976,7 +2976,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3001,7 +3001,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3015,7 +3015,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3035,7 +3035,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3051,7 +3051,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3062,21 +3062,6 @@
           <http://model.geneontology.org/reaction_URACIL-PRIBOSYLTRANS-RXN_location_lociGO_0005829>
 ] .
 
-<http://model.geneontology.org/YDR400W-MONOMER_RXN0-361_controller>
-        a       <http://identifiers.org/sgd/S000002808> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
-        <http://www.w3.org/2000/01/rdf-schema#label>
-                "nicotinic acid riboside hydrolase [multifunctional]" ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" ;
-        <http://www.w3.org/2004/02/skos/core#exactMatch>
-                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVProtein46730> ;
-        <http://www.w3.org/2004/02/skos/core#note>
-                "org.biopax.paxtools.model.level3.Protein" .
-
 <http://model.geneontology.org/CHEBI_60377_RXN-11832>
         a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/CHEBI_60377> ;
         <http://www.w3.org/2000/01/rdf-schema#comment>
@@ -3086,7 +3071,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3094,13 +3079,28 @@
         <http://www.w3.org/2004/02/skos/core#note>
                 "org.biopax.paxtools.model.level3.SmallMolecule" .
 
+<http://model.geneontology.org/YDR400W-MONOMER_RXN0-361_controller>
+        a       <http://identifiers.org/sgd/S000002808> , <http://www.w3.org/2002/07/owl#NamedIndividual> ;
+        <http://www.w3.org/2000/01/rdf-schema#label>
+                "nicotinic acid riboside hydrolase [multifunctional]" ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" ;
+        <http://www.w3.org/2004/02/skos/core#exactMatch>
+                <http://http://pathway-2a.yeastgenome.org:8080//YEAST/pathway-biopax?type=3%38object=YEAST-RNT-SALVProtein46730> ;
+        <http://www.w3.org/2004/02/skos/core#note>
+                "org.biopax.paxtools.model.level3.Protein" .
+
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_CYTIDINEKIN-RXN_RO_0002234_CHEBI_58189_CYTIDINEKIN-RXN_SGD_YEAST-RNT-SALV> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3117,7 +3117,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3137,7 +3137,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3150,7 +3150,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3161,7 +3161,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3179,7 +3179,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3199,7 +3199,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3213,7 +3213,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3230,7 +3230,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3250,7 +3250,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3264,7 +3264,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -3295,7 +3295,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3311,7 +3311,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3326,7 +3326,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -3339,7 +3339,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3350,7 +3350,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-RNT-SALV" ;
         <http://purl.org/pav/providedBy>
@@ -3362,7 +3362,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-RNT-SALV" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>

--- a/models/YEAST-SALV-PYRMID-DNTP-YEAST-SALV-PYRMID-DNTP.ttl
+++ b/models/YEAST-SALV-PYRMID-DNTP-YEAST-SALV-PYRMID-DNTP.ttl
@@ -9,7 +9,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -28,7 +28,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -44,7 +44,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -59,7 +59,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -75,7 +75,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -92,7 +92,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -106,7 +106,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -121,7 +121,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -134,7 +134,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -146,7 +146,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -162,7 +162,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -174,7 +174,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -194,7 +194,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -207,7 +207,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -218,7 +218,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -239,7 +239,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -253,7 +253,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -270,7 +270,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -286,7 +286,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -303,7 +303,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -325,7 +325,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -340,7 +340,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -357,7 +357,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -383,7 +383,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -396,7 +396,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -410,7 +410,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -421,7 +421,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -433,7 +433,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -444,27 +444,13 @@
           <http://model.geneontology.org/CHEBI_456216_THYKI-RXN>
 ] .
 
-<http://geneontology.org/lego/modelstate>
-        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
-
-<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_15378_RXN-14093_SGD_YEAST-SALV-PYRMID-DNTP>
-        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
-        <http://purl.org/dc/elements/1.1/contributor>
-                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
-        <http://purl.org/dc/elements/1.1/source>
-                "SGD:YEAST-SALV-PYRMID-DNTP" ;
-        <http://purl.org/pav/providedBy>
-                "https://yeastgenome.org" .
-
 [ a       <http://www.w3.org/2002/07/owl#Axiom> ;
   <http://geneontology.org/lego/evidence>
           <http://model.geneontology.org/ev_w_id_DURIDKI-RXN_RO_0002234_CHEBI_456216_DURIDKI-RXN_SGD_YEAST-SALV-PYRMID-DNTP> ;
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -474,6 +460,20 @@
   <http://www.w3.org/2002/07/owl#annotatedTarget>
           <http://model.geneontology.org/CHEBI_456216_DURIDKI-RXN>
 ] .
+
+<http://model.geneontology.org/ev_w_id_RXN-14093_RO_0002234_CHEBI_15378_RXN-14093_SGD_YEAST-SALV-PYRMID-DNTP>
+        a       <http://www.w3.org/2002/07/owl#NamedIndividual> , <http://purl.obolibrary.org/obo/ECO_0000313> ;
+        <http://purl.org/dc/elements/1.1/contributor>
+                "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/dc/elements/1.1/date>
+                "2022-04-13" ;
+        <http://purl.org/dc/elements/1.1/source>
+                "SGD:YEAST-SALV-PYRMID-DNTP" ;
+        <http://purl.org/pav/providedBy>
+                "https://yeastgenome.org" .
+
+<http://geneontology.org/lego/modelstate>
+        a       <http://www.w3.org/2002/07/owl#AnnotationProperty> .
 
 <http://purl.obolibrary.org/obo/RO_0002234>
         a       <http://www.w3.org/2002/07/owl#ObjectProperty> .
@@ -487,7 +487,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -500,7 +500,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -526,7 +526,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -540,7 +540,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -557,7 +557,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -573,7 +573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -590,7 +590,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -602,7 +602,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -618,7 +618,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -636,7 +636,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -656,7 +656,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -672,7 +672,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -692,7 +692,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -705,7 +705,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -716,7 +716,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -731,7 +731,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -744,7 +744,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -755,7 +755,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -766,7 +766,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -783,7 +783,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -799,7 +799,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -814,7 +814,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -828,7 +828,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -844,7 +844,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -859,7 +859,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -879,7 +879,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -895,7 +895,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -907,7 +907,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -935,7 +935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -948,7 +948,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -963,7 +963,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -977,7 +977,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1000,7 +1000,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1020,7 +1020,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1036,7 +1036,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1051,7 +1051,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1065,7 +1065,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1081,7 +1081,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1096,7 +1096,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1118,7 +1118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1139,7 +1139,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1165,7 +1165,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1179,7 +1179,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1199,7 +1199,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1215,7 +1215,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1229,7 +1229,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1255,7 +1255,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1285,7 +1285,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1299,7 +1299,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1316,7 +1316,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1335,7 +1335,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1351,7 +1351,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1369,7 +1369,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1386,7 +1386,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1403,7 +1403,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1425,7 +1425,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1436,7 +1436,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1451,7 +1451,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1465,7 +1465,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1485,7 +1485,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1499,7 +1499,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1516,7 +1516,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1538,7 +1538,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1553,7 +1553,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1573,7 +1573,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1586,7 +1586,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1597,7 +1597,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1612,7 +1612,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1628,7 +1628,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1645,7 +1645,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1661,7 +1661,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1679,7 +1679,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1696,7 +1696,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1713,7 +1713,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1727,7 +1727,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1747,7 +1747,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1761,7 +1761,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1778,7 +1778,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1798,7 +1798,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1811,7 +1811,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1823,7 +1823,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1839,7 +1839,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1851,7 +1851,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1867,7 +1867,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -1882,7 +1882,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1898,7 +1898,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1915,7 +1915,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1935,7 +1935,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1950,7 +1950,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -1964,7 +1964,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -1987,7 +1987,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2004,7 +2004,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/title>
                 "salvage pathways of pyrimidine deoxyribonucleotides - imported from: Saccharomyces Genome Database" ;
         <http://purl.org/pav/providedBy>
@@ -2030,7 +2030,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2043,7 +2043,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2056,7 +2056,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2070,7 +2070,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2086,7 +2086,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2098,7 +2098,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2118,7 +2118,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2135,7 +2135,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2149,7 +2149,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2168,7 +2168,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2182,7 +2182,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2193,7 +2193,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2205,7 +2205,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2222,7 +2222,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2242,7 +2242,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.geneontology.org/formats/oboInOwl#hasDbXref>
@@ -2256,7 +2256,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2272,7 +2272,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "null:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2289,7 +2289,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2300,7 +2300,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2315,7 +2315,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2329,7 +2329,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2345,7 +2345,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2359,7 +2359,7 @@
   <http://purl.org/dc/elements/1.1/contributor>
           "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
   <http://purl.org/dc/elements/1.1/date>
-          "2022-03-14" ;
+          "2022-04-13" ;
   <http://purl.org/pav/providedBy>
           "https://yeastgenome.org" ;
   <http://www.w3.org/2002/07/owl#annotatedProperty>
@@ -2387,7 +2387,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2403,7 +2403,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2414,7 +2414,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/dc/elements/1.1/source>
                 "SGD:YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/pav/providedBy>
@@ -2432,7 +2432,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>
@@ -2447,7 +2447,7 @@
         <http://purl.org/dc/elements/1.1/contributor>
                 "https://pathway.yeastgenome.org/YEAST/NEW-IMAGE?object=YEAST-SALV-PYRMID-DNTP" ;
         <http://purl.org/dc/elements/1.1/date>
-                "2022-03-14" ;
+                "2022-04-13" ;
         <http://purl.org/pav/providedBy>
                 "https://yeastgenome.org" ;
         <http://www.w3.org/2004/02/skos/core#exactMatch>


### PR DESCRIPTION
Fixed annoying typo in chemical entity:
![image](https://user-images.githubusercontent.com/2678599/163288329-679dc942-7ccd-45f1-96c6-47ff0ef4cab6.png)
Should be CHEBI:24431.